### PR TITLE
aggregate permissions

### DIFF
--- a/chaincode/input.go
+++ b/chaincode/input.go
@@ -15,6 +15,7 @@
 package main
 
 var (
+	// OpenPermissions represent struct for default public permissions that could apply to assets
 	OpenPermissions = inputPermissions{
 		Process: inputPermission{
 			Public:        true,

--- a/chaincode/input.go
+++ b/chaincode/input.go
@@ -14,6 +14,15 @@
 
 package main
 
+var (
+	OpenPermissions = inputPermissions{
+		Process: inputPermission{
+			Public:        true,
+			AuthorizedIDs: []string{},
+		},
+	}
+)
+
 // -------------------------------------------------------------------------------------------
 // Struct used to represent inputs for smart contracts. In Hyperledger Fabric, we get as input
 // arg  [][]byte or []string, and it is not possible to input a string looking like a json

--- a/chaincode/input_test.go
+++ b/chaincode/input_test.go
@@ -42,12 +42,6 @@ var (
 			},
 		},
 	}
-	OpenPermissions = inputPermissions{
-		Process: inputPermission{
-			Public:        true,
-			AuthorizedIDs: []string{},
-		},
-	}
 )
 
 func (dataManager *inputDataManager) createDefault() [][]byte {

--- a/chaincode/main_test.go
+++ b/chaincode/main_test.go
@@ -248,71 +248,81 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	return resp, inpAggregatetuple
 }
 
-func registerTraintuple(mockStub *MockStub, assetType AssetType) (key string, err error) {
+func registerRandomCompositeAlgo(mockStub *MockStub) (key string, err error) {
+	key = GetRandomHash()
+	inpAlgo := inputCompositeAlgo{inputAlgo{Hash: key}}
+	args := inpAlgo.createDefault()
+	resp := mockStub.MockInvoke("42", args)
+	if resp.Status != 200 {
+		err = fmt.Errorf("failed to register random algo: %s", resp.Message)
+		return
+	}
+	return
+}
 
-	randAlgoKey := GetRandomHash()
+func registerTraintuple(mockStub *MockStub, assetType AssetType) (key string, err error) {
 
 	// 1. Generate and register random algo
 	// 2. Generate and register traintuple using that algo
 
 	switch assetType {
 	case CompositeTraintupleType:
-		inpAlgo := inputCompositeAlgo{inputAlgo{Hash: randAlgoKey}}
-		args := inpAlgo.createDefault()
-		resp := mockStub.MockInvoke("42", args)
-		if resp.Status != 200 {
-			err = fmt.Errorf("Failed to register random algo: %s", resp.Message)
+		randAlgoKey, _err := registerRandomCompositeAlgo(mockStub)
+		if _err != nil {
+			err = _err
 			return
 		}
 		inpTraintuple := inputCompositeTraintuple{AlgoKey: randAlgoKey}
 		inpTraintuple.fillDefaults()
-		args = inpTraintuple.getArgs()
-		resp = mockStub.MockInvoke("42", args)
+		args := inpTraintuple.getArgs()
+		resp := mockStub.MockInvoke("42", args)
 		if resp.Status != 200 {
-			err = fmt.Errorf("Failed to register traintuple: %s", resp.Message)
+			err = fmt.Errorf("failed to register traintuple: %s", resp.Message)
 			return
 		}
 		var _key struct{ Key string }
 		json.Unmarshal(resp.Payload, &_key)
 		return _key.Key, nil
 	case TraintupleType:
+		randAlgoKey := GetRandomHash()
 		inpAlgo := inputAlgo{Hash: randAlgoKey}
 		args := inpAlgo.createDefault()
 		resp := mockStub.MockInvoke("42", args)
 		if resp.Status != 200 {
-			err = fmt.Errorf("Failed to register random algo: %s", resp.Message)
+			err = fmt.Errorf("failed to register random algo: %s", resp.Message)
 			return
 		}
 		inpTraintuple := inputTraintuple{AlgoKey: randAlgoKey}
 		args = inpTraintuple.createDefault()
 		resp = mockStub.MockInvoke("42", args)
 		if resp.Status != 200 {
-			err = fmt.Errorf("Failed to register traintuple: %s", resp.Message)
+			err = fmt.Errorf("failed to register traintuple: %s", resp.Message)
 			return
 		}
 		var _key struct{ Key string }
 		json.Unmarshal(resp.Payload, &_key)
 		return _key.Key, nil
 	case AggregatetupleType:
+		randAlgoKey := GetRandomHash()
 		inpAlgo := inputAggregateAlgo{inputAlgo{Hash: randAlgoKey}}
 		args := inpAlgo.createDefault()
 		resp := mockStub.MockInvoke("42", args)
 		if resp.Status != 200 {
-			err = fmt.Errorf("Failed to register random algo: %s", resp.Message)
+			err = fmt.Errorf("failed to register random algo: %s", resp.Message)
 			return
 		}
 		inpTraintuple := inputAggregatetuple{AlgoKey: randAlgoKey}
 		args = inpTraintuple.createDefault()
 		resp = mockStub.MockInvoke("42", args)
 		if resp.Status != 200 {
-			err = fmt.Errorf("Failed to register traintuple: %s", resp.Message)
+			err = fmt.Errorf("failed to register traintuple: %s", resp.Message)
 			return
 		}
 		var _key struct{ Key string }
 		json.Unmarshal(resp.Payload, &_key)
 		return _key.Key, nil
 	default:
-		err = fmt.Errorf("Invalid asset type: %v", assetType)
+		err = fmt.Errorf("invalid asset type: %v", assetType)
 		return
 	}
 }

--- a/chaincode/output_aggregate.go
+++ b/chaincode/output_aggregate.go
@@ -100,6 +100,7 @@ func (outputAggregatetuple *outputAggregatetuple) Fill(db LedgerDB, traintuple A
 	}
 
 	outputAggregatetuple.Worker = traintuple.Worker
+	outputAggregatetuple.Permissions.Fill(traintuple.Permissions)
 
 	return
 }

--- a/chaincode/tuple_aggregate.go
+++ b/chaincode/tuple_aggregate.go
@@ -88,7 +88,7 @@ func (tuple *Aggregatetuple) SetFromParents(db LedgerDB, inModels []string) erro
 		case CompositeTraintupleType:
 			tuple, err := db.GetCompositeTraintuple(parentTraintupleKey)
 			if err == nil {
-				// if parent is aggregate, always take the "trunk" out-model
+				// if the parent is composite, always take the "trunk" out-model
 				parentOutModel = tuple.OutTrunkModel.OutModel
 				parentPermissions = tuple.OutTrunkModel.Permissions
 			}

--- a/chaincode/tuple_aggregate.go
+++ b/chaincode/tuple_aggregate.go
@@ -74,10 +74,10 @@ func (tuple *Aggregatetuple) SetFromParents(db LedgerDB, inModels []string) erro
 		return errors.BadRequest(err, "could not generate open permissions")
 	}
 
