### PR TITLE
Allow traintuples with the same compute plan id to be generated from different algos

### DIFF
--- a/chaincode/traintuple.go
+++ b/chaincode/traintuple.go
@@ -155,16 +155,6 @@ func (traintuple *Traintuple) AddToComputePlan(db LedgerDB, inp inputTraintuple,
 	if len(ttKeys) == 0 {
 		return errors.BadRequest("cannot find the ComputePlanID %s", inp.ComputePlanID)
 	}
-	for _, ttKey := range ttKeys {
-		FLTraintuple, err := db.GetTraintuple(ttKey)
-		if err != nil {
-			return err
-		}
-		if FLTraintuple.AlgoKey != inp.AlgoKey {
-			return errors.BadRequest("previous traintuple for ComputePlanID %s does not have the same algo key %s", inp.ComputePlanID, inp.AlgoKey)
-		}
-	}
-
 	ttKeys, err = db.GetIndexKeys("traintuple~computeplanid~worker~rank~key", []string{"traintuple", inp.ComputePlanID, traintuple.Dataset.Worker, inp.Rank})
 	if err != nil {
 		return err

--- a/chaincode/traintuple_test.go
+++ b/chaincode/traintuple_test.go
@@ -239,8 +239,7 @@ func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 		ComputePlanID: key}
 	args = inpTraintuple.createDefault()
 	resp = mockStub.MockInvoke("42", args)
-	assert.EqualValues(t, 400, resp.Status, resp.Message, "sould fail for it doesn't have the same algo key")
-	assert.Contains(t, resp.Message, "does not have the same algo key")
+	assert.EqualValues(t, 200, resp.Status, resp.Message, "should be able to create a traintuple with the same ComputePlanID and different algo keys")
 }
 
 func TestTraintuple(t *testing.T) {


### PR DESCRIPTION
Currently this is not possible: an error is raised when creating a traintuple if its algo is different from the traintuples algo of this compute plan.

Removing this check could allow to create multiple traintuples from different algos to share the same local folder. 

This could be the first step before creating a compute plan with traintuples of different algos.

Tests should be updated, but I'm first opening this PR to discuss about it.