### PR TITLE
Generic tuples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1574,3 +1574,4 @@ peer chaincode invoke -n mycc -c '{"Args":["queryObjectiveLeaderboard","{\"objec
  ]
 }
 ```
+ 

--- a/README.md
+++ b/README.md
@@ -1574,4 +1574,3 @@ peer chaincode invoke -n mycc -c '{"Args":["queryObjectiveLeaderboard","{\"objec
  ]
 }
 ```
- 

--- a/chaincode/input.go
+++ b/chaincode/input.go
@@ -90,6 +90,24 @@ type inputTraintuple struct {
 	Tag            string   `validate:"omitempty,lte=64" json:"tag"`
 }
 
+// inputCompositeTraintuple is the representation of input args to register a Traintuple
+type inputCompositeTraintuple struct {
+	AlgoKey        string              `validate:"required,len=64,hexadecimal" json:"algoKey"`
+	ObjectiveKey   string              `validate:"required,len=64,hexadecimal" json:"objectiveKey"`
+	InModelHead    inputCompositeModel `validate:"omitempty" json:"inModelHead"`
+	InModelTrunk   inputCompositeModel `validate:"omitempty" json:"inModelTrunk"`
+	DataManagerKey string              `validate:"required,len=64,hexadecimal" json:"dataManagerKey"`
+	DataSampleKeys []string            `validate:"required,unique,gt=0,dive,len=64,hexadecimal" json:"dataSampleKeys"`
+	ComputePlanID  string              `validate:"omitempty" json:"computePlanID"`
+	Rank           string              `validate:"omitempty" json:"rank"`
+	Tag            string              `validate:"omitempty,lte=64" json:"tag"`
+}
+
+type inputCompositeModel struct {
+	Key            string           `validate:"required,len=64,hexadecimal" json:"key"`
+	OutPermissions inputPermissions `validate:"required" json:"outPermissions"`
+}
+
 // inputTestuple is the representation of input args to register a Testtuple
 type inputTesttuple struct {
 	TraintupleKey  string   `validate:"required,len=64,hexadecimal" json:"traintupleKey"`


### PR DESCRIPTION
## Composite

- [x] Creation of a new structure used for “inputting” a new compositetraintuple
- [ ] Creation of a new structure corresponding to elements stored in the ledger for a given compositetraintuple
- [ ] Creation of a new structure used for “outputting” a compositetraintuple
- [ ] Creation of a smart contract to create an compositetraintuple
- [ ] Creation of smart contracts to query an compositetraintuple and query all compositetraintuple
- [ ] Creation of smart contracts similar to logStartTrain, logFailTrain, logSuccesTrain for compositetraintuples
- [ ] Modification of createTesttuple to make it possible to consider as input a compositetraintuple (on top of a traintuple)
- [ ] Create a smart contract to add/get/list compositeAlgo, which have the same structure as a normal Algo (and the same input and output)

## Aggregate

- [ ] Creation of a new structure used for “inputting” a new aggtuple
- [ ] Creation of a new structure corresponding to elements stored in the ledger for a given aggtuple
- [ ] Creation of a new structure used for “outputting” an aggtuple
- [ ] Creation of a smart contract to create an aggtuple with the input mentioned above.
- [ ] Creation of smart contracts to query an aggtuple and query all aggtuples
- [ ] Creation of smart contracts similar to logStartTrain, logFailTrain, logSuccesTrain for aggtuples.
- [ ] Create a smart contract to add/get/list aggregateAlgo, which have the same structure as a normal Algo (and the same input and output)

## Compute plan

- [ ] Creation of a smart contract to query a compute plan
- [ ] Modification of the creation of a compute plan to make it possible to consider as compositetraintuples (on top of traintuples and testtuples)
- [ ] Modification of the creation of a compute plan to make it possible to consider as input aggtuples (on top of traintuples and testtuples)