-	for _, parentKey := range inModels {
-		parentType, err := db.GetAssetType(parentKey)
+	for _, parentTraintupleKey := range inModels {
+		parentType, err := db.GetAssetType(parentTraintupleKey)
 		if err != nil {
-			return fmt.Errorf("could not retrieve traintuple type with key %s - %s", parentKey, err.Error())
+			return fmt.Errorf("could not retrieve traintuple type with key %s - %s", parentTraintupleKey, err.Error())
 		}
 
 		var parentOutModel *HashDress
@@ -86,37 +86,37 @@ func (tuple *Aggregatetuple) SetFromParents(db LedgerDB, inModels []string) erro
 		// get out-model and permissions from parent
 		switch parentType {
 		case CompositeTraintupleType:
-			tuple, err := db.GetCompositeTraintuple(parentKey)
+			tuple, err := db.GetCompositeTraintuple(parentTraintupleKey)
 			if err == nil {
 				// if parent is aggregate, always take the "trunk" out-model
 				parentOutModel = tuple.OutTrunkModel.OutModel
 				parentPermissions = tuple.OutTrunkModel.Permissions
 			}
 		case TraintupleType:
-			tuple, err := db.GetTraintuple(parentKey)
+			tuple, err := db.GetTraintuple(parentTraintupleKey)
 			if err == nil {
 				parentOutModel = tuple.OutModel
 				parentPermissions = tuple.Permissions
 			}
 		case AggregatetupleType:
-			tuple, err := db.GetAggregatetuple(parentKey)
+			tuple, err := db.GetAggregatetuple(parentTraintupleKey)
 			if err == nil {
 				parentOutModel = tuple.OutModel
 				parentPermissions = tuple.Permissions
 			}
 		default:
-			return fmt.Errorf("Aggregate.SetFromParents: Unsupported parent type %s", parentType)
+			return fmt.Errorf("aggregate.SetFromParents: Unsupported parent type %s", parentType)
 		}
 
 		if err != nil {
-			return fmt.Errorf("could not retrieve traintuple type with key %s - %s", parentKey, err.Error())
+			return fmt.Errorf("could not retrieve traintuple type with key %s - %s", parentTraintupleKey, err.Error())
 		}
 
 		// update child properties based on parent
 		if parentOutModel == nil {
 			status = StatusWaiting
 		}
-		inModelKeys = append(inModelKeys, parentKey)
+		inModelKeys = append(inModelKeys, parentTraintupleKey)
 		permissions = MergePermissions(permissions, parentPermissions)
 	}
 

--- a/chaincode/tuple_aggregate.go
+++ b/chaincode/tuple_aggregate.go
@@ -56,12 +56,10 @@ func (tuple *Aggregatetuple) SetFromInput(db LedgerDB, inp inputAggregatetuple) 
 	if !objective.Permissions.CanProcess(objective.Owner, creator) {
 		return errors.Forbidden("not authorized to process objective %s", inp.ObjectiveKey)
 	}
+
 	tuple.ObjectiveKey = inp.ObjectiveKey
-
-	// TODO (aggregate): uncomment + add test
-	// tuple.Permissions = MergePermissions(dataManager.Permissions, algo.Permissions)
-
 	tuple.Worker = inp.Worker
+
 	return nil
 }
 
