### PR TITLE
Build the chaincode in the travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,7 @@ branches:
 
 install: skip
 
-script: cd chaincode && go test -v ./...
+script:
+  - cd chaincode
+  - go test -v ./...
+  - go build


### PR DESCRIPTION
Currently, if there's an undeclared variable in the code that is being used, `go test` will happily succeed. However, instantiating the chaincode in `hlf-k8s` will fail! This commit makes sure the CI doesn't pass if building the chaincode fails.

Example of bad behavior: [this CI build succeeded](https://travis-ci.org/SubstraFoundation/substra-chaincode/builds/615741650?utm_source=github_status&utm_medium=notification), even though the chaincode had a bug (use of undeclared variable, visible when trying to instantiate the chaincode) fixed [in a later commit](https://github.com/SubstraFoundation/substra-chaincode/pull/5/commits/270f9558e603f0c00cdca0a0babbe5e5ee8bc396)