### PR TITLE
readme: add section about local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ Chaincode for the Substra platform
 ## License
 
 This project is developed under the Apache License, Version 2.0 (Apache-2.0), located in the [LICENSE](./LICENSE) file.
+
+## Local development
+
+### Prerequisites
+
+go version 1.11.x
+
+### Run the tests
+
+```
+cd chaincode/
+go test
+```
+
 ## Devmode
 
 See [chaincode-docker-devmode](./chaincode-docker-devmode/README.rst)


### PR DESCRIPTION
It's the second time I spend 20+ minutes looking for which go version HLF uses. It's [not very easy to find](https://hyperledger-fabric.readthedocs.io/en/release-1.4/prereqs.html#go-programming-language) a definitive answer :)

Hopefully this section can be built upon in the future!