@@ -70,20 +68,62 @@ func (tuple *Aggregatetuple) SetFromInput(db LedgerDB, inp inputAggregatetuple) 
 // Also it's InModelKeys are set.
 func (tuple *Aggregatetuple) SetFromParents(db LedgerDB, inModels []string) error {
 	status := StatusTodo
-
-	for _, parentTraintupleKey := range inModels {
-		hashDress, err := db.GetOutModelHashDress(parentTraintupleKey, TrunkType, []AssetType{TraintupleType, CompositeTraintupleType, AggregatetupleType})
-		if err != nil {
-			return err
-		}
-		if hashDress == nil {
-			status = StatusWaiting
-		}
-
-		tuple.InModelKeys = append(tuple.InModelKeys, parentTraintupleKey)
+	inModelKeys := tuple.InModelKeys
+	permissions, err := NewPermissions(db, OpenPermissions)
+	if err != nil {
+		return errors.BadRequest(err, "could not generate open permissions")
 	}
 
+	for _, parentKey := range inModels {
+		parentType, err := db.GetAssetType(parentKey)
+		if err != nil {
+			return fmt.Errorf("could not retrieve traintuple type with key %s - %s", parentKey, err.Error())
+		}
+
+		var parentOutModel *HashDress
+		parentPermissions := Permissions{}
+
+		// get out-model and permissions from parent
+		switch parentType {
+		case CompositeTraintupleType:
+			tuple, err := db.GetCompositeTraintuple(parentKey)
+			if err == nil {
+				// if parent is aggregate, always take the "trunk" out-model
+				parentOutModel = tuple.OutTrunkModel.OutModel
+				parentPermissions = tuple.OutTrunkModel.Permissions
+			}
+		case TraintupleType:
+			tuple, err := db.GetTraintuple(parentKey)
+			if err == nil {
+				parentOutModel = tuple.OutModel
+				parentPermissions = tuple.Permissions
+			}
+		case AggregatetupleType:
+			tuple, err := db.GetAggregatetuple(parentKey)
+			if err == nil {
+				parentOutModel = tuple.OutModel
+				parentPermissions = tuple.Permissions
+			}
+		default:
+			return fmt.Errorf("Aggregate.SetFromParents: Unsupported parent type %s", parentType)
+		}
+
+		if err != nil {
+			return fmt.Errorf("could not retrieve traintuple type with key %s - %s", parentKey, err.Error())
+		}
+
+		// update child properties based on parent
+		if parentOutModel == nil {
+			status = StatusWaiting
+		}
+		inModelKeys = append(inModelKeys, parentKey)
+		permissions = MergePermissions(permissions, parentPermissions)
+	}
+
+	tuple.InModelKeys = inModelKeys
+	tuple.Permissions = permissions
 	tuple.Status = status
+
 	return nil
 }
 

--- a/chaincode/tuple_aggregate_test.go
+++ b/chaincode/tuple_aggregate_test.go
@@ -285,7 +285,6 @@ func TestTraintupleAggregate(t *testing.T) {
 			},
 		},
 	}
-	expected.Permissions.Process.Public = true
 	assert.Exactly(t, expected, out, "the aggregate tuple queried from the ledger differ from expected")
 
 	// Query all traintuples and check consistency

--- a/chaincode/tuple_aggregate_test.go
+++ b/chaincode/tuple_aggregate_test.go
@@ -278,7 +278,14 @@ func TestTraintupleAggregate(t *testing.T) {
 			},
 		},
 		Status: StatusTodo,
+		Permissions: outputPermissions{
+			Process: Permission{
+				Public:        true,
+				AuthorizedIDs: []string{},
+			},
+		},
 	}
+	expected.Permissions.Process.Public = true
 	assert.Exactly(t, expected, out, "the aggregate tuple queried from the ledger differ from expected")
 
 	// Query all traintuples and check consistency
