### PR TITLE
Fix invalid JSON tag

### DIFF
--- a/chaincode/permissions.go
+++ b/chaincode/permissions.go
@@ -33,7 +33,7 @@ type Permission struct {
 	// the nodes listed in AuthorizedIDs (open to all nodes if false)
 	Public bool `json:"public"`
 	// AuthorizedIDs list all authorised nodes other than the asset's owner
-	AuthorizedIDs []string `json:"authorizedIDs", omitempty`
+	AuthorizedIDs []string `json:"authorizedIDs"`
 }
 
 // Permissions represents all permissions associated with an asset


### PR DESCRIPTION
Reported by [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck).

If `omitempty` is intended, this requires fixing `TestAlgo` in a way that is unclear to me. I am not sure that `testify/assert` supports it. In that case, I could open an issue instead and close the PR as it is probably not my place to introduce such a change in a test.