@@ -438,35 +445,66 @@ func TestInsertTraintupleTwiceAggregate(t *testing.T) {
 func TestAggregatetuplePermissions(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	registerItem(t, *mockStub, "trainDataset")
+	registerItem(t, *mockStub, "aggregateAlgo")
 
-	objHash := strings.ReplaceAll(objectiveDescriptionHash, "1", "2")
-	inpObjective := inputObjective{DescriptionHash: objHash}
-	inpObjective.createDefault()
-	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke("42", methodAndAssetToByte("registerObjective", inpObjective))
+	// register nodes
+	registerNode := func(nodeName string) {
+		initialCreator := mockStub.Creator
+		mockStub.Creator = nodeName
+		mockStub.MockInvoke("42", [][]byte{[]byte("registerNode")})
+		mockStub.Creator = initialCreator
+	}
+	registerNode("nodeA")
+	registerNode("nodeB")
+	registerNode("nodeC")
+	registerNode("nodeD")
 
-	inpAlgo := inputAggregateAlgo{}
-	args := inpAlgo.createDefault()
+	// register 3 algos
+	algo1, err := registerRandomCompositeAlgo(mockStub)
+	assert.Nil(t, err)
+	algo2, err := registerRandomCompositeAlgo(mockStub)
+	assert.Nil(t, err)
+	algo3, err := registerRandomCompositeAlgo(mockStub)
+	assert.Nil(t, err)
+
+	// register 3 composite traintuples, with various permissions
+	registerCompositeTraintuple := func(algoKey string, authorizedIds []string) string {
+		inp := inputCompositeTraintuple{AlgoKey: algoKey}
+		inp.fillDefaults()
+		inp.OutTrunkModelPermissions.Process.Public = false
+		inp.OutTrunkModelPermissions.Process.AuthorizedIDs = authorizedIds
+		resp := mockStub.MockInvoke("42", inp.getArgs())
+		assert.EqualValues(t, 200, resp.Status, resp.Message)
+		var _key struct{ Key string }
+		json.Unmarshal(resp.Payload, &_key)
+		return _key.Key
+	}
+	traintuple1 := registerCompositeTraintuple(algo1, []string{"nodeA", "nodeC"})
+	traintuple2 := registerCompositeTraintuple(algo2, []string{"nodeB", "nodeC"})
+	traintuple3 := registerCompositeTraintuple(algo3, []string{"nodeA", "nodeC", "nodeD"})
+
+	// create an aggregate tuple with the 3 composite as in-models
+	inpAgg := inputAggregatetuple{}
+	inpAgg.fillDefaults()
+	inpAgg.InModels = []string{traintuple1, traintuple2, traintuple3}
+	resp := mockStub.MockInvoke("42", inpAgg.getArgs())
+	assert.EqualValues(t, 200, resp.Status, resp.Message)
+	var _key struct{ Key string }
+	json.Unmarshal(resp.Payload, &_key)
+	aggrKey := _key.Key
+
+	// fetch the aggregate tuple back
+	aggr := outputAggregatetuple{}
+	args := [][]byte{[]byte("queryAggregatetuple"), keyToJSON(aggrKey)}
 	resp = mockStub.MockInvoke("42", args)
+	aggr = outputAggregatetuple{}
+	json.Unmarshal(resp.Payload, &aggr)
 
-	inpTraintuple := inputAggregatetuple{ObjectiveKey: objHash}
-	inpTraintuple.fillDefaults()
-	args = inpTraintuple.getArgs()
-	resp = mockStub.MockInvoke("42", args)
-
-	traintuple := outputAggregatetuple{}
-	json.Unmarshal(resp.Payload, &traintuple)
-	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(traintuple.Key)}
-	resp = mockStub.MockInvoke("42", args)
-	traintuple = outputAggregatetuple{}
-	json.Unmarshal(resp.Payload, &traintuple)
-
-	// TODO (aggregate): check permissions
-	// assert.EqualValues(t, false, traintuple.OutHeadModel.Permissions.Process.Public,
-	// 	"the head model should not be public")
-	// assert.EqualValues(t, []string{worker}, traintuple.OutHeadModel.Permissions.Process.AuthorizedIDs,
-	// 	"the head model should only be processable by creator")
+	// verify permissions
+	assert.EqualValues(t, false, aggr.Permissions.Process.Public,
+		"the aggregate tuple should not be public")
+	assert.EqualValues(t, []string{worker, "nodeC"}, aggr.Permissions.Process.AuthorizedIDs,
+		"the aggregate tuple permissions should be the intersect of the in-model permissions")
 }
 
 func TestAggregatetupleLogSuccessFail(t *testing.T) {


### PR DESCRIPTION
This PR implements aggregate tuple permissions:

```
Rule of permission for process : intersection of permissions of inModels. 
More specifically, if the aggtuple has as inModels:
	{modelA: {process : [nodeA, nodeC]},
	modelB: {process : [nodeB, nodeC]},
	modelC: {process : [nodeA, nodeC, node D]}},
then the outmodel is:
	{outmodel: {process: [nodeC]}}
```