### PR TITLE
Compute plan: support composite/aggregate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1507,7 +1507,7 @@ peer chaincode invoke -n mycc -c '{"Args":["createComputePlan","{\"objectiveKey\
  "testtupleKeys": [
   "1dbd49d84e00ad6f339f416af0decfaf2db8f14412786de65b597e49a6820f96"
  ],
- "trainingTaskKeys": [
+ "traintupleKeys": [
   "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
   "d23f8cf290b902417ae698d68e2c6835483521d54fcbece31208517759b7c299"
  ]
@@ -1594,7 +1594,7 @@ peer chaincode invoke -n mycc -c '{"Args":["queryComputePlan","{\"key\":\"432fcf
  "testtupleKeys": [
   "1dbd49d84e00ad6f339f416af0decfaf2db8f14412786de65b597e49a6820f96"
  ],
- "trainingTaskKeys": [
+ "traintupleKeys": [
   "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
   "d23f8cf290b902417ae698d68e2c6835483521d54fcbece31208517759b7c299"
  ]
@@ -1613,7 +1613,7 @@ peer chaincode invoke -n mycc -c '{"Args":["queryComputePlans"]}' -C myc
   "testtupleKeys": [
    "1dbd49d84e00ad6f339f416af0decfaf2db8f14412786de65b597e49a6820f96"
   ],
-  "trainingTaskKeys": [
+  "traintupleKeys": [
    "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
    "d23f8cf290b902417ae698d68e2c6835483521d54fcbece31208517759b7c299"
   ]

--- a/README.md
+++ b/README.md
@@ -1612,8 +1612,8 @@ peer chaincode invoke -n mycc -c '{"Args":["queryComputePlan","{\"key\":\"432fcf
 ##### Command output:
 ```json
 {
- "aggregatetupleKeys": null,
- "compositeTraintupleKeys": null,
+ "aggregatetupleKeys": [],
+ "compositeTraintupleKeys": [],
  "computePlanID": "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
  "objectiveKey": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
  "testtupleKeys": [
@@ -1633,8 +1633,8 @@ peer chaincode invoke -n mycc -c '{"Args":["queryComputePlans"]}' -C myc
 ```json
 [
  {
-  "aggregatetupleKeys": null,
-  "compositeTraintupleKeys": null,
+  "aggregatetupleKeys": [],
+  "compositeTraintupleKeys": [],
   "computePlanID": "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
   "objectiveKey": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
   "testtupleKeys": [

--- a/README.md
+++ b/README.md
@@ -1479,7 +1479,7 @@ Smart contract: `createComputePlan`
 ```go
 {
  "objectiveKey": string (required,len=64,hexadecimal),
- "trainingTasks": (required,gt=0) [{
+ "traintuples": (required,gt=0) [{
    "dataManagerKey": string (required,len=64,hexadecimal),
    "dataSampleKeys": [string] (required,dive,len=64,hexadecimal),
    "algoKey": string (required,len=64,hexadecimal),
@@ -1497,7 +1497,7 @@ Smart contract: `createComputePlan`
 ```
 ##### Command peer example:
 ```bash
-peer chaincode invoke -n mycc -c '{"Args":["createComputePlan","{\"objectiveKey\":\"5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379\",\"trainingTasks\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"firstTraintupleID\",\"inModelsIDs\":null,\"tag\":\"\"},{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"secondTraintupleID\",\"inModelsIDs\":[\"firstTraintupleID\"],\"tag\":\"\"}],\"testtuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"bb1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"bb2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"tag\":\"\",\"traintupleID\":\"secondTraintupleID\"}]}"]}' -C myc
+peer chaincode invoke -n mycc -c '{"Args":["createComputePlan","{\"objectiveKey\":\"5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379\",\"traintuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"firstTraintupleID\",\"inModelsIDs\":null,\"tag\":\"\"},{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"secondTraintupleID\",\"inModelsIDs\":[\"firstTraintupleID\"],\"tag\":\"\"}],\"testtuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"bb1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"bb2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"tag\":\"\",\"traintupleID\":\"secondTraintupleID\"}]}"]}' -C myc
 ```
 ##### Command output:
 ```json

--- a/README.md
+++ b/README.md
@@ -1492,6 +1492,7 @@ Smart contract: `createComputePlan`
    "id": string (required,lte=64),
    "inModelsIDs": [string] (omitempty,dive,lte=64),
    "tag": string (omitempty,lte=64),
+   "worker": string (required),
  }],
  "compositeTraintuples": (omitempty) [{
    "dataManagerKey": string (required,len=64,hexadecimal),

--- a/README.md
+++ b/README.md
@@ -1479,12 +1479,27 @@ Smart contract: `createComputePlan`
 ```go
 {
  "objectiveKey": string (required,len=64,hexadecimal),
- "traintuples": (required,gt=0) [{
+ "traintuples": (omitempty) [{
    "dataManagerKey": string (required,len=64,hexadecimal),
    "dataSampleKeys": [string] (required,dive,len=64,hexadecimal),
    "algoKey": string (required,len=64,hexadecimal),
    "id": string (required,lte=64),
    "inModelsIDs": [string] (omitempty,dive,lte=64),
+   "tag": string (omitempty,lte=64),
+ }],
+ "compositeTraintuples": (omitempty) [{
+   "dataManagerKey": string (required,len=64,hexadecimal),
+   "dataSampleKeys": [string] (required,dive,len=64,hexadecimal),
+   "algoKey": string (required,len=64,hexadecimal),
+   "id": string (required,lte=64),
+   "inHeadModelID": string (required_with=InTrunkModelID,omitempty,len=64,hexadecimal),
+   "inTrunkModelID": string (required_with=InHeadModelID,omitempty,len=64,hexadecimal),
+   "OutTrunkModelPermissions": (required){
+     "process": (required){
+       "public": bool (required),
+       "authorizedIDs": [string] (required),
+     },
+   },
    "tag": string (omitempty,lte=64),
  }],
  "testtuples": (omitempty) [{
@@ -1497,11 +1512,12 @@ Smart contract: `createComputePlan`
 ```
 ##### Command peer example:
 ```bash
-peer chaincode invoke -n mycc -c '{"Args":["createComputePlan","{\"objectiveKey\":\"5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379\",\"traintuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"firstTraintupleID\",\"inModelsIDs\":null,\"tag\":\"\"},{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"secondTraintupleID\",\"inModelsIDs\":[\"firstTraintupleID\"],\"tag\":\"\"}],\"testtuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"bb1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"bb2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"tag\":\"\",\"traintupleID\":\"secondTraintupleID\"}]}"]}' -C myc
+peer chaincode invoke -n mycc -c '{"Args":["createComputePlan","{\"objectiveKey\":\"5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379\",\"traintuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"firstTraintupleID\",\"inModelsIDs\":null,\"tag\":\"\"},{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"secondTraintupleID\",\"inModelsIDs\":[\"firstTraintupleID\"],\"tag\":\"\"}],\"compositeTraintuples\":null,\"testtuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"bb1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"bb2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"tag\":\"\",\"traintupleID\":\"secondTraintupleID\"}]}"]}' -C myc
 ```
 ##### Command output:
 ```json
 {
+ "compositeTraintupleKeys": null,
  "computePlanID": "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
  "objectiveKey": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
  "testtupleKeys": [
@@ -1589,6 +1605,7 @@ peer chaincode invoke -n mycc -c '{"Args":["queryComputePlan","{\"key\":\"432fcf
 ##### Command output:
 ```json
 {
+ "compositeTraintupleKeys": null,
  "computePlanID": "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
  "objectiveKey": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
  "testtupleKeys": [
@@ -1608,6 +1625,7 @@ peer chaincode invoke -n mycc -c '{"Args":["queryComputePlans"]}' -C myc
 ```json
 [
  {
+  "compositeTraintupleKeys": null,
   "computePlanID": "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
   "objectiveKey": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
   "testtupleKeys": [

--- a/README.md
+++ b/README.md
@@ -1487,6 +1487,12 @@ Smart contract: `createComputePlan`
    "inModelsIDs": [string] (omitempty,dive,lte=64),
    "tag": string (omitempty,lte=64),
  }],
+ "aggregatetuples": (omitempty) [{
+   "algoKey": string (required,len=64,hexadecimal),
+   "id": string (required,lte=64),
+   "inModelsIDs": [string] (omitempty,dive,lte=64),
+   "tag": string (omitempty,lte=64),
+ }],
  "compositeTraintuples": (omitempty) [{
    "dataManagerKey": string (required,len=64,hexadecimal),
    "dataSampleKeys": [string] (required,dive,len=64,hexadecimal),
@@ -1512,11 +1518,12 @@ Smart contract: `createComputePlan`
 ```
 ##### Command peer example:
 ```bash
-peer chaincode invoke -n mycc -c '{"Args":["createComputePlan","{\"objectiveKey\":\"5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379\",\"traintuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"firstTraintupleID\",\"inModelsIDs\":null,\"tag\":\"\"},{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"secondTraintupleID\",\"inModelsIDs\":[\"firstTraintupleID\"],\"tag\":\"\"}],\"compositeTraintuples\":null,\"testtuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"bb1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"bb2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"tag\":\"\",\"traintupleID\":\"secondTraintupleID\"}]}"]}' -C myc
+peer chaincode invoke -n mycc -c '{"Args":["createComputePlan","{\"objectiveKey\":\"5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379\",\"traintuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"firstTraintupleID\",\"inModelsIDs\":null,\"tag\":\"\"},{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"secondTraintupleID\",\"inModelsIDs\":[\"firstTraintupleID\"],\"tag\":\"\"}],\"aggregatetuples\":null,\"compositeTraintuples\":null,\"testtuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"bb1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"bb2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"tag\":\"\",\"traintupleID\":\"secondTraintupleID\"}]}"]}' -C myc
 ```
 ##### Command output:
 ```json
 {
+ "aggregatetupleKeys": null,
  "compositeTraintupleKeys": null,
  "computePlanID": "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
  "objectiveKey": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
@@ -1605,6 +1612,7 @@ peer chaincode invoke -n mycc -c '{"Args":["queryComputePlan","{\"key\":\"432fcf
 ##### Command output:
 ```json
 {
+ "aggregatetupleKeys": null,
  "compositeTraintupleKeys": null,
  "computePlanID": "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
  "objectiveKey": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
@@ -1625,6 +1633,7 @@ peer chaincode invoke -n mycc -c '{"Args":["queryComputePlans"]}' -C myc
 ```json
 [
  {
+  "aggregatetupleKeys": null,
   "compositeTraintupleKeys": null,
   "computePlanID": "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
   "objectiveKey": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",

--- a/README.md
+++ b/README.md
@@ -1478,11 +1478,11 @@ Smart contract: `createComputePlan`
 ##### JSON Inputs:
 ```go
 {
- "algoKey": string (required,len=64,hexadecimal),
  "objectiveKey": string (required,len=64,hexadecimal),
- "traintuples": (required,gt=0) [{
+ "trainingTasks": (required,gt=0) [{
    "dataManagerKey": string (required,len=64,hexadecimal),
    "dataSampleKeys": [string] (required,dive,len=64,hexadecimal),
+   "algoKey": string (required,len=64,hexadecimal),
    "id": string (required,lte=64),
    "inModelsIDs": [string] (omitempty,dive,lte=64),
    "tag": string (omitempty,lte=64),
@@ -1497,16 +1497,17 @@ Smart contract: `createComputePlan`
 ```
 ##### Command peer example:
 ```bash
-peer chaincode invoke -n mycc -c '{"Args":["createComputePlan","{\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"objectiveKey\":\"5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379\",\"traintuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"id\":\"firstTraintupleID\",\"inModelsIDs\":null,\"tag\":\"\"},{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"id\":\"secondTraintupleID\",\"inModelsIDs\":[\"firstTraintupleID\"],\"tag\":\"\"}],\"testtuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"bb1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"bb2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"tag\":\"\",\"traintupleID\":\"secondTraintupleID\"}]}"]}' -C myc
+peer chaincode invoke -n mycc -c '{"Args":["createComputePlan","{\"objectiveKey\":\"5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379\",\"trainingTasks\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"firstTraintupleID\",\"inModelsIDs\":null,\"tag\":\"\"},{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"secondTraintupleID\",\"inModelsIDs\":[\"firstTraintupleID\"],\"tag\":\"\"}],\"testtuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"bb1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"bb2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"tag\":\"\",\"traintupleID\":\"secondTraintupleID\"}]}"]}' -C myc
 ```
 ##### Command output:
 ```json
 {
  "computePlanID": "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
+ "objectiveKey": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
  "testtupleKeys": [
   "1dbd49d84e00ad6f339f416af0decfaf2db8f14412786de65b597e49a6820f96"
  ],
- "traintupleKeys": [
+ "trainingTaskKeys": [
   "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
   "d23f8cf290b902417ae698d68e2c6835483521d54fcbece31208517759b7c299"
  ]
@@ -1588,13 +1589,12 @@ peer chaincode invoke -n mycc -c '{"Args":["queryComputePlan","{\"key\":\"432fcf
 ##### Command output:
 ```json
 {
- "algoKey": "fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
  "computePlanID": "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
  "objectiveKey": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
- "testtuples": [
+ "testtupleKeys": [
   "1dbd49d84e00ad6f339f416af0decfaf2db8f14412786de65b597e49a6820f96"
  ],
- "traintuples": [
+ "trainingTaskKeys": [
   "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
   "d23f8cf290b902417ae698d68e2c6835483521d54fcbece31208517759b7c299"
  ]
@@ -1608,13 +1608,12 @@ peer chaincode invoke -n mycc -c '{"Args":["queryComputePlans"]}' -C myc
 ```json
 [
  {
-  "algoKey": "fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
   "computePlanID": "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
   "objectiveKey": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-  "testtuples": [
+  "testtupleKeys": [
    "1dbd49d84e00ad6f339f416af0decfaf2db8f14412786de65b597e49a6820f96"
   ],
-  "traintuples": [
+  "trainingTaskKeys": [
    "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
    "d23f8cf290b902417ae698d68e2c6835483521d54fcbece31208517759b7c299"
   ]

--- a/chaincode/algo.go
+++ b/chaincode/algo.go
@@ -20,7 +20,7 @@ import (
 
 // Set is a method of the receiver Algo. It uses inputAlgo fields to set the Algo
 // Returns the algoKey
-func (algo *Algo) Set(db LedgerDB, inp inputAlgo) (algoKey string, err error) {
+func (algo *Algo) Set(db *LedgerDB, inp inputAlgo) (algoKey string, err error) {
 	algoKey = inp.Hash
 	// find associated owner
 	owner, err := GetTxCreator(db.cc)
@@ -50,7 +50,7 @@ func (algo *Algo) Set(db LedgerDB, inp inputAlgo) (algoKey string, err error) {
 // -------------------------------------------------------------------------------------------
 // registerAlgo stores a new algo in the ledger.
 // If the key exists, it will override the value with the new one
-func registerAlgo(db LedgerDB, args []string) (resp map[string]string, err error) {
+func registerAlgo(db *LedgerDB, args []string) (resp map[string]string, err error) {
 	inp := inputAlgo{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -76,7 +76,7 @@ func registerAlgo(db LedgerDB, args []string) (resp map[string]string, err error
 }
 
 // queryAlgo returns an algo of the ledger given its key
-func queryAlgo(db LedgerDB, args []string) (out outputAlgo, err error) {
+func queryAlgo(db *LedgerDB, args []string) (out outputAlgo, err error) {
 	inp := inputHash{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -91,7 +91,7 @@ func queryAlgo(db LedgerDB, args []string) (out outputAlgo, err error) {
 }
 
 // queryAlgos returns all algos of the ledger
-func queryAlgos(db LedgerDB, args []string) (outAlgos []outputAlgo, err error) {
+func queryAlgos(db *LedgerDB, args []string) (outAlgos []outputAlgo, err error) {
 	outAlgos = []outputAlgo{}
 	if len(args) != 0 {
 		err = errors.BadRequest("incorrect number of arguments, expecting nothing")

--- a/chaincode/algo_aggregate.go
+++ b/chaincode/algo_aggregate.go
@@ -20,7 +20,7 @@ import (
 
 // Set is a method of the receiver Aggregate. It uses inputAggregateAlgo fields to set the AggregateAlgo
 // Returns the aggregateAlgoKey
-func (algo *AggregateAlgo) Set(db LedgerDB, inp inputAggregateAlgo) (algoKey string, err error) {
+func (algo *AggregateAlgo) Set(db *LedgerDB, inp inputAggregateAlgo) (algoKey string, err error) {
 	algoKey = inp.Hash
 	// find associated owner
 	owner, err := GetTxCreator(db.cc)
@@ -50,7 +50,7 @@ func (algo *AggregateAlgo) Set(db LedgerDB, inp inputAggregateAlgo) (algoKey str
 // -------------------------------------------------------------------------------------------
 // registerAggregateAlgo stores a new algo in the ledger.
 // If the key exists, it will override the value with the new one
-func registerAggregateAlgo(db LedgerDB, args []string) (resp map[string]string, err error) {
+func registerAggregateAlgo(db *LedgerDB, args []string) (resp map[string]string, err error) {
 	inp := inputAggregateAlgo{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -76,7 +76,7 @@ func registerAggregateAlgo(db LedgerDB, args []string) (resp map[string]string, 
 }
 
 // queryAggregateAlgo returns an algo of the ledger given its key
-func queryAggregateAlgo(db LedgerDB, args []string) (out outputAggregateAlgo, err error) {
+func queryAggregateAlgo(db *LedgerDB, args []string) (out outputAggregateAlgo, err error) {
 	inp := inputHash{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -91,7 +91,7 @@ func queryAggregateAlgo(db LedgerDB, args []string) (out outputAggregateAlgo, er
 }
 
 // queryAggregateAlgos returns all algos of the ledger
-func queryAggregateAlgos(db LedgerDB, args []string) (outAlgos []outputAggregateAlgo, err error) {
+func queryAggregateAlgos(db *LedgerDB, args []string) (outAlgos []outputAggregateAlgo, err error) {
 	outAlgos = []outputAggregateAlgo{}
 	if len(args) != 0 {
 		err = errors.BadRequest("incorrect number of arguments, expecting nothing")

--- a/chaincode/algo_composite.go
+++ b/chaincode/algo_composite.go
@@ -20,7 +20,7 @@ import (
 
 // Set is a method of the receiver CompositeAlgo. It uses inputCompositeAlgo fields to set the CompositeAlgo
 // Returns the compositeAlgoKey
-func (algo *CompositeAlgo) Set(db LedgerDB, inp inputCompositeAlgo) (algoKey string, err error) {
+func (algo *CompositeAlgo) Set(db *LedgerDB, inp inputCompositeAlgo) (algoKey string, err error) {
 	algoKey = inp.Hash
 	// find associated owner
 	owner, err := GetTxCreator(db.cc)
@@ -50,7 +50,7 @@ func (algo *CompositeAlgo) Set(db LedgerDB, inp inputCompositeAlgo) (algoKey str
 // -------------------------------------------------------------------------------------------
 // registerCompositeAlgo stores a new algo in the ledger.
 // If the key exists, it will override the value with the new one
-func registerCompositeAlgo(db LedgerDB, args []string) (resp map[string]string, err error) {
+func registerCompositeAlgo(db *LedgerDB, args []string) (resp map[string]string, err error) {
 	inp := inputCompositeAlgo{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -76,7 +76,7 @@ func registerCompositeAlgo(db LedgerDB, args []string) (resp map[string]string, 
 }
 
 // queryCompositeAlgo returns an algo of the ledger given its key
-func queryCompositeAlgo(db LedgerDB, args []string) (out outputCompositeAlgo, err error) {
+func queryCompositeAlgo(db *LedgerDB, args []string) (out outputCompositeAlgo, err error) {
 	inp := inputHash{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -91,7 +91,7 @@ func queryCompositeAlgo(db LedgerDB, args []string) (out outputCompositeAlgo, er
 }
 
 // queryCompositeAlgos returns all algos of the ledger
-func queryCompositeAlgos(db LedgerDB, args []string) (outAlgos []outputCompositeAlgo, err error) {
+func queryCompositeAlgos(db *LedgerDB, args []string) (outAlgos []outputCompositeAlgo, err error) {
 	outAlgos = []outputCompositeAlgo{}
 	if len(args) != 0 {
 		err = errors.BadRequest("incorrect number of arguments, expecting nothing")

--- a/chaincode/common.go
+++ b/chaincode/common.go
@@ -21,7 +21,7 @@ import (
 
 // queryFilter returns all elements of the ledger matching some filters
 // For now, ok for everything. Later returns if the requester has permission to see it
-func queryFilter(db LedgerDB, args []string) (elements interface{}, err error) {
+func queryFilter(db *LedgerDB, args []string) (elements interface{}, err error) {
 	inp := inputQueryFilter{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {

--- a/chaincode/compute_plan.go
+++ b/chaincode/compute_plan.go
@@ -43,6 +43,7 @@ func (inpTraintuple *inputTraintuple) Fill(inpCP inputComputePlanTraintuple, tra
 func (inpAggregatetuple *inputAggregatetuple) Fill(inpCP inputComputePlanAggregatetuple, aggregatetupleKeysByID map[string]string) error {
 	inpAggregatetuple.AlgoKey = inpCP.AlgoKey
 	inpAggregatetuple.Tag = inpCP.Tag
+	inpAggregatetuple.Worker = inpCP.Worker
 
 	// Set the inModels by matching the id to tuples key previously
 	// encontered in this compute plan

--- a/chaincode/compute_plan.go
+++ b/chaincode/compute_plan.go
@@ -213,13 +213,6 @@ func createComputePlanInternal(db LedgerDB, inp inputComputePlan) (resp outputCo
 		resp.TesttupleKeys = append(resp.TesttupleKeys, testtupleKey)
 	}
 
-	// event := TuplesEvent{}
-	//	event.SetTraintuples(traintuplesTodo...)
-	// err = SendTuplesEvent(db.cc, event)
-	// if err != nil {
-	// return resp, err
-	// }
-
 	return resp, err
 }
 

--- a/chaincode/compute_plan.go
+++ b/chaincode/compute_plan.go
@@ -97,7 +97,7 @@ func (inpTesttuple *inputTesttuple) Fill(inpCP inputComputePlanTesttuple, traint
 }
 
 // createComputePlan is the wrapper for the substra smartcontract CreateComputePlan
-func createComputePlan(db LedgerDB, args []string) (resp outputComputePlan, err error) {
+func createComputePlan(db *LedgerDB, args []string) (resp outputComputePlan, err error) {
 	inp := inputComputePlan{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -106,7 +106,7 @@ func createComputePlan(db LedgerDB, args []string) (resp outputComputePlan, err 
 	return createComputePlanInternal(db, inp)
 }
 
-func createComputePlanInternal(db LedgerDB, inp inputComputePlan) (resp outputComputePlan, err error) {
+func createComputePlanInternal(db *LedgerDB, inp inputComputePlan) (resp outputComputePlan, err error) {
 	traintupleKeysByID := map[string]string{}
 
 	resp.ObjectiveKey = inp.ObjectiveKey
@@ -216,7 +216,7 @@ func createComputePlanInternal(db LedgerDB, inp inputComputePlan) (resp outputCo
 	return resp, err
 }
 
-func queryComputePlan(db LedgerDB, args []string) (resp outputComputePlan, err error) {
+func queryComputePlan(db *LedgerDB, args []string) (resp outputComputePlan, err error) {
 	inp := inputHash{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -225,7 +225,7 @@ func queryComputePlan(db LedgerDB, args []string) (resp outputComputePlan, err e
 	return getComputePlan(db, inp.Key)
 }
 
-func queryComputePlans(db LedgerDB, args []string) (resp []outputComputePlan, err error) {
+func queryComputePlans(db *LedgerDB, args []string) (resp []outputComputePlan, err error) {
 	resp = []outputComputePlan{}
 	computePlanIDs, err := db.GetIndexKeys("computeplan~id", []string{"computeplan"})
 	if err != nil {
@@ -244,7 +244,7 @@ func queryComputePlans(db LedgerDB, args []string) (resp []outputComputePlan, er
 
 // getComputePlan returns details for a compute plan id.
 // Traintuples, CompositeTraintuples and Aggregatetuples are ordered by ascending rank.
-func getComputePlan(db LedgerDB, key string) (resp outputComputePlan, err error) {
+func getComputePlan(db *LedgerDB, key string) (resp outputComputePlan, err error) {
 
 	// 1. Get tuples (regular, composite, aggregate)
 	tupleKeys, err := db.GetIndexKeys("computePlan~computeplanid~worker~rank~key", []string{"computePlan", key})

--- a/chaincode/compute_plan.go
+++ b/chaincode/compute_plan.go
@@ -132,7 +132,7 @@ func createComputePlanInternal(db LedgerDB, inp inputComputePlan) (resp outputCo
 				return resp, errors.BadRequest("traintuple ID %s: "+err.Error(), computeTraintuple.ID)
 			}
 
-			traintupleKey, err := createTraintupleInternal(db, inpTraintuple)
+			traintupleKey, err := createTraintupleInternal(db, inpTraintuple, true)
 			if err != nil {
 				return resp, errors.BadRequest("traintuple ID %s: "+err.Error(), computeTraintuple.ID)
 			}
@@ -157,7 +157,7 @@ func createComputePlanInternal(db LedgerDB, inp inputComputePlan) (resp outputCo
 				return resp, errors.BadRequest("traintuple ID %s: "+err.Error(), computeCompositeTraintuple.ID)
 			}
 			_ = computeCompositeTraintuple
-			compositeTraintupleKey, err := createCompositeTraintupleInternal(db, inpCompositeTraintuple)
+			compositeTraintupleKey, err := createCompositeTraintupleInternal(db, inpCompositeTraintuple, true)
 			if err != nil {
 				return resp, errors.BadRequest("traintuple ID %s: "+err.Error(), computeCompositeTraintuple.ID)
 			}
@@ -182,7 +182,7 @@ func createComputePlanInternal(db LedgerDB, inp inputComputePlan) (resp outputCo
 				return resp, errors.BadRequest("traintuple ID %s: "+err.Error(), computeAggregatetuple.ID)
 			}
 			_ = computeAggregatetuple
-			aggregatetupleKey, err := createAggregatetupleInternal(db, inpAggregatetuple)
+			aggregatetupleKey, err := createAggregatetupleInternal(db, inpAggregatetuple, true)
 			if err != nil {
 				return resp, errors.BadRequest("traintuple ID %s: "+err.Error(), computeAggregatetuple.ID)
 			}

--- a/chaincode/compute_plan.go
+++ b/chaincode/compute_plan.go
@@ -133,7 +133,9 @@ func createComputePlanInternal(db *LedgerDB, inp inputComputePlan) (resp outputC
 				return resp, errors.BadRequest("traintuple ID %s: "+err.Error(), computeTraintuple.ID)
 			}
 
-			traintupleKey, err := createTraintupleInternal(db, inpTraintuple, true)
+			// Intentionally skip the compute plan availability check: since the transaction hasn't been
+			// committed yet, the index changes haven't been commited, so the check would always fail.
+			traintupleKey, err := createTraintupleInternal(db, inpTraintuple, false)
 			if err != nil {
 				return resp, errors.BadRequest("traintuple ID %s: "+err.Error(), computeTraintuple.ID)
 			}
@@ -158,7 +160,9 @@ func createComputePlanInternal(db *LedgerDB, inp inputComputePlan) (resp outputC
 				return resp, errors.BadRequest("traintuple ID %s: "+err.Error(), computeCompositeTraintuple.ID)
 			}
 			_ = computeCompositeTraintuple
-			compositeTraintupleKey, err := createCompositeTraintupleInternal(db, inpCompositeTraintuple, true)
+			// Intentionally skip the compute plan availability check: since the transaction hasn't been
+			// committed yet, the index changes haven't been commited, so the check would always fail.
+			compositeTraintupleKey, err := createCompositeTraintupleInternal(db, inpCompositeTraintuple, false)
 			if err != nil {
 				return resp, errors.BadRequest("traintuple ID %s: "+err.Error(), computeCompositeTraintuple.ID)
 			}
@@ -183,7 +187,9 @@ func createComputePlanInternal(db *LedgerDB, inp inputComputePlan) (resp outputC
 				return resp, errors.BadRequest("traintuple ID %s: "+err.Error(), computeAggregatetuple.ID)
 			}
 			_ = computeAggregatetuple
-			aggregatetupleKey, err := createAggregatetupleInternal(db, inpAggregatetuple, true)
+			// Intentionally skip the compute plan availability check: since the transaction hasn't been
+			// committed yet, the index changes haven't been commited, so the check would always fail.
+			aggregatetupleKey, err := createAggregatetupleInternal(db, inpAggregatetuple, false)
 			if err != nil {
 				return resp, errors.BadRequest("traintuple ID %s: "+err.Error(), computeAggregatetuple.ID)
 			}

--- a/chaincode/compute_plan_dag.go
+++ b/chaincode/compute_plan_dag.go
@@ -71,7 +71,7 @@ func (dag *ComputeDAG) sort() error {
 		if ready {
 			final = append(final, current[i])
 			if _, ok := IDPresents[current[i].ID]; ok {
-				return fmt.Errorf("Compute plan error: Duplicate training task ID: %s", current[i].ID)
+				return fmt.Errorf("compute plan error: Duplicate training task ID: %s", current[i].ID)
 			}
 			IDPresents[current[i].ID] = true
 		} else {
@@ -86,7 +86,7 @@ func (dag *ComputeDAG) sort() error {
 			for _, c := range current {
 				errorIDs = append(errorIDs, c.ID)
 			}
-			return fmt.Errorf("Compute plan error: Cyclic or missing dependency among inModels IDs: %v", errorIDs)
+			return fmt.Errorf("compute plan error: Cyclic or missing dependency among inModels IDs: %v", errorIDs)
 		}
 		i = 0
 		current = temp

--- a/chaincode/compute_plan_dag_test.go
+++ b/chaincode/compute_plan_dag_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSort(t *testing.T) {
+func TestDAGSort(t *testing.T) {
 	ts := []struct {
 		name        string
 		list        []TrainingTask
@@ -45,7 +45,7 @@ func TestSort(t *testing.T) {
 				{ID: "four", InModelsIDs: []string{"five"}},
 			},
 			expectError: true,
-			errorStr:    "compute plan error, either cyclic or missing dep among those IDs'inModels: [four]"},
+			errorStr:    "Compute plan error: Cyclic or missing dependency among inModels IDs: [four]"},
 		{name: "cyclic inModels",
 			list: []TrainingTask{
 				{ID: "one"},
@@ -55,7 +55,7 @@ func TestSort(t *testing.T) {
 				{ID: "five", InModelsIDs: []string{"four"}},
 			},
 			expectError: true,
-			errorStr:    "compute plan error, either cyclic or missing dep among those IDs'inModels: [two three four five]"},
+			errorStr:    "Compute plan error: Cyclic or missing dependency among inModels IDs: [two three four five]"},
 		{name: "Same ID twice",
 			list: []TrainingTask{
 				{ID: "one"},
@@ -64,7 +64,7 @@ func TestSort(t *testing.T) {
 				{ID: "one", InModelsIDs: []string{"three"}},
 			},
 			expectError: true,
-			errorStr:    `compute plan error, ID use twice: one`},
+			errorStr:    `Compute plan error: Duplicate training task ID: one`},
 	}
 	for _, tc := range ts {
 		t.Run(tc.name, func(t *testing.T) {

--- a/chaincode/compute_plan_dag_test.go
+++ b/chaincode/compute_plan_dag_test.go
@@ -45,7 +45,7 @@ func TestDAGSort(t *testing.T) {
 				{ID: "four", InModelsIDs: []string{"five"}},
 			},
 			expectError: true,
-			errorStr:    "Compute plan error: Cyclic or missing dependency among inModels IDs: [four]"},
+			errorStr:    "compute plan error: Cyclic or missing dependency among inModels IDs: [four]"},
 		{name: "cyclic inModels",
 			list: []TrainingTask{
 				{ID: "one"},
@@ -55,7 +55,7 @@ func TestDAGSort(t *testing.T) {
 				{ID: "five", InModelsIDs: []string{"four"}},
 			},
 			expectError: true,
-			errorStr:    "Compute plan error: Cyclic or missing dependency among inModels IDs: [two three four five]"},
+			errorStr:    "compute plan error: Cyclic or missing dependency among inModels IDs: [two three four five]"},
 		{name: "Same ID twice",
 			list: []TrainingTask{
 				{ID: "one"},
@@ -64,7 +64,7 @@ func TestDAGSort(t *testing.T) {
 				{ID: "one", InModelsIDs: []string{"three"}},
 			},
 			expectError: true,
-			errorStr:    `Compute plan error: Duplicate training task ID: one`},
+			errorStr:    `compute plan error: Duplicate training task ID: one`},
 	}
 	for _, tc := range ts {
 		t.Run(tc.name, func(t *testing.T) {

--- a/chaincode/compute_plan_test.go
+++ b/chaincode/compute_plan_test.go
@@ -142,7 +142,7 @@ func TestCreateComputePlan(t *testing.T) {
 	inCP := defaultComputePlan
 	outCP, err := createComputePlanInternal(db, inCP)
 	assert.NoError(t, err)
-	validateComputePlan(t, outCP, defaultComputePlan)
+	validateDefaultComputePlan(t, outCP, defaultComputePlan)
 
 	// Check the traintuples
 	traintuples, err := queryTraintuples(db, []string{})
@@ -202,7 +202,7 @@ func TestQueryComputePlan(t *testing.T) {
 	cp, err := queryComputePlan(db, assetToArgs(inputHash{Key: outCP.ComputePlanID}))
 	assert.NoError(t, err, "calling queryComputePlan should succeed")
 	assert.NotNil(t, cp)
-	validateComputePlan(t, cp, defaultComputePlan)
+	validateDefaultComputePlan(t, cp, defaultComputePlan)
 }
 
 func TestQueryComputePlans(t *testing.T) {
@@ -223,7 +223,23 @@ func TestQueryComputePlans(t *testing.T) {
 	cps, err := queryComputePlans(db, []string{})
 	assert.NoError(t, err, "calling queryComputePlans should succeed")
 	assert.Len(t, cps, 1, "queryComputePlans should return one compute plan")
-	validateComputePlan(t, cps[0], defaultComputePlan)
+	validateDefaultComputePlan(t, cps[0], defaultComputePlan)
+}
+
+func validateDefaultComputePlan(t *testing.T, cp outputComputePlan, in inputComputePlan) {
+	assert.Len(t, cp.TraintupleKeys, 2)
+	cpID := cp.TraintupleKeys[0]
+
+	assert.Equal(t, in.ObjectiveKey, cp.ObjectiveKey)
+
+	assert.Equal(t, cpID, cp.ComputePlanID)
+	assert.Equal(t, in.ObjectiveKey, cp.ObjectiveKey)
+
+	assert.NotEmpty(t, cp.TraintupleKeys[0])
+	assert.NotEmpty(t, cp.TraintupleKeys[1])
+
+	require.Len(t, cp.TesttupleKeys, 1)
+	assert.NotEmpty(t, cp.TesttupleKeys[0])
 }
 
 func TestComputePlanEmptyTesttuples(t *testing.T) {
@@ -282,20 +298,4 @@ func TestQueryComputePlanEmpty(t *testing.T) {
 	cps, err := queryComputePlans(db, []string{})
 	assert.NoError(t, err, "calling queryComputePlans should succeed")
 	assert.Equal(t, []outputComputePlan{}, cps)
-}
-
-func validateComputePlan(t *testing.T, cp outputComputePlan, in inputComputePlan) {
-	assert.Len(t, cp.TraintupleKeys, 2)
-	cpID := cp.TraintupleKeys[0]
-
-	assert.Equal(t, in.ObjectiveKey, cp.ObjectiveKey)
-
-	assert.Equal(t, cpID, cp.ComputePlanID)
-	assert.Equal(t, in.ObjectiveKey, cp.ObjectiveKey)
-
-	assert.NotEmpty(t, cp.TraintupleKeys[0])
-	assert.NotEmpty(t, cp.TraintupleKeys[1])
-
-	require.Len(t, cp.TesttupleKeys, 1)
-	assert.NotEmpty(t, cp.TesttupleKeys[0])
 }

--- a/chaincode/compute_plan_test.go
+++ b/chaincode/compute_plan_test.go
@@ -74,6 +74,53 @@ var (
 	}
 )
 
+func TestCreateComputePlanAggregate(t *testing.T) {
+	scc := new(SubstraChaincode)
+	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	registerItem(t, *mockStub, "aggregateAlgo")
+
+	mockStub.MockTransactionStart("42")
+	db := NewLedgerDB(mockStub)
+
+	tag := []string{"compositeTraintuple1", "compositeTraintuple2", "aggregatetuple1", "aggregatetuple2"}
+	// Simply test method and return values
+	inCP := defaultComputePlan
+	inCP.CompositeTraintuples = []inputComputePlanCompositeTraintuple{
+		{
+			DataManagerKey: dataManagerOpenerHash,
+			DataSampleKeys: []string{trainDataSampleHash1},
+			AlgoKey:        compositeAlgoHash,
+			ID:             tag[0],
+		},
+		{
+			DataManagerKey: dataManagerOpenerHash,
+			DataSampleKeys: []string{trainDataSampleHash1},
+			AlgoKey:        compositeAlgoHash,
+			ID:             tag[1],
+			InTrunkModelID: tag[0],
+			InHeadModelID:  tag[0],
+		},
+	}
+	inCP.Aggregatetuples = []inputComputePlanAggregatetuple{
+		{
+			AlgoKey: aggregateAlgoHash,
+			ID:      tag[2],
+		},
+		{
+			AlgoKey:     aggregateAlgoHash,
+			ID:          tag[3],
+			InModelsIDs: []string{tag[2]},
+		},
+	}
+	outCP, err := createComputePlanInternal(db, inCP)
+	assert.NoError(t, err)
+	// Check the composite traintuples
+	traintuples, err := queryAggregatetuples(db, []string{})
+	assert.NoError(t, err)
+	require.Len(t, traintuples, 2)
+	require.Contains(t, outCP.AggregatetupleKeys, traintuples[0].Key)
+	require.Contains(t, outCP.AggregatetupleKeys, traintuples[1].Key)
+}
 func TestCreateComputePlanComposite(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)

--- a/chaincode/compute_plan_test.go
+++ b/chaincode/compute_plan_test.go
@@ -246,7 +246,7 @@ func TestCreateComputePlan(t *testing.T) {
 	inCP := defaultComputePlan
 	outCP, err := createComputePlanInternal(db, inCP)
 	assert.NoError(t, err)
-	validateDefaultComputePlan(t, outCP, defaultComputePlan)
+	validateDefaultComputePlan(t, outCP)
 
 	// Check the traintuples
 	traintuples, err := queryTraintuples(db, []string{})
@@ -306,7 +306,7 @@ func TestQueryComputePlan(t *testing.T) {
 	cp, err := queryComputePlan(db, assetToArgs(inputHash{Key: outCP.ComputePlanID}))
 	assert.NoError(t, err, "calling queryComputePlan should succeed")
 	assert.NotNil(t, cp)
-	validateDefaultComputePlan(t, cp, defaultComputePlan)
+	validateDefaultComputePlan(t, cp)
 }
 
 func TestQueryComputePlans(t *testing.T) {
@@ -327,10 +327,11 @@ func TestQueryComputePlans(t *testing.T) {
 	cps, err := queryComputePlans(db, []string{})
 	assert.NoError(t, err, "calling queryComputePlans should succeed")
 	assert.Len(t, cps, 1, "queryComputePlans should return one compute plan")
-	validateDefaultComputePlan(t, cps[0], defaultComputePlan)
+	validateDefaultComputePlan(t, cps[0])
 }
 
-func validateDefaultComputePlan(t *testing.T, cp outputComputePlan, in inputComputePlan) {
+func validateDefaultComputePlan(t *testing.T, cp outputComputePlan) {
+	in := defaultComputePlan
 	assert.Len(t, cp.TraintupleKeys, 2)
 	cpID := cp.TraintupleKeys[0]
 

--- a/chaincode/compute_plan_test.go
+++ b/chaincode/compute_plan_test.go
@@ -168,16 +168,20 @@ func TestModelCompositionComputePlanWorkflow(t *testing.T) {
 	_, err = logStartCompositeTrain(db, assetToArgs(inputHash{out.CompositeTraintupleKeys[1]}))
 	assert.NoError(t, err)
 
+	db.tuplesEvent = &TuplesEvent{}
 	inpLogCompo := inputLogSuccessCompositeTrain{}
 	inpLogCompo.fillDefaults()
 	inpLogCompo.Key = out.CompositeTraintupleKeys[0]
 	_, err = logSuccessCompositeTrain(db, assetToArgs(inpLogCompo))
 	assert.NoError(t, err)
 
-	db.tuplesEvent = &TuplesEvent{}
 	inpLogCompo.Key = out.CompositeTraintupleKeys[1]
 	_, err = logSuccessCompositeTrain(db, assetToArgs(inpLogCompo))
 	assert.NoError(t, err)
+	assert.Len(t, db.tuplesEvent.Testtuples, 2)
+	for _, test := range db.tuplesEvent.Testtuples {
+		assert.Equalf(t, StatusTodo, test.Status, "blame it on %+v", test)
+	}
 	require.Len(t, db.tuplesEvent.Aggregatetuples, 1)
 	assert.Equal(t, StatusTodo, db.tuplesEvent.Aggregatetuples[0].Status)
 
@@ -190,6 +194,24 @@ func TestModelCompositionComputePlanWorkflow(t *testing.T) {
 	agg, err := logSuccessAggregateTrain(db, assetToArgs(inpLogAgg))
 	assert.NoError(t, err)
 	assert.Equal(t, StatusDone, agg.Status)
+
+	_, err = logStartCompositeTrain(db, assetToArgs(inputHash{out.CompositeTraintupleKeys[2]}))
+	assert.NoError(t, err)
+	_, err = logStartCompositeTrain(db, assetToArgs(inputHash{out.CompositeTraintupleKeys[3]}))
+	assert.NoError(t, err)
+
+	db.tuplesEvent = &TuplesEvent{}
+	inpLogCompo.Key = out.CompositeTraintupleKeys[2]
+	_, err = logSuccessCompositeTrain(db, assetToArgs(inpLogCompo))
+	assert.NoError(t, err)
+
+	inpLogCompo.Key = out.CompositeTraintupleKeys[3]
+	_, err = logSuccessCompositeTrain(db, assetToArgs(inpLogCompo))
+	assert.NoError(t, err)
+	assert.Len(t, db.tuplesEvent.Testtuples, 2)
+	for _, test := range db.tuplesEvent.Testtuples {
+		assert.Equalf(t, StatusTodo, test.Status, "blame it on %+v", test)
+	}
 }
 
 func TestCreateComputePlanCompositeAggregate(t *testing.T) {

--- a/chaincode/compute_plan_test.go
+++ b/chaincode/compute_plan_test.go
@@ -74,7 +74,7 @@ var (
 	}
 )
 
-func TestCreateComputePlanAggregate(t *testing.T) {
+func TestCreateComputePlanCompositeAggregate(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
 	registerItem(t, *mockStub, "aggregateAlgo")
@@ -114,48 +114,20 @@ func TestCreateComputePlanAggregate(t *testing.T) {
 	}
 	outCP, err := createComputePlanInternal(db, inCP)
 	assert.NoError(t, err)
-	// Check the composite traintuples
-	traintuples, err := queryAggregatetuples(db, []string{})
-	assert.NoError(t, err)
-	require.Len(t, traintuples, 2)
-	require.Contains(t, outCP.AggregatetupleKeys, traintuples[0].Key)
-	require.Contains(t, outCP.AggregatetupleKeys, traintuples[1].Key)
-}
-func TestCreateComputePlanComposite(t *testing.T) {
-	scc := new(SubstraChaincode)
-	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	registerItem(t, *mockStub, "compositeAlgo")
 
-	mockStub.MockTransactionStart("42")
-	db := NewLedgerDB(mockStub)
-
-	tag := []string{"compositeTraintuple1", "compositeTraintuple2"}
-	// Simply test method and return values
-	inCP := defaultComputePlan
-	inCP.CompositeTraintuples = []inputComputePlanCompositeTraintuple{
-		{
-			DataManagerKey: dataManagerOpenerHash,
-			DataSampleKeys: []string{trainDataSampleHash1},
-			AlgoKey:        compositeAlgoHash,
-			ID:             tag[0],
-		},
-		{
-			DataManagerKey: dataManagerOpenerHash,
-			DataSampleKeys: []string{trainDataSampleHash1},
-			AlgoKey:        compositeAlgoHash,
-			ID:             tag[1],
-			InTrunkModelID: tag[0],
-			InHeadModelID:  tag[0],
-		},
-	}
-	outCP, err := createComputePlanInternal(db, inCP)
-	assert.NoError(t, err)
 	// Check the composite traintuples
 	traintuples, err := queryCompositeTraintuples(db, []string{})
 	assert.NoError(t, err)
 	require.Len(t, traintuples, 2)
 	require.Contains(t, outCP.CompositeTraintupleKeys, traintuples[0].Key)
 	require.Contains(t, outCP.CompositeTraintupleKeys, traintuples[1].Key)
+
+	// Check the aggregate traintuples
+	aggtuples, err := queryAggregatetuples(db, []string{})
+	assert.NoError(t, err)
+	require.Len(t, aggtuples, 2)
+	require.Contains(t, outCP.AggregatetupleKeys, aggtuples[0].Key)
+	require.Contains(t, outCP.AggregatetupleKeys, aggtuples[1].Key)
 }
 
 func TestCreateComputePlan(t *testing.T) {

--- a/chaincode/compute_plan_test.go
+++ b/chaincode/compute_plan_test.go
@@ -21,6 +21,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+
+	// Default compute plan:
+	//
+	//     ø     ø             ø      ø
+	//     |     |             |      |
+	//     hd    tr            tr     hd
+	//   -----------         -----------
+	//  | Composite |       | Composite |
+	//   -----------         -----------
+	//     hd    tr            tr     hd
+	//     |      \            /      |
+	//     |       \          /       |
+	//     |        -----------       |
+	//     |       | Aggregate |      |
+	//     |        -----------       |
+	//     |            |             |
+	//     |     ,_____/ \_____       |
+	//     |     |             |      |
+	//     hd    tr            tr     hd
+	//   -----------         -----------
+	//  | Composite |       | Composite |
+	//   -----------         -----------
+	//     hd    tr            tr     hd
+	//
+	//
+	defaultComputePlan = inputComputePlan{
+		ObjectiveKey: objectiveDescriptionHash,
+		TrainingTasks: []inputComputePlanTrainingTask{
+			inputComputePlanTrainingTask{
+				DataManagerKey: dataManagerOpenerHash,
+				DataSampleKeys: []string{trainDataSampleHash1},
+				AlgoKey:        algoHash,
+				ID:             traintupleID1,
+			},
+			inputComputePlanTrainingTask{
+				DataManagerKey: dataManagerOpenerHash,
+				DataSampleKeys: []string{trainDataSampleHash2},
+				ID:             traintupleID2,
+				AlgoKey:        algoHash,
+				InModelsIDs:    []string{traintupleID1},
+			},
+		},
+		Testtuples: []inputComputePlanTesttuple{
+			inputComputePlanTesttuple{
+				DataManagerKey: dataManagerOpenerHash,
+				DataSampleKeys: []string{testDataSampleHash1, testDataSampleHash2},
+				TraintupleID:   traintupleID2,
+			},
+		},
+	}
+)
+
 func TestCreateComputePlan(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)

--- a/chaincode/compute_plan_test.go
+++ b/chaincode/compute_plan_test.go
@@ -128,6 +128,13 @@ func TestCreateComputePlanCompositeAggregate(t *testing.T) {
 	require.Len(t, aggtuples, 2)
 	require.Contains(t, outCP.AggregatetupleKeys, aggtuples[0].Key)
 	require.Contains(t, outCP.AggregatetupleKeys, aggtuples[1].Key)
+
+	// Query the compute plan
+	cp, err := queryComputePlan(db, assetToArgs(inputHash{Key: outCP.ComputePlanID}))
+	assert.NoError(t, err, "calling queryComputePlan should succeed")
+	assert.NotNil(t, cp)
+	assert.Equal(t, 2, len(cp.CompositeTraintupleKeys))
+	assert.Equal(t, 2, len(cp.AggregatetupleKeys))
 }
 
 func TestCreateComputePlan(t *testing.T) {

--- a/chaincode/compute_plan_test.go
+++ b/chaincode/compute_plan_test.go
@@ -83,35 +83,38 @@ func TestCreateComputePlanCompositeAggregate(t *testing.T) {
 	db := NewLedgerDB(mockStub)
 
 	tag := []string{"compositeTraintuple1", "compositeTraintuple2", "aggregatetuple1", "aggregatetuple2"}
-	// Simply test method and return values
-	inCP := defaultComputePlan
-	inCP.CompositeTraintuples = []inputComputePlanCompositeTraintuple{
-		{
-			DataManagerKey: dataManagerOpenerHash,
-			DataSampleKeys: []string{trainDataSampleHash1},
-			AlgoKey:        compositeAlgoHash,
-			ID:             tag[0],
+
+	inCP := inputComputePlan{
+		ObjectiveKey: objectiveDescriptionHash,
+		CompositeTraintuples: []inputComputePlanCompositeTraintuple{
+			{
+				DataManagerKey: dataManagerOpenerHash,
+				DataSampleKeys: []string{trainDataSampleHash1},
+				AlgoKey:        compositeAlgoHash,
+				ID:             tag[0],
+			},
+			{
+				DataManagerKey: dataManagerOpenerHash,
+				DataSampleKeys: []string{trainDataSampleHash1},
+				AlgoKey:        compositeAlgoHash,
+				ID:             tag[1],
+				InTrunkModelID: tag[0],
+				InHeadModelID:  tag[0],
+			},
 		},
-		{
-			DataManagerKey: dataManagerOpenerHash,
-			DataSampleKeys: []string{trainDataSampleHash1},
-			AlgoKey:        compositeAlgoHash,
-			ID:             tag[1],
-			InTrunkModelID: tag[0],
-			InHeadModelID:  tag[0],
+		Aggregatetuples: []inputComputePlanAggregatetuple{
+			{
+				AlgoKey: aggregateAlgoHash,
+				ID:      tag[2],
+			},
+			{
+				AlgoKey:     aggregateAlgoHash,
+				ID:          tag[3],
+				InModelsIDs: []string{tag[2]},
+			},
 		},
 	}
-	inCP.Aggregatetuples = []inputComputePlanAggregatetuple{
-		{
-			AlgoKey: aggregateAlgoHash,
-			ID:      tag[2],
-		},
-		{
-			AlgoKey:     aggregateAlgoHash,
-			ID:          tag[3],
-			InModelsIDs: []string{tag[2]},
-		},
-	}
+
 	outCP, err := createComputePlanInternal(db, inCP)
 	assert.NoError(t, err)
 
@@ -135,6 +138,13 @@ func TestCreateComputePlanCompositeAggregate(t *testing.T) {
 	assert.NotNil(t, cp)
 	assert.Equal(t, 2, len(cp.CompositeTraintupleKeys))
 	assert.Equal(t, 2, len(cp.AggregatetupleKeys))
+
+	// Query compute plans
+	cps, err := queryComputePlans(db, []string{})
+	assert.NoError(t, err, "calling queryComputePlans should succeed")
+	assert.Len(t, cps, 1, "queryComputePlans should return one compute plan")
+	assert.Equal(t, 2, len(cps[0].CompositeTraintupleKeys))
+	assert.Equal(t, 2, len(cps[0].AggregatetupleKeys))
 }
 
 func TestCreateComputePlan(t *testing.T) {

--- a/chaincode/compute_plan_test.go
+++ b/chaincode/compute_plan_test.go
@@ -159,6 +159,8 @@ func TestModelCompositionComputePlanWorkflow(t *testing.T) {
 
 	_, err := createComputePlanInternal(db, modelCompositionComputePlan)
 	assert.NoError(t, err)
+	assert.NotNil(t, db.tuplesEvent)
+	assert.Len(t, db.tuplesEvent.CompositeTraintuples, 2)
 }
 
 func TestCreateComputePlanCompositeAggregate(t *testing.T) {

--- a/chaincode/compute_plan_test.go
+++ b/chaincode/compute_plan_test.go
@@ -185,13 +185,13 @@ func TestModelCompositionComputePlanWorkflow(t *testing.T) {
 	require.Len(t, db.tuplesEvent.Aggregatetuples, 1)
 	assert.Equal(t, StatusTodo, db.tuplesEvent.Aggregatetuples[0].Status)
 
-	_, err = logStartAggregateTrain(db, assetToArgs(inputHash{out.AggregatetupleKeys[0]}))
+	_, err = logStartAggregate(db, assetToArgs(inputHash{out.AggregatetupleKeys[0]}))
 	assert.NoError(t, err)
 
 	inpLogAgg := inputLogSuccessTrain{}
 	inpLogAgg.fillDefaults()
 	inpLogAgg.Key = out.AggregatetupleKeys[0]
-	agg, err := logSuccessAggregateTrain(db, assetToArgs(inpLogAgg))
+	agg, err := logSuccessAggregate(db, assetToArgs(inpLogAgg))
 	assert.NoError(t, err)
 	assert.Equal(t, StatusDone, agg.Status)
 

--- a/chaincode/compute_plan_test.go
+++ b/chaincode/compute_plan_test.go
@@ -49,14 +49,14 @@ var (
 	//
 	defaultComputePlan = inputComputePlan{
 		ObjectiveKey: objectiveDescriptionHash,
-		TrainingTasks: []inputComputePlanTrainingTask{
-			inputComputePlanTrainingTask{
+		Traintuples: []inputComputePlanTraintuple{
+			inputComputePlanTraintuple{
 				DataManagerKey: dataManagerOpenerHash,
 				DataSampleKeys: []string{trainDataSampleHash1},
 				AlgoKey:        algoHash,
 				ID:             traintupleID1,
 			},
-			inputComputePlanTrainingTask{
+			inputComputePlanTraintuple{
 				DataManagerKey: dataManagerOpenerHash,
 				DataSampleKeys: []string{trainDataSampleHash2},
 				ID:             traintupleID2,
@@ -91,14 +91,14 @@ func TestCreateComputePlan(t *testing.T) {
 	traintuples, err := queryTraintuples(db, []string{})
 	assert.NoError(t, err)
 	assert.Len(t, traintuples, 2)
-	require.Contains(t, outCP.TrainingTaskKeys, traintuples[0].Key)
-	require.Contains(t, outCP.TrainingTaskKeys, traintuples[1].Key)
+	require.Contains(t, outCP.TraintupleKeys, traintuples[0].Key)
+	require.Contains(t, outCP.TraintupleKeys, traintuples[1].Key)
 	var first, second outputTraintuple
 	for _, el := range traintuples {
 		switch el.Key {
-		case outCP.TrainingTaskKeys[0]:
+		case outCP.TraintupleKeys[0]:
 			first = el
-		case outCP.TrainingTaskKeys[1]:
+		case outCP.TraintupleKeys[1]:
 			second = el
 		}
 	}
@@ -106,7 +106,7 @@ func TestCreateComputePlan(t *testing.T) {
 	// check first traintuple
 	assert.NotZero(t, first)
 	assert.EqualValues(t, first.Key, first.ComputePlanID)
-	assert.Equal(t, inCP.TrainingTasks[0].AlgoKey, first.Algo.Hash)
+	assert.Equal(t, inCP.Traintuples[0].AlgoKey, first.Algo.Hash)
 	assert.Equal(t, StatusTodo, first.Status)
 
 	// check second traintuple
@@ -114,7 +114,7 @@ func TestCreateComputePlan(t *testing.T) {
 	assert.EqualValues(t, first.Key, second.InModels[0].TraintupleKey)
 	assert.EqualValues(t, first.ComputePlanID, second.ComputePlanID)
 	assert.Len(t, second.InModels, 1)
-	assert.Equal(t, inCP.TrainingTasks[1].AlgoKey, second.Algo.Hash)
+	assert.Equal(t, inCP.Traintuples[1].AlgoKey, second.Algo.Hash)
 	assert.Equal(t, StatusWaiting, second.Status)
 
 	// Check the testtuples
@@ -140,7 +140,7 @@ func TestQueryComputePlan(t *testing.T) {
 	outCP, err := createComputePlanInternal(db, inCP)
 	assert.NoError(t, err)
 	assert.NotNil(t, outCP)
-	assert.Equal(t, outCP.ComputePlanID, outCP.TrainingTaskKeys[0])
+	assert.Equal(t, outCP.ComputePlanID, outCP.TraintupleKeys[0])
 
 	cp, err := queryComputePlan(db, assetToArgs(inputHash{Key: outCP.ComputePlanID}))
 	assert.NoError(t, err, "calling queryComputePlan should succeed")
@@ -161,7 +161,7 @@ func TestQueryComputePlans(t *testing.T) {
 	outCP, err := createComputePlanInternal(db, inCP)
 	assert.NoError(t, err)
 	assert.NotNil(t, outCP)
-	assert.Equal(t, outCP.ComputePlanID, outCP.TrainingTaskKeys[0])
+	assert.Equal(t, outCP.ComputePlanID, outCP.TraintupleKeys[0])
 
 	cps, err := queryComputePlans(db, []string{})
 	assert.NoError(t, err, "calling queryComputePlans should succeed")
@@ -179,14 +179,14 @@ func TestComputePlanEmptyTesttuples(t *testing.T) {
 
 	inCP := inputComputePlan{
 		ObjectiveKey: objectiveDescriptionHash,
-		TrainingTasks: []inputComputePlanTrainingTask{
-			inputComputePlanTrainingTask{
+		Traintuples: []inputComputePlanTraintuple{
+			inputComputePlanTraintuple{
 				DataManagerKey: dataManagerOpenerHash,
 				DataSampleKeys: []string{trainDataSampleHash1},
 				AlgoKey:        algoHash,
 				ID:             traintupleID1,
 			},
-			inputComputePlanTrainingTask{
+			inputComputePlanTraintuple{
 				DataManagerKey: dataManagerOpenerHash,
 				DataSampleKeys: []string{trainDataSampleHash2},
 				ID:             traintupleID2,
@@ -200,7 +200,7 @@ func TestComputePlanEmptyTesttuples(t *testing.T) {
 	outCP, err := createComputePlanInternal(db, inCP)
 	assert.NoError(t, err)
 	assert.NotNil(t, outCP)
-	assert.Equal(t, outCP.ComputePlanID, outCP.TrainingTaskKeys[0])
+	assert.Equal(t, outCP.ComputePlanID, outCP.TraintupleKeys[0])
 	assert.Equal(t, []string{}, outCP.TesttupleKeys)
 
 	cp, err := queryComputePlan(db, assetToArgs(inputHash{Key: outCP.ComputePlanID}))
@@ -228,16 +228,16 @@ func TestQueryComputePlanEmpty(t *testing.T) {
 }
 
 func validateComputePlan(t *testing.T, cp outputComputePlan, in inputComputePlan) {
-	assert.Len(t, cp.TrainingTaskKeys, 2)
-	cpID := cp.TrainingTaskKeys[0]
+	assert.Len(t, cp.TraintupleKeys, 2)
+	cpID := cp.TraintupleKeys[0]
 
 	assert.Equal(t, in.ObjectiveKey, cp.ObjectiveKey)
 
 	assert.Equal(t, cpID, cp.ComputePlanID)
 	assert.Equal(t, in.ObjectiveKey, cp.ObjectiveKey)
 
-	assert.NotEmpty(t, cp.TrainingTaskKeys[0])
-	assert.NotEmpty(t, cp.TrainingTaskKeys[1])
+	assert.NotEmpty(t, cp.TraintupleKeys[0])
+	assert.NotEmpty(t, cp.TraintupleKeys[1])
 
 	require.Len(t, cp.TesttupleKeys, 1)
 	assert.NotEmpty(t, cp.TesttupleKeys[0])

--- a/chaincode/compute_plan_test.go
+++ b/chaincode/compute_plan_test.go
@@ -74,6 +74,43 @@ var (
 	}
 )
 
+func TestCreateComputePlanComposite(t *testing.T) {
+	scc := new(SubstraChaincode)
+	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	registerItem(t, *mockStub, "compositeAlgo")
+
+	mockStub.MockTransactionStart("42")
+	db := NewLedgerDB(mockStub)
+
+	tag := []string{"compositeTraintuple1", "compositeTraintuple2"}
+	// Simply test method and return values
+	inCP := defaultComputePlan
+	inCP.CompositeTraintuples = []inputComputePlanCompositeTraintuple{
+		{
+			DataManagerKey: dataManagerOpenerHash,
+			DataSampleKeys: []string{trainDataSampleHash1},
+			AlgoKey:        compositeAlgoHash,
+			ID:             tag[0],
+		},
+		{
+			DataManagerKey: dataManagerOpenerHash,
+			DataSampleKeys: []string{trainDataSampleHash1},
+			AlgoKey:        compositeAlgoHash,
+			ID:             tag[1],
+			InTrunkModelID: tag[0],
+			InHeadModelID:  tag[0],
+		},
+	}
+	outCP, err := createComputePlanInternal(db, inCP)
+	assert.NoError(t, err)
+	// Check the composite traintuples
+	traintuples, err := queryCompositeTraintuples(db, []string{})
+	assert.NoError(t, err)
+	require.Len(t, traintuples, 2)
+	require.Contains(t, outCP.CompositeTraintupleKeys, traintuples[0].Key)
+	require.Contains(t, outCP.CompositeTraintupleKeys, traintuples[1].Key)
+}
+
 func TestCreateComputePlan(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
@@ -85,6 +122,7 @@ func TestCreateComputePlan(t *testing.T) {
 	// Simply test method and return values
 	inCP := defaultComputePlan
 	outCP, err := createComputePlanInternal(db, inCP)
+	assert.NoError(t, err)
 	validateComputePlan(t, outCP, defaultComputePlan)
 
 	// Check the traintuples

--- a/chaincode/dag.go
+++ b/chaincode/dag.go
@@ -1,0 +1,72 @@
+package main
+
+import "fmt"
+
+type TrainingTask struct {
+	ID          string
+	InModelsIDs []string
+	InputIndex  int
+	TaskType    AssetType
+}
+
+type ComputeDAG struct {
+	OrderTasks []TrainingTask
+}
+
+func createComputeDAG(cp inputComputePlan) (ComputeDAG, error) {
+	DAG := ComputeDAG{}
+	for i, traintuple := range cp.Traintuples {
+		task := TrainingTask{
+			ID:          traintuple.ID,
+			InModelsIDs: traintuple.InModelsIDs,
+			InputIndex:  i,
+			TaskType:    TraintupleType,
+		}
+		DAG.OrderTasks = append(DAG.OrderTasks, task)
+	}
+	err := DAG.sort()
+	if err != nil {
+		return DAG, err
+	}
+	return DAG, nil
+}
+
+// sort order the listed task of the dag or return an error if there is a cyclic
+// dependencies in the inModelIDs
+func (dag *ComputeDAG) sort() error {
+	current := dag.OrderTasks
+	var temp, final []TrainingTask
+	IDPresents := map[string]bool{}
+	for i := 0; len(current) != 0; {
+		ready := true
+		for _, ID := range current[i].InModelsIDs {
+			_, ok := IDPresents[ID]
+			ready = ready && ok
+		}
+		if ready {
+			final = append(final, current[i])
+			if _, ok := IDPresents[current[i].ID]; ok {
+				return fmt.Errorf("compute plan error, ID use twice: %s", current[i].ID)
+			}
+			IDPresents[current[i].ID] = true
+		} else {
+			temp = append(temp, current[i])
+		}
+		if i != len(current)-1 {
+			i++
+			continue
+		}
+		if len(temp) == len(current) {
+			var errorIDs []string
+			for _, c := range current {
+				errorIDs = append(errorIDs, c.ID)
+			}
+			return fmt.Errorf("compute plan error, either cyclic or missing dep among those IDs'inModels: %v", errorIDs)
+		}
+		i = 0
+		current = temp
+		temp = []TrainingTask{}
+	}
+	dag.OrderTasks = final
+	return nil
+}

--- a/chaincode/dag.go
+++ b/chaincode/dag.go
@@ -24,6 +24,15 @@ func createComputeDAG(cp inputComputePlan) (ComputeDAG, error) {
 		}
 		DAG.OrderTasks = append(DAG.OrderTasks, task)
 	}
+	for i, traintuple := range cp.CompositeTraintuples {
+		task := TrainingTask{
+			ID:          traintuple.ID,
+			InModelsIDs: []string{traintuple.InHeadModelID, traintuple.InTrunkModelID},
+			InputIndex:  i,
+			TaskType:    CompositeTraintupleType,
+		}
+		DAG.OrderTasks = append(DAG.OrderTasks, task)
+	}
 	err := DAG.sort()
 	if err != nil {
 		return DAG, err
@@ -40,6 +49,9 @@ func (dag *ComputeDAG) sort() error {
 	for i := 0; len(current) != 0; {
 		ready := true
 		for _, ID := range current[i].InModelsIDs {
+			if ID == "" {
+				continue
+			}
 			_, ok := IDPresents[ID]
 			ready = ready && ok
 		}

--- a/chaincode/dag.go
+++ b/chaincode/dag.go
@@ -33,6 +33,15 @@ func createComputeDAG(cp inputComputePlan) (ComputeDAG, error) {
 		}
 		DAG.OrderTasks = append(DAG.OrderTasks, task)
 	}
+	for i, traintuple := range cp.Aggregatetuples {
+		task := TrainingTask{
+			ID:          traintuple.ID,
+			InModelsIDs: traintuple.InModelsIDs,
+			InputIndex:  i,
+			TaskType:    AggregatetupleType,
+		}
+		DAG.OrderTasks = append(DAG.OrderTasks, task)
+	}
 	err := DAG.sort()
 	if err != nil {
 		return DAG, err

--- a/chaincode/dag_test.go
+++ b/chaincode/dag_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSort(t *testing.T) {
+	ts := []struct {
+		name        string
+		list        []TrainingTask
+		expectError bool
+		errorStr    string
+	}{
+		{name: "no inModels",
+			list: []TrainingTask{
+				{ID: "one"},
+				{ID: "two"},
+				{ID: "three"},
+				{ID: "four"},
+			},
+			expectError: false},
+		{name: "some inModels",
+			list: []TrainingTask{
+				{ID: "three", InModelsIDs: []string{"one"}},
+				{ID: "one"},
+				{ID: "four", InModelsIDs: []string{"two", "three"}},
+				{ID: "two"},
+			},
+			expectError: false},
+		{name: "all-inModels",
+			list: []TrainingTask{
+				{ID: "three", InModelsIDs: []string{"two"}},
+				{ID: "one"},
+				{ID: "four", InModelsIDs: []string{"three", "one"}},
+				{ID: "two", InModelsIDs: []string{"one"}},
+			},
+			expectError: false},
+		{name: "wrong ID inModels",
+			list: []TrainingTask{
+				{ID: "one"},
+				{ID: "two", InModelsIDs: []string{"one"}},
+				{ID: "three", InModelsIDs: []string{"two"}},
+				{ID: "four", InModelsIDs: []string{"five"}},
+			},
+			expectError: true,
+			errorStr:    "compute plan error, either cyclic or missing dep among those IDs'inModels: [four]"},
+		{name: "cyclic inModels",
+			list: []TrainingTask{
+				{ID: "one"},
+				{ID: "two", InModelsIDs: []string{"one", "five"}},
+				{ID: "three", InModelsIDs: []string{"two"}},
+				{ID: "four", InModelsIDs: []string{"three"}},
+				{ID: "five", InModelsIDs: []string{"four"}},
+			},
+			expectError: true,
+			errorStr:    "compute plan error, either cyclic or missing dep among those IDs'inModels: [two three four five]"},
+		{name: "Same ID twice",
+			list: []TrainingTask{
+				{ID: "one"},
+				{ID: "two", InModelsIDs: []string{"one"}},
+				{ID: "three", InModelsIDs: []string{"two"}},
+				{ID: "one", InModelsIDs: []string{"three"}},
+			},
+			expectError: true,
+			errorStr:    `compute plan error, ID use twice: one`},
+	}
+	for _, tc := range ts {
+		t.Run(tc.name, func(t *testing.T) {
+			dag := ComputeDAG{OrderTasks: tc.list}
+			err := dag.sort()
+			if err != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tc.errorStr, err.Error())
+				return
+			}
+			assert.NoError(t, err)
+			for i, ID := range []string{"one", "two", "three", "four"} {
+				assert.Equal(t, ID, dag.OrderTasks[i].ID)
+			}
+		})
+	}
+}

--- a/chaincode/data.go
+++ b/chaincode/data.go
@@ -23,7 +23,7 @@ import (
 
 // Set is a method of the receiver DataManager. It uses inputDataManager fields to set the DataManager
 // Returns the dataManagerKey and associated objectiveKeys
-func (dataManager *DataManager) Set(db LedgerDB, inp inputDataManager) (string, string, error) {
+func (dataManager *DataManager) Set(db *LedgerDB, inp inputDataManager) (string, string, error) {
 	dataManagerKey := inp.OpenerHash
 	dataManager.ObjectiveKey = inp.ObjectiveKey
 	dataManager.AssetType = DataManagerType
@@ -51,7 +51,7 @@ func (dataManager *DataManager) Set(db LedgerDB, inp inputDataManager) (string, 
 
 // setDataSample is a method checking the validity of inputDataSample to be registered in the ledger
 // and returning corresponding dataSample hashes, associated dataManagers, testOnly and errors
-func setDataSample(db LedgerDB, inp inputDataSample) (dataSampleHashes []string, dataSample DataSample, err error) {
+func setDataSample(db *LedgerDB, inp inputDataSample) (dataSampleHashes []string, dataSample DataSample, err error) {
 	dataSampleHashes = inp.Hashes
 	if err = checkHashes(dataSampleHashes); err != nil {
 		err = errors.BadRequest(err)
@@ -90,7 +90,7 @@ func setDataSample(db LedgerDB, inp inputDataSample) (dataSampleHashes []string,
 
 // validateUpdateDataSample is a method checking the validity of elements sent to update
 // one or more dataSamplef
-func validateUpdateDataSample(db LedgerDB, inp inputUpdateDataSample) (dataSampleHashes []string, dataManagerKeys []string, err error) {
+func validateUpdateDataSample(db *LedgerDB, inp inputUpdateDataSample) (dataSampleHashes []string, dataManagerKeys []string, err error) {
 	// TODO return full dataSample
 	// check validity of dataSampleHashes
 	if err = checkHashes(inp.Hashes); err != nil {
@@ -109,7 +109,7 @@ func validateUpdateDataSample(db LedgerDB, inp inputUpdateDataSample) (dataSampl
 // -----------------------------------------------------------------
 
 // registerDataManager stores a new dataManager in the ledger.
-func registerDataManager(db LedgerDB, args []string) (resp map[string]string, err error) {
+func registerDataManager(db *LedgerDB, args []string) (resp map[string]string, err error) {
 	inp := inputDataManager{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -147,7 +147,7 @@ func registerDataManager(db LedgerDB, args []string) (resp map[string]string, er
 }
 
 // registerDataSample stores new dataSample in the ledger (one or more).
-func registerDataSample(db LedgerDB, args []string) (dataSampleKeys map[string][]string, err error) {
+func registerDataSample(db *LedgerDB, args []string) (dataSampleKeys map[string][]string, err error) {
 	// convert input strings args to input struct inputDataSample
 	inp := inputDataSample{}
 	err = AssetFromJSON(args, &inp)
@@ -182,7 +182,7 @@ func registerDataSample(db LedgerDB, args []string) (dataSampleKeys map[string][
 }
 
 // updateDataSample associates one or more dataManagerKeys to one or more dataSample
-func updateDataSample(db LedgerDB, args []string) (resp map[string]string, err error) {
+func updateDataSample(db *LedgerDB, args []string) (resp map[string]string, err error) {
 	inp := inputUpdateDataSample{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -232,7 +232,7 @@ func updateDataSample(db LedgerDB, args []string) (resp map[string]string, err e
 }
 
 // updateDataManager associates a objectiveKey to an existing dataManager
-func updateDataManager(db LedgerDB, args []string) (resp map[string]string, err error) {
+func updateDataManager(db *LedgerDB, args []string) (resp map[string]string, err error) {
 	inp := inputUpdateDataManager{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -247,7 +247,7 @@ func updateDataManager(db LedgerDB, args []string) (resp map[string]string, err 
 }
 
 // queryDataManager returns dataManager and its key
-func queryDataManager(db LedgerDB, args []string) (out outputDataManager, err error) {
+func queryDataManager(db *LedgerDB, args []string) (out outputDataManager, err error) {
 	inp := inputHash{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -266,7 +266,7 @@ func queryDataManager(db LedgerDB, args []string) (out outputDataManager, err er
 }
 
 // queryDataManagers returns all DataManagers of the ledger
-func queryDataManagers(db LedgerDB, args []string) ([]outputDataManager, error) {
+func queryDataManagers(db *LedgerDB, args []string) ([]outputDataManager, error) {
 	var err error
 	outDataManagers := []outputDataManager{}
 	if len(args) != 0 {
@@ -291,7 +291,7 @@ func queryDataManagers(db LedgerDB, args []string) ([]outputDataManager, error) 
 }
 
 // queryDataset returns info about a dataManager and all related dataSample
-func queryDataset(db LedgerDB, args []string) (outputDataset, error) {
+func queryDataset(db *LedgerDB, args []string) (outputDataset, error) {
 	inp := inputHash{}
 	out := outputDataset{}
 	err := AssetFromJSON(args, &inp)
@@ -320,7 +320,7 @@ func queryDataset(db LedgerDB, args []string) (outputDataset, error) {
 	return out, nil
 }
 
-func queryDataSamples(db LedgerDB, args []string) ([]outputDataSample, error) {
+func queryDataSamples(db *LedgerDB, args []string) ([]outputDataSample, error) {
 	outDataSamples := []outputDataSample{}
 	if len(args) != 0 {
 		err := fmt.Errorf("incorrect number of arguments, expecting nothing")
@@ -351,7 +351,7 @@ func queryDataSamples(db LedgerDB, args []string) ([]outputDataSample, error) {
 
 // checkDataManagerOwner checks if the transaction requester is the owner of dataManager
 // specified by their keys in a slice
-func checkDataManagerOwner(db LedgerDB, dataManagerKeys []string) error {
+func checkDataManagerOwner(db *LedgerDB, dataManagerKeys []string) error {
 	// get transaction requester
 	txCreator, err := GetTxCreator(db.cc)
 	if err != nil {
@@ -371,7 +371,7 @@ func checkDataManagerOwner(db LedgerDB, dataManagerKeys []string) error {
 }
 
 //  checkDataSampleOwner checks if the transaction requester is the owner of the dataSample
-func checkDataSampleOwner(db LedgerDB, dataSample DataSample) error {
+func checkDataSampleOwner(db *LedgerDB, dataSample DataSample) error {
 	txRequester, err := GetTxCreator(db.cc)
 	if err != nil {
 		return err
@@ -384,7 +384,7 @@ func checkDataSampleOwner(db LedgerDB, dataSample DataSample) error {
 
 // checkSameDataManager checks if dataSample in a slice exist and are from the same dataManager.
 // If yes, returns two boolean indicating if dataSample are testOnly and trainOnly
-func checkSameDataManager(db LedgerDB, dataManagerKey string, dataSampleKeys []string) (bool, bool, error) {
+func checkSameDataManager(db *LedgerDB, dataManagerKey string, dataSampleKeys []string) (bool, bool, error) {
 	testOnly := true
 	trainOnly := true
 	for _, dataSampleKey := range dataSampleKeys {
@@ -403,7 +403,7 @@ func checkSameDataManager(db LedgerDB, dataManagerKey string, dataSampleKeys []s
 }
 
 // getDataset returns all dataSample keys associated to a dataManager
-func getDataset(db LedgerDB, dataManagerKey string, testOnly bool) ([]string, error) {
+func getDataset(db *LedgerDB, dataManagerKey string, testOnly bool) ([]string, error) {
 	indexName := "dataSample~dataManager~testOnly~key"
 	attributes := []string{"dataSample", dataManagerKey, strconv.FormatBool(testOnly)}
 	dataSampleKeys, err := db.GetIndexKeys(indexName, attributes)
@@ -414,7 +414,7 @@ func getDataset(db LedgerDB, dataManagerKey string, testOnly bool) ([]string, er
 }
 
 // getDataManagerOwner returns the owner of a dataManager given its key
-func getDataManagerOwner(db LedgerDB, dataManagerKey string) (string, error) {
+func getDataManagerOwner(db *LedgerDB, dataManagerKey string) (string, error) {
 	dataManager, err := db.GetDataManager(dataManagerKey)
 	if err != nil {
 		return "", errors.BadRequest(err, "dataManager %s not found", dataManagerKey)
@@ -424,7 +424,7 @@ func getDataManagerOwner(db LedgerDB, dataManagerKey string) (string, error) {
 
 // checkDataSamplesExist checks if keys in a slice correspond to existing elements in the ledger
 // returns the slice of already existing elements
-func checkDataSamplesExist(db LedgerDB, keys []string) (existingKeys []string) {
+func checkDataSamplesExist(db *LedgerDB, keys []string) (existingKeys []string) {
 	for _, key := range keys {
 		if _, err := db.GetDataSample(key); err == nil {
 			existingKeys = append(existingKeys, key)

--- a/chaincode/input.go
+++ b/chaincode/input.go
@@ -169,6 +169,7 @@ type inputComputePlanAggregatetuple struct {
 	ID          string   `validate:"required,lte=64" json:"id"`
 	InModelsIDs []string `validate:"omitempty,dive,lte=64" json:"inModelsIDs"`
 	Tag         string   `validate:"omitempty,lte=64" json:"tag"`
+	Worker      string   `validate:"required" json:"worker"`
 }
 
 type inputComputePlanCompositeTraintuple struct {

--- a/chaincode/input.go
+++ b/chaincode/input.go
@@ -150,6 +150,7 @@ type inputQueryFilter struct {
 type inputComputePlan struct {
 	ObjectiveKey         string                                `validate:"required,len=64,hexadecimal" json:"objectiveKey"`
 	Traintuples          []inputComputePlanTraintuple          `validate:"omitempty" json:"traintuples"`
+	Aggregatetuples      []inputComputePlanAggregatetuple      `validate:"omitempty" json:"aggregatetuples"`
 	CompositeTraintuples []inputComputePlanCompositeTraintuple `validate:"omitempty" json:"compositeTraintuples"`
 	Testtuples           []inputComputePlanTesttuple           `validate:"omitempty" json:"testtuples"`
 }
@@ -161,6 +162,13 @@ type inputComputePlanTraintuple struct {
 	ID             string   `validate:"required,lte=64" json:"id"`
 	InModelsIDs    []string `validate:"omitempty,dive,lte=64" json:"inModelsIDs"`
 	Tag            string   `validate:"omitempty,lte=64" json:"tag"`
+}
+
+type inputComputePlanAggregatetuple struct {
+	AlgoKey     string   `validate:"required,len=64,hexadecimal" json:"algoKey"`
+	ID          string   `validate:"required,lte=64" json:"id"`
+	InModelsIDs []string `validate:"omitempty,dive,lte=64" json:"inModelsIDs"`
+	Tag         string   `validate:"omitempty,lte=64" json:"tag"`
 }
 
 type inputComputePlanCompositeTraintuple struct {

--- a/chaincode/input.go
+++ b/chaincode/input.go
@@ -144,20 +144,20 @@ type inputQueryFilter struct {
 }
 
 // inputConputePlan represent a coherent set of tuples uploaded together.
-// They share the same Algo and Objective represented by their respective keys.
-// Traintuples is the list of all the traintuples planed by the compute plan
+// They share the same Objective represented by its key.
+// TrainingTasks is the list of all the training tasks planed by the compute plan.
 // Beware, it's order sensitive since the `InModelsIDs` can only be interpreted
-// if the traintuples matching those IDs have already been created.
+// if the training tasks matching those IDs have already been created.
 type inputComputePlan struct {
-	AlgoKey      string                       `validate:"required,len=64,hexadecimal" json:"algoKey"`
-	ObjectiveKey string                       `validate:"required,len=64,hexadecimal" json:"objectiveKey"`
-	Traintuples  []inputComputePlanTraintuple `validate:"required,gt=0" json:"traintuples"`
-	Testtuples   []inputComputePlanTesttuple  `validate:"omitempty" json:"testtuples"`
+	ObjectiveKey  string                         `validate:"required,len=64,hexadecimal" json:"objectiveKey"`
+	TrainingTasks []inputComputePlanTrainingTask `validate:"required,gt=0" json:"trainingTasks"`
+	Testtuples    []inputComputePlanTesttuple    `validate:"omitempty" json:"testtuples"`
 }
 
-type inputComputePlanTraintuple struct {
+type inputComputePlanTrainingTask struct {
 	DataManagerKey string   `validate:"required,len=64,hexadecimal" json:"dataManagerKey"`
 	DataSampleKeys []string `validate:"required,dive,len=64,hexadecimal" json:"dataSampleKeys"`
+	AlgoKey        string   `validate:"required,len=64,hexadecimal" json:"algoKey"`
 	ID             string   `validate:"required,lte=64" json:"id"`
 	InModelsIDs    []string `validate:"omitempty,dive,lte=64" json:"inModelsIDs"`
 	Tag            string   `validate:"omitempty,lte=64" json:"tag"`

--- a/chaincode/input.go
+++ b/chaincode/input.go
@@ -148,9 +148,10 @@ type inputQueryFilter struct {
 // Beware, it's order sensitive since the `InModelsIDs` can only be interpreted
 // if the training tasks matching those IDs have already been created.
 type inputComputePlan struct {
-	ObjectiveKey string                       `validate:"required,len=64,hexadecimal" json:"objectiveKey"`
-	Traintuples  []inputComputePlanTraintuple `validate:"required,gt=0" json:"traintuples"`
-	Testtuples   []inputComputePlanTesttuple  `validate:"omitempty" json:"testtuples"`
+	ObjectiveKey         string                                `validate:"required,len=64,hexadecimal" json:"objectiveKey"`
+	Traintuples          []inputComputePlanTraintuple          `validate:"omitempty" json:"traintuples"`
+	CompositeTraintuples []inputComputePlanCompositeTraintuple `validate:"omitempty" json:"compositeTraintuples"`
+	Testtuples           []inputComputePlanTesttuple           `validate:"omitempty" json:"testtuples"`
 }
 
 type inputComputePlanTraintuple struct {
@@ -160,6 +161,17 @@ type inputComputePlanTraintuple struct {
 	ID             string   `validate:"required,lte=64" json:"id"`
 	InModelsIDs    []string `validate:"omitempty,dive,lte=64" json:"inModelsIDs"`
 	Tag            string   `validate:"omitempty,lte=64" json:"tag"`
+}
+
+type inputComputePlanCompositeTraintuple struct {
+	DataManagerKey           string           `validate:"required,len=64,hexadecimal" json:"dataManagerKey"`
+	DataSampleKeys           []string         `validate:"required,dive,len=64,hexadecimal" json:"dataSampleKeys"`
+	AlgoKey                  string           `validate:"required,len=64,hexadecimal" json:"algoKey"`
+	ID                       string           `validate:"required,lte=64" json:"id"`
+	InHeadModelID            string           `validate:"required_with=InTrunkModelID,omitempty,len=64,hexadecimal" json:"inHeadModelID"`
+	InTrunkModelID           string           `validate:"required_with=InHeadModelID,omitempty,len=64,hexadecimal" json:"inTrunkModelID"`
+	OutTrunkModelPermissions inputPermissions `validate:"required" json:"OutTrunkModelPermissions"`
+	Tag                      string           `validate:"omitempty,lte=64" json:"tag"`
 }
 
 type inputComputePlanTesttuple struct {

--- a/chaincode/input.go
+++ b/chaincode/input.go
@@ -145,16 +145,15 @@ type inputQueryFilter struct {
 
 // inputConputePlan represent a coherent set of tuples uploaded together.
 // They share the same Objective represented by its key.
-// TrainingTasks is the list of all the training tasks planed by the compute plan.
 // Beware, it's order sensitive since the `InModelsIDs` can only be interpreted
 // if the training tasks matching those IDs have already been created.
 type inputComputePlan struct {
-	ObjectiveKey  string                         `validate:"required,len=64,hexadecimal" json:"objectiveKey"`
-	TrainingTasks []inputComputePlanTrainingTask `validate:"required,gt=0" json:"trainingTasks"`
-	Testtuples    []inputComputePlanTesttuple    `validate:"omitempty" json:"testtuples"`
+	ObjectiveKey string                       `validate:"required,len=64,hexadecimal" json:"objectiveKey"`
+	Traintuples  []inputComputePlanTraintuple `validate:"required,gt=0" json:"traintuples"`
+	Testtuples   []inputComputePlanTesttuple  `validate:"omitempty" json:"testtuples"`
 }
 
-type inputComputePlanTrainingTask struct {
+type inputComputePlanTraintuple struct {
 	DataManagerKey string   `validate:"required,len=64,hexadecimal" json:"dataManagerKey"`
 	DataSampleKeys []string `validate:"required,dive,len=64,hexadecimal" json:"dataSampleKeys"`
 	AlgoKey        string   `validate:"required,len=64,hexadecimal" json:"algoKey"`

--- a/chaincode/input_test.go
+++ b/chaincode/input_test.go
@@ -15,34 +15,9 @@
 package main
 
 var (
-	traintupleID1      = "firstTraintupleID"
-	traintupleID2      = "secondTraintupleID"
-	testtupleID        = "testtupleID"
-	defaultComputePlan = inputComputePlan{
-		ObjectiveKey: objectiveDescriptionHash,
-		TrainingTasks: []inputComputePlanTrainingTask{
-			inputComputePlanTrainingTask{
-				DataManagerKey: dataManagerOpenerHash,
-				DataSampleKeys: []string{trainDataSampleHash1},
-				AlgoKey:        algoHash,
-				ID:             traintupleID1,
-			},
-			inputComputePlanTrainingTask{
-				DataManagerKey: dataManagerOpenerHash,
-				DataSampleKeys: []string{trainDataSampleHash2},
-				ID:             traintupleID2,
-				AlgoKey:        algoHash,
-				InModelsIDs:    []string{traintupleID1},
-			},
-		},
-		Testtuples: []inputComputePlanTesttuple{
-			inputComputePlanTesttuple{
-				DataManagerKey: dataManagerOpenerHash,
-				DataSampleKeys: []string{testDataSampleHash1, testDataSampleHash2},
-				TraintupleID:   traintupleID2,
-			},
-		},
-	}
+	traintupleID1 = "firstTraintupleID"
+	traintupleID2 = "secondTraintupleID"
+	testtupleID   = "testtupleID"
 )
 
 func (dataManager *inputDataManager) createDefault() [][]byte {

--- a/chaincode/input_test.go
+++ b/chaincode/input_test.go
@@ -19,18 +19,19 @@ var (
 	traintupleID2      = "secondTraintupleID"
 	testtupleID        = "testtupleID"
 	defaultComputePlan = inputComputePlan{
-		AlgoKey:      algoHash,
 		ObjectiveKey: objectiveDescriptionHash,
-		Traintuples: []inputComputePlanTraintuple{
-			inputComputePlanTraintuple{
+		TrainingTasks: []inputComputePlanTrainingTask{
+			inputComputePlanTrainingTask{
 				DataManagerKey: dataManagerOpenerHash,
 				DataSampleKeys: []string{trainDataSampleHash1},
+				AlgoKey:        algoHash,
 				ID:             traintupleID1,
 			},
-			inputComputePlanTraintuple{
+			inputComputePlanTrainingTask{
 				DataManagerKey: dataManagerOpenerHash,
 				DataSampleKeys: []string{trainDataSampleHash2},
 				ID:             traintupleID2,
+				AlgoKey:        algoHash,
 				InModelsIDs:    []string{traintupleID1},
 			},
 		},

--- a/chaincode/ledger.go
+++ b/chaincode/ledger.go
@@ -88,57 +88,72 @@ type AggregateAlgo struct {
 	Algo
 }
 
+// GenericTuple is a structure that contains the fields
+// that are common to Traintuple, CompositeTraintuple and
+// AggregateTuple
+type GenericTuple struct {
+	AssetType     AssetType `json:"assetType"`
+	ObjectiveKey  string    `json:"objectiveKey"`
+	AlgoKey       string    `json:"algoKey"`
+	ComputePlanID string    `json:"computePlanID"`
+	Creator       string    `json:"creator"`
+	Log           string    `json:"log"`
+	Rank          int       `json:"rank"`
+	Status        string    `json:"status"`
+	Tag           string    `json:"tag"`
+}
+
 // Traintuple is the representation of one the element type stored in the ledger. It describes a training task occuring on the platform
 type Traintuple struct {
 	AssetType     AssetType   `json:"assetType"`
-	AlgoKey       string      `json:"algoKey"`
-	Creator       string      `json:"creator"`
-	Dataset       *Dataset    `json:"dataset"`
-	ComputePlanID string      `json:"computePlanID"`
-	InModelKeys   []string    `json:"inModels"`
-	Log           string      `json:"log"`
 	ObjectiveKey  string      `json:"objectiveKey"`
-	OutModel      *HashDress  `json:"outModel"`
-	Perf          float32     `json:"perf"`
-	Permissions   Permissions `json:"permissions"`
+	AlgoKey       string      `json:"algoKey"`
+	ComputePlanID string      `json:"computePlanID"`
+	Creator       string      `json:"creator"`
+	Log           string      `json:"log"`
 	Rank          int         `json:"rank"`
 	Status        string      `json:"status"`
 	Tag           string      `json:"tag"`
+	Dataset       *Dataset    `json:"dataset"`
+	InModelKeys   []string    `json:"inModels"`
+	OutModel      *HashDress  `json:"outModel"`
+	Perf          float32     `json:"perf"`
+	Permissions   Permissions `json:"permissions"`
 }
 
 // CompositeTraintuple is like a traintuple, but for composite model composition
 type CompositeTraintuple struct {
-	AlgoKey       string                      `json:"algoKey"`
 	AssetType     AssetType                   `json:"assetType"`
+	ObjectiveKey  string                      `json:"objectiveKey"`
+	AlgoKey       string                      `json:"algoKey"`
 	ComputePlanID string                      `json:"computePlanID"`
 	Creator       string                      `json:"creator"`
-	Dataset       *Dataset                    `json:"dataset"`
-	InHeadModel   string                      `json:"inHeadModel"`
-	InTrunkModel  string                      `json:"inTrunkModel"`
 	Log           string                      `json:"log"`
-	ObjectiveKey  string                      `json:"objectiveKey"`
-	OutHeadModel  CompositeTraintupleOutModel `json:"outHeadModel"`
-	OutTrunkModel CompositeTraintupleOutModel `json:"outTrunkModel"`
-	Perf          float32                     `json:"perf"`
 	Rank          int                         `json:"rank"`
 	Status        string                      `json:"status"`
 	Tag           string                      `json:"tag"`
+	Dataset       *Dataset                    `json:"dataset"`
+	InHeadModel   string                      `json:"inHeadModel"`
+	InTrunkModel  string                      `json:"inTrunkModel"`
+	OutHeadModel  CompositeTraintupleOutModel `json:"outHeadModel"`
+	OutTrunkModel CompositeTraintupleOutModel `json:"outTrunkModel"`
+	Perf          float32                     `json:"perf"`
 }
 
 // Aggregatetuple is like a traintuple, but for aggregate model composition
 type Aggregatetuple struct {
-	AlgoKey       string      `json:"algoKey"`
 	AssetType     AssetType   `json:"assetType"`
+	ObjectiveKey  string      `json:"objectiveKey"`
+	AlgoKey       string      `json:"algoKey"`
 	ComputePlanID string      `json:"computePlanID"`
 	Creator       string      `json:"creator"`
-	InModelKeys   []string    `json:"inModels"`
 	Log           string      `json:"log"`
-	ObjectiveKey  string      `json:"objectiveKey"`
-	OutModel      *HashDress  `json:"outModel"`
-	Permissions   Permissions `json:"permissions"` // TODO (aggregate): what do permissions mean here?
 	Rank          int         `json:"rank"`
 	Status        string      `json:"status"`
 	Tag           string      `json:"tag"`
+	InModelKeys   []string    `json:"inModels"`
+	OutModel      *HashDress  `json:"outModel"`
+	Permissions   Permissions `json:"permissions"` // TODO (aggregate): what do permissions mean here?
 	Worker        string      `json:"worker"`
 }
 

--- a/chaincode/ledger_db.go
+++ b/chaincode/ledger_db.go
@@ -37,8 +37,8 @@ type LedgerDB struct {
 }
 
 // NewLedgerDB create a new db to access the chaincode during a SmartContract
-func NewLedgerDB(stub shim.ChaincodeStubInterface) LedgerDB {
-	return LedgerDB{
+func NewLedgerDB(stub shim.ChaincodeStubInterface) *LedgerDB {
+	return &LedgerDB{
 		cc: stub,
 		transactionState: State{
 			items: make(map[string]([]byte)),
@@ -425,7 +425,7 @@ func (db *LedgerDB) AddTupleEvent(tupleKey string) error {
 			return err
 		}
 		out := outputTraintuple{}
-		out.Fill(*db, tuple, tupleKey)
+		out.Fill(db, tuple, tupleKey)
 		db.tuplesEvent.Traintuples = append(db.tuplesEvent.Traintuples, out)
 	case CompositeTraintupleType:
 		tuple, err := db.GetCompositeTraintuple(tupleKey)
@@ -433,7 +433,7 @@ func (db *LedgerDB) AddTupleEvent(tupleKey string) error {
 			return err
 		}
 		out := outputCompositeTraintuple{}
-		out.Fill(*db, tuple, tupleKey)
+		out.Fill(db, tuple, tupleKey)
 		db.tuplesEvent.CompositeTraintuples = append(db.tuplesEvent.CompositeTraintuples, out)
 	case AggregatetupleType:
 		tuple, err := db.GetAggregatetuple(tupleKey)
@@ -441,7 +441,7 @@ func (db *LedgerDB) AddTupleEvent(tupleKey string) error {
 			return err
 		}
 		out := outputAggregatetuple{}
-		out.Fill(*db, tuple, tupleKey)
+		out.Fill(db, tuple, tupleKey)
 		db.tuplesEvent.Aggregatetuples = append(db.tuplesEvent.Aggregatetuples, out)
 	case TesttupleType:
 		tuple, err := db.GetTesttuple(tupleKey)
@@ -449,7 +449,7 @@ func (db *LedgerDB) AddTupleEvent(tupleKey string) error {
 			return err
 		}
 		out := outputTesttuple{}
-		out.Fill(*db, tupleKey, tuple)
+		out.Fill(db, tupleKey, tuple)
 		db.tuplesEvent.Testtuples = append(db.tuplesEvent.Testtuples, out)
 	}
 	return nil

--- a/chaincode/ledger_db.go
+++ b/chaincode/ledger_db.go
@@ -192,17 +192,14 @@ func (db *LedgerDB) GetAssetType(key string) (AssetType, error) {
 	return asset.AssetType, nil
 }
 
-// GetGenericTraintuple fetches a regular/composite/aggregate tuple in the chaincode db and returns
-// its common properties.
-func (db *LedgerDB) GetGenericTraintuple(key string) (assetType AssetType, status string, err error) {
-	asset := struct {
-		Status    string    `json:"status"`
-		AssetType AssetType `json:"assetType"`
-	}{}
+// GetGenericTuple fetches a GenericTuple (Traintuple, CompositeTraintuple or AggregateTuple)
+// from the chaincode db
+func (db *LedgerDB) GetGenericTuple(key string) (GenericTuple, error) {
+	asset := GenericTuple{}
 	if err := db.Get(key, &asset); err != nil {
-		return asset.AssetType, asset.Status, err
+		return asset, err
 	}
-	return asset.AssetType, asset.Status, nil
+	return asset, nil
 }
 
 // GetAlgo fetches an Algo from the ledger using its unique key

--- a/chaincode/ledger_db.go
+++ b/chaincode/ledger_db.go
@@ -296,7 +296,7 @@ func (db *LedgerDB) GetCompositeTraintuple(key string) (CompositeTraintuple, err
 		return traintuple, err
 	}
 	if traintuple.AssetType != CompositeTraintupleType {
-		return traintuple, errors.NotFound("traintuple %s not found", key)
+		return traintuple, errors.NotFound("composite traintuple %s not found", key)
 	}
 	return traintuple, nil
 }

--- a/chaincode/ledger_db.go
+++ b/chaincode/ledger_db.go
@@ -408,6 +408,9 @@ func (db *LedgerDB) SendTuplesEvent() error {
 
 // AddTupleEvent add the output tuple matching the tupleKey to the event struct
 func (db *LedgerDB) AddTupleEvent(tupleKey string) error {
+	// We take advantage of the fact that Testtuples have the fields "AssetType"
+	// and "Status": we use db.GetGenericTuple to get the value for these fields
+	// even though Testtuples aren't technically GenericTuples.
 	genericTuple, err := db.GetGenericTuple(tupleKey)
 	if err != nil {
 		return err

--- a/chaincode/ledger_db.go
+++ b/chaincode/ledger_db.go
@@ -426,7 +426,7 @@ func (db *LedgerDB) AddTupleEvent(tupleKey string) error {
 		}
 		out := outputTraintuple{}
 		out.Fill(*db, tuple, tupleKey)
-		db.tuplesEvent.AddTraintuple(out)
+		db.tuplesEvent.Traintuples = append(db.tuplesEvent.Traintuples, out)
 	case CompositeTraintupleType:
 		tuple, err := db.GetCompositeTraintuple(tupleKey)
 		if err != nil {
@@ -434,7 +434,7 @@ func (db *LedgerDB) AddTupleEvent(tupleKey string) error {
 		}
 		out := outputCompositeTraintuple{}
 		out.Fill(*db, tuple, tupleKey)
-		db.tuplesEvent.AddCompositeTraintuple(out)
+		db.tuplesEvent.CompositeTraintuples = append(db.tuplesEvent.CompositeTraintuples, out)
 	case AggregatetupleType:
 		tuple, err := db.GetAggregatetuple(tupleKey)
 		if err != nil {
@@ -442,7 +442,7 @@ func (db *LedgerDB) AddTupleEvent(tupleKey string) error {
 		}
 		out := outputAggregatetuple{}
 		out.Fill(*db, tuple, tupleKey)
-		db.tuplesEvent.AddAggregatetuple(out)
+		db.tuplesEvent.Aggregatetuples = append(db.tuplesEvent.Aggregatetuples, out)
 	case TesttupleType:
 		tuple, err := db.GetTesttuple(tupleKey)
 		if err != nil {
@@ -450,7 +450,7 @@ func (db *LedgerDB) AddTupleEvent(tupleKey string) error {
 		}
 		out := outputTesttuple{}
 		out.Fill(*db, tupleKey, tuple)
-		db.tuplesEvent.AddTesttuple(out)
+		db.tuplesEvent.Testtuples = append(db.tuplesEvent.Testtuples, out)
 	}
 	return nil
 }

--- a/chaincode/main.go
+++ b/chaincode/main.go
@@ -170,6 +170,12 @@ func (t *SubstraChaincode) Invoke(stub shim.ChaincodeStubInterface) peer.Respons
 	if err != nil {
 		return formatErrorResponse(err)
 	}
+	// Send event if there is any. It's done in one batch since we can only send
+	// one event per call
+	err = db.SendTuplesEvent()
+	if err != nil {
+		return formatErrorResponse(fmt.Errorf("could not send event for unknown reason"))
+	}
 	// Marshal to json the smartcontract result
 	resp, err := json.Marshal(result)
 	if err != nil {

--- a/chaincode/main.go
+++ b/chaincode/main.go
@@ -73,7 +73,7 @@ func (t *SubstraChaincode) Invoke(stub shim.ChaincodeStubInterface) peer.Respons
 	case "logFailCompositeTrain":
 		result, err = logFailCompositeTrain(db, args)
 	case "logFailAggregate":
-		result, err = logFailAggregateTrain(db, args)
+		result, err = logFailAggregate(db, args)
 	case "logStartTest":
 		result, err = logStartTest(db, args)
 	case "logStartTrain":
@@ -81,7 +81,7 @@ func (t *SubstraChaincode) Invoke(stub shim.ChaincodeStubInterface) peer.Respons
 	case "logStartCompositeTrain":
 		result, err = logStartCompositeTrain(db, args)
 	case "logStartAggregate":
-		result, err = logStartAggregateTrain(db, args)
+		result, err = logStartAggregate(db, args)
 	case "logSuccessTest":
 		result, err = logSuccessTest(db, args)
 	case "logSuccessTrain":
@@ -89,7 +89,7 @@ func (t *SubstraChaincode) Invoke(stub shim.ChaincodeStubInterface) peer.Respons
 	case "logSuccessCompositeTrain":
 		result, err = logSuccessCompositeTrain(db, args)
 	case "logSuccessAggregate":
-		result, err = logSuccessAggregateTrain(db, args)
+		result, err = logSuccessAggregate(db, args)
 	case "queryAlgo":
 		result, err = queryAlgo(db, args)
 	case "queryAlgos":

--- a/chaincode/main.go
+++ b/chaincode/main.go
@@ -174,12 +174,12 @@ func (t *SubstraChaincode) Invoke(stub shim.ChaincodeStubInterface) peer.Respons
 	// one event per call
 	err = db.SendTuplesEvent()
 	if err != nil {
-		return formatErrorResponse(fmt.Errorf("could not send event for unknown reason"))
+		return formatErrorResponse(fmt.Errorf("could not send event: %s", err.Error()))
 	}
 	// Marshal to json the smartcontract result
 	resp, err := json.Marshal(result)
 	if err != nil {
-		return formatErrorResponse(fmt.Errorf("could not format response for unknown reason"))
+		return formatErrorResponse(fmt.Errorf("could not format response: %s", err.Error()))
 	}
 
 	return shim.Success(resp)

--- a/chaincode/model_composition_test.go
+++ b/chaincode/model_composition_test.go
@@ -119,8 +119,9 @@ func TestModelComposition(t *testing.T) {
 				}
 
 				// check state of child traintuple/testtuple
-				_, trainChildStatus, err := db.GetGenericTraintuple(childKey)
+				tuple, err := db.GetGenericTuple(childKey)
 				assert.NoError(t, err)
+				trainChildStatus := tuple.Status
 
 				outChildTesttuple, err := db.GetTesttuple(childTesttupleKey)
 				assert.NoError(t, err)

--- a/chaincode/model_composition_test.go
+++ b/chaincode/model_composition_test.go
@@ -157,7 +157,7 @@ func trainStart(db *LedgerDB, tupleType AssetType, tupleKey string) (interface{}
 	case CompositeTraintupleType:
 		return logStartCompositeTrain(db, assetToArgs(inputHash{Key: tupleKey}))
 	case AggregatetupleType:
-		return logStartAggregateTrain(db, assetToArgs(inputHash{Key: tupleKey}))
+		return logStartAggregate(db, assetToArgs(inputHash{Key: tupleKey}))
 	default:
 		return nil, fmt.Errorf("unsupported test case %s", tupleType)
 	}
@@ -179,7 +179,7 @@ func trainSuccess(db *LedgerDB, tupleType AssetType, tupleKey string) (interface
 		successParent1 := inputLogSuccessTrain{}
 		successParent1.fillDefaults()
 		successParent1.Key = tupleKey
-		return logSuccessAggregateTrain(db, assetToArgs(successParent1))
+		return logSuccessAggregate(db, assetToArgs(successParent1))
 	default:
 		return nil, fmt.Errorf("unsupported test case %s", tupleType)
 	}
@@ -195,7 +195,7 @@ func trainFail(db *LedgerDB, tupleType AssetType, tupleKey string) (interface{},
 	case CompositeTraintupleType:
 		return logFailCompositeTrain(db, assetToArgs(in))
 	case AggregatetupleType:
-		return logFailAggregateTrain(db, assetToArgs(in))
+		return logFailAggregate(db, assetToArgs(in))
 	default:
 		return nil, fmt.Errorf("unsupported test case %s", tupleType)
 	}

--- a/chaincode/model_composition_test.go
+++ b/chaincode/model_composition_test.go
@@ -150,7 +150,7 @@ func TestModelComposition(t *testing.T) {
 	}
 }
 
-func trainStart(db LedgerDB, tupleType AssetType, tupleKey string) (interface{}, error) {
+func trainStart(db *LedgerDB, tupleType AssetType, tupleKey string) (interface{}, error) {
 	switch tupleType {
 	case TraintupleType:
 		return logStartTrain(db, assetToArgs(inputHash{Key: tupleKey}))
@@ -163,7 +163,7 @@ func trainStart(db LedgerDB, tupleType AssetType, tupleKey string) (interface{},
 	}
 }
 
-func trainSuccess(db LedgerDB, tupleType AssetType, tupleKey string) (interface{}, error) {
+func trainSuccess(db *LedgerDB, tupleType AssetType, tupleKey string) (interface{}, error) {
 	switch tupleType {
 	case TraintupleType:
 		successParent1 := inputLogSuccessTrain{}
@@ -185,7 +185,7 @@ func trainSuccess(db LedgerDB, tupleType AssetType, tupleKey string) (interface{
 	}
 }
 
-func trainFail(db LedgerDB, tupleType AssetType, tupleKey string) (interface{}, error) {
+func trainFail(db *LedgerDB, tupleType AssetType, tupleKey string) (interface{}, error) {
 	in := inputLogFailTrain{}
 	in.Key = tupleKey
 	in.fillDefaults()

--- a/chaincode/node.go
+++ b/chaincode/node.go
@@ -14,7 +14,7 @@
 
 package main
 
-func registerNode(db LedgerDB, args []string) (Node, error) {
+func registerNode(db *LedgerDB, args []string) (Node, error) {
 	txCreator, err := GetTxCreator(db.cc)
 	if err != nil {
 		return Node{}, err
@@ -46,7 +46,7 @@ func registerNode(db LedgerDB, args []string) (Node, error) {
 	return node, nil
 }
 
-func queryNodes(db LedgerDB, args []string) (resp []Node, err error) {
+func queryNodes(db *LedgerDB, args []string) (resp []Node, err error) {
 	elementsKeys, err := db.GetIndexKeys("node~key", []string{"node"})
 	if err != nil {
 		return nil, err

--- a/chaincode/objective.go
+++ b/chaincode/objective.go
@@ -22,7 +22,7 @@ import (
 
 // Set is a method of the receiver Objective. It checks the validity of inputObjective and uses its fields to set the Objective.
 // Returns the objectiveKey and the dataManagerKey associated to test dataSample
-func (objective *Objective) Set(db LedgerDB, inp inputObjective) (objectiveKey string, dataManagerKey string, err error) {
+func (objective *Objective) Set(db *LedgerDB, inp inputObjective) (objectiveKey string, dataManagerKey string, err error) {
 	dataManagerKey = inp.TestDataset.DataManagerKey
 	if dataManagerKey != "" {
 		var testOnly bool
@@ -70,7 +70,7 @@ func (objective *Objective) Set(db LedgerDB, inp inputObjective) (objectiveKey s
 
 // registerObjective stores a new objective in the ledger.
 // If the key exists, it will override the value with the new one
-func registerObjective(db LedgerDB, args []string) (resp map[string]string, err error) {
+func registerObjective(db *LedgerDB, args []string) (resp map[string]string, err error) {
 	// convert input strings args to input struct inputObjective
 	inp := inputObjective{}
 	err = AssetFromJSON(args, &inp)
@@ -98,7 +98,7 @@ func registerObjective(db LedgerDB, args []string) (resp map[string]string, err 
 }
 
 // queryObjective returns a objective of the ledger given its key
-func queryObjective(db LedgerDB, args []string) (out outputObjective, err error) {
+func queryObjective(db *LedgerDB, args []string) (out outputObjective, err error) {
 	inp := inputHash{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -113,7 +113,7 @@ func queryObjective(db LedgerDB, args []string) (out outputObjective, err error)
 }
 
 // queryObjectives returns all objectives of the ledger
-func queryObjectives(db LedgerDB, args []string) (outObjectives []outputObjective, err error) {
+func queryObjectives(db *LedgerDB, args []string) (outObjectives []outputObjective, err error) {
 	outObjectives = []outputObjective{}
 	if len(args) != 0 {
 		err = fmt.Errorf("incorrect number of arguments, expecting nothing")
@@ -137,7 +137,7 @@ func queryObjectives(db LedgerDB, args []string) (outObjectives []outputObjectiv
 
 // getObjectiveLeaderboard returns for an objective, all its certified testtuples with a done status, ordered by their perf
 // It can be an ascending sort or not depending on the ascendingOrder value.
-func queryObjectiveLeaderboard(db LedgerDB, args []string) (outputLeaderboard, error) {
+func queryObjectiveLeaderboard(db *LedgerDB, args []string) (outputLeaderboard, error) {
 	inp := inputLeaderboard{}
 	err := AssetFromJSON(args, &inp)
 	if err != nil {
@@ -186,7 +186,7 @@ func queryObjectiveLeaderboard(db LedgerDB, args []string) (outputLeaderboard, e
 // -------------------------------------------------------------------------------------------
 
 // addObjectiveDataManager associates a objective to a dataManager, more precisely, it adds the objective key to the dataManager
-func addObjectiveDataManager(db LedgerDB, dataManagerKey string, objectiveKey string) error {
+func addObjectiveDataManager(db *LedgerDB, dataManagerKey string, objectiveKey string) error {
 	dataManager, err := db.GetDataManager(dataManagerKey)
 	if err != nil {
 		return nil

--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -318,10 +318,11 @@ func (te *TuplesEvent) AddTesttuple(out outputTesttuple) {
 }
 
 type outputComputePlan struct {
-	ComputePlanID  string   `json:"computePlanID"`
-	ObjectiveKey   string   `json:"objectiveKey"`
-	TraintupleKeys []string `json:"traintupleKeys"`
-	TesttupleKeys  []string `json:"testtupleKeys"`
+	ComputePlanID           string   `json:"computePlanID"`
+	ObjectiveKey            string   `json:"objectiveKey"`
+	TraintupleKeys          []string `json:"traintupleKeys"`
+	CompositeTraintupleKeys []string `json:"compositeTraintupleKeys"`
+	TesttupleKeys           []string `json:"testtupleKeys"`
 }
 
 type outputPermissions struct {

--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -321,6 +321,7 @@ type outputComputePlan struct {
 	ComputePlanID           string   `json:"computePlanID"`
 	ObjectiveKey            string   `json:"objectiveKey"`
 	TraintupleKeys          []string `json:"traintupleKeys"`
+	AggregatetupleKeys      []string `json:"aggregatetupleKeys"`
 	CompositeTraintupleKeys []string `json:"compositeTraintupleKeys"`
 	TesttupleKeys           []string `json:"testtupleKeys"`
 }

--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -127,7 +127,7 @@ type outputTraintuple struct {
 }
 
 //Fill is a method of the receiver outputTraintuple. It returns all elements necessary to do a training task from a trainuple stored in the ledger
-func (outputTraintuple *outputTraintuple) Fill(db LedgerDB, traintuple Traintuple, traintupleKey string) (err error) {
+func (outputTraintuple *outputTraintuple) Fill(db *LedgerDB, traintuple Traintuple, traintupleKey string) (err error) {
 
 	outputTraintuple.Key = traintupleKey
 	outputTraintuple.Creator = traintuple.Creator
@@ -212,7 +212,7 @@ type outputTesttuple struct {
 	Tag            string         `json:"tag"`
 }
 
-func (out *outputTesttuple) Fill(db LedgerDB, key string, in Testtuple) error {
+func (out *outputTesttuple) Fill(db *LedgerDB, key string, in Testtuple) error {
 	out.Key = key
 	out.Certified = in.Certified
 	out.Creator = in.Creator
@@ -346,7 +346,7 @@ type outputBoardTuple struct {
 	Tag           string         `json:"tag"`
 }
 
-func (out *outputBoardTuple) Fill(db LedgerDB, in Testtuple, testtupleKey string) error {
+func (out *outputBoardTuple) Fill(db *LedgerDB, in Testtuple, testtupleKey string) error {
 	out.Key = testtupleKey
 	out.Creator = in.Creator
 	algo, err := db.GetAlgo(in.AlgoKey)

--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -318,9 +318,10 @@ func (te *TuplesEvent) AddTesttuple(out outputTesttuple) {
 }
 
 type outputComputePlan struct {
-	ComputePlanID  string   `json:"computePlanID"`
-	TraintupleKeys []string `json:"traintupleKeys"`
-	TesttupleKeys  []string `json:"testtupleKeys"`
+	ComputePlanID    string   `json:"computePlanID"`
+	ObjectiveKey     string   `json:"objectiveKey"`
+	TrainingTaskKeys []string `json:"trainingTaskKeys"`
+	TesttupleKeys    []string `json:"testtupleKeys"`
 }
 
 type outputPermissions struct {
@@ -380,12 +381,4 @@ func (out *outputBoardTuple) Fill(db LedgerDB, in Testtuple, testtupleKey string
 	out.Tag = in.Tag
 
 	return nil
-}
-
-type outputComputePlanDetails struct {
-	ComputePlanID string   `json:"computePlanID"`
-	AlgoKey       string   `json:"algoKey"`
-	ObjectiveKey  string   `json:"objectiveKey"`
-	Traintuples   []string `json:"traintuples"`
-	Testtuples    []string `json:"testtuples"`
 }

--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -297,26 +297,6 @@ type TuplesEvent struct {
 	Aggregatetuples      []outputAggregatetuple      `json:"aggregatetuple"`
 }
 
-// SetTesttuples add one or several testtuples to the event struct
-func (te *TuplesEvent) SetTesttuples(otuples ...outputTesttuple) {
-	te.Testtuples = otuples
-}
-
-// SetTraintuples add one or several traintuples to the event struct
-func (te *TuplesEvent) SetTraintuples(otuples ...outputTraintuple) {
-	te.Traintuples = otuples
-}
-
-// AddTraintuple add one traintuple to the event struct
-func (te *TuplesEvent) AddTraintuple(out outputTraintuple) {
-	te.Traintuples = append(te.Traintuples, out)
-}
-
-// AddTesttuple add one testtuple to the event struct
-func (te *TuplesEvent) AddTesttuple(out outputTesttuple) {
-	te.Testtuples = append(te.Testtuples, out)
-}
-
 type outputComputePlan struct {
 	ComputePlanID           string   `json:"computePlanID"`
 	ObjectiveKey            string   `json:"objectiveKey"`

--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -318,10 +318,10 @@ func (te *TuplesEvent) AddTesttuple(out outputTesttuple) {
 }
 
 type outputComputePlan struct {
-	ComputePlanID    string   `json:"computePlanID"`
-	ObjectiveKey     string   `json:"objectiveKey"`
-	TrainingTaskKeys []string `json:"trainingTaskKeys"`
-	TesttupleKeys    []string `json:"testtupleKeys"`
+	ComputePlanID  string   `json:"computePlanID"`
+	ObjectiveKey   string   `json:"objectiveKey"`
+	TraintupleKeys []string `json:"traintupleKeys"`
+	TesttupleKeys  []string `json:"testtupleKeys"`
 }
 
 type outputPermissions struct {

--- a/chaincode/output_aggregate.go
+++ b/chaincode/output_aggregate.go
@@ -41,7 +41,7 @@ func (out *outputAggregateAlgo) Fill(key string, in AggregateAlgo) {
 }
 
 // Fill is a method of the receiver outputAggregatetuple. It returns all elements necessary to do a training task from an aggregate trainuple stored in the ledger
-func (outputAggregatetuple *outputAggregatetuple) Fill(db LedgerDB, traintuple Aggregatetuple, traintupleKey string) (err error) {
+func (outputAggregatetuple *outputAggregatetuple) Fill(db *LedgerDB, traintuple Aggregatetuple, traintupleKey string) (err error) {
 	outputAggregatetuple.Key = traintupleKey
 	outputAggregatetuple.Creator = traintuple.Creator
 	outputAggregatetuple.Log = traintuple.Log

--- a/chaincode/output_aggregate.go
+++ b/chaincode/output_aggregate.go
@@ -104,13 +104,3 @@ func (outputAggregatetuple *outputAggregatetuple) Fill(db LedgerDB, traintuple A
 
 	return
 }
-
-// AddAggregatetuple adds one aggregate tuple to the event struct
-func (te *TuplesEvent) AddAggregatetuple(out outputAggregatetuple) {
-	te.Aggregatetuples = append(te.Aggregatetuples, out)
-}
-
-// SetAggregatetuples adds one or several tuples to the event struct
-func (te *TuplesEvent) SetAggregatetuples(otuples ...outputAggregatetuple) {
-	te.Aggregatetuples = otuples
-}

--- a/chaincode/output_composite.go
+++ b/chaincode/output_composite.go
@@ -45,7 +45,7 @@ type outModelComposite struct {
 }
 
 //Fill is a method of the receiver outputCompositeTraintuple. It returns all elements necessary to do a training task from a trainuple stored in the ledger
-func (outputCompositeTraintuple *outputCompositeTraintuple) Fill(db LedgerDB, traintuple CompositeTraintuple, traintupleKey string) (err error) {
+func (outputCompositeTraintuple *outputCompositeTraintuple) Fill(db *LedgerDB, traintuple CompositeTraintuple, traintupleKey string) (err error) {
 
 	outputCompositeTraintuple.Key = traintupleKey
 	outputCompositeTraintuple.Creator = traintuple.Creator

--- a/chaincode/output_composite.go
+++ b/chaincode/output_composite.go
@@ -147,13 +147,3 @@ func getOutPermissions(in Permissions) (out outputPermissions) {
 func (out *outputCompositeAlgo) Fill(key string, in CompositeAlgo) {
 	out.outputAlgo.Fill(key, in.Algo)
 }
-
-// SetCompositeTraintuples adds one or several tuples to the event struct
-func (te *TuplesEvent) SetCompositeTraintuples(otuples ...outputCompositeTraintuple) {
-	te.CompositeTraintuples = otuples
-}
-
-// AddCompositeTraintuple add one traintuple to the event struct
-func (te *TuplesEvent) AddCompositeTraintuple(out outputCompositeTraintuple) {
-	te.CompositeTraintuples = append(te.CompositeTraintuples, out)
-}

--- a/chaincode/permissions.go
+++ b/chaincode/permissions.go
@@ -65,7 +65,7 @@ func (perms Permissions) CanProcess(owner, node string) bool {
 }
 
 // NewPermissions create the Permissions according to the arg received
-func NewPermissions(db LedgerDB, in inputPermissions) (Permissions, error) {
+func NewPermissions(db *LedgerDB, in inputPermissions) (Permissions, error) {
 	nodes, err := queryNodes(db, []string{})
 	if err != nil {
 		return Permissions{}, err

--- a/chaincode/testtuple.go
+++ b/chaincode/testtuple.go
@@ -243,15 +243,7 @@ func createTesttupleInternal(db LedgerDB, inp inputTesttuple) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	out := outputTesttuple{}
-	err = out.Fill(db, testtupleKey, testtuple)
-	if err != nil {
-		return "", err
-	}
-
-	event := TuplesEvent{}
-	event.SetTesttuples(out)
-	err = SendTuplesEvent(db.cc, event)
+	err = db.AddTupleEvent(testtupleKey)
 	if err != nil {
 		return "", err
 	}

--- a/chaincode/testtuple.go
+++ b/chaincode/testtuple.go
@@ -34,7 +34,7 @@ import (
 //  - Tag
 //  - Dataset
 //  - Certified
-func (testtuple *Testtuple) SetFromInput(db LedgerDB, inp inputTesttuple) error {
+func (testtuple *Testtuple) SetFromInput(db *LedgerDB, inp inputTesttuple) error {
 	creator, err := GetTxCreator(db.cc)
 	if err != nil {
 		return err
@@ -100,7 +100,7 @@ func (testtuple *Testtuple) SetFromInput(db LedgerDB, inp inputTesttuple) error 
 //  - ObjectiveKey
 //  - Model
 //  - Status
-func (testtuple *Testtuple) SetFromTraintuple(db LedgerDB, traintupleKey string) error {
+func (testtuple *Testtuple) SetFromTraintuple(db *LedgerDB, traintupleKey string) error {
 
 	var status, tupleCreator string
 	var permissions Permissions
@@ -179,7 +179,7 @@ func (testtuple *Testtuple) GetKey() string {
 
 // Save will put in the legder interface both the testtuple with its key
 // and all the associated composite keys
-func (testtuple *Testtuple) Save(db LedgerDB, testtupleKey string) error {
+func (testtuple *Testtuple) Save(db *LedgerDB, testtupleKey string) error {
 	var err error
 	if err = db.Add(testtupleKey, testtuple); err != nil {
 		return err
@@ -212,7 +212,7 @@ func (testtuple *Testtuple) Save(db LedgerDB, testtupleKey string) error {
 // -------------------------------------
 
 // createTesttuple adds a Testtuple in the ledger
-func createTesttuple(db LedgerDB, args []string) (map[string]string, error) {
+func createTesttuple(db *LedgerDB, args []string) (map[string]string, error) {
 
 	inp := inputTesttuple{}
 	err := AssetFromJSON(args, &inp)
@@ -227,7 +227,7 @@ func createTesttuple(db LedgerDB, args []string) (map[string]string, error) {
 	return map[string]string{"key": key}, nil
 }
 
-func createTesttupleInternal(db LedgerDB, inp inputTesttuple) (string, error) {
+func createTesttupleInternal(db *LedgerDB, inp inputTesttuple) (string, error) {
 	// check validity of input arg and set testtuple
 	testtuple := Testtuple{}
 	err := testtuple.SetFromTraintuple(db, inp.TraintupleKey)
@@ -252,7 +252,7 @@ func createTesttupleInternal(db LedgerDB, inp inputTesttuple) (string, error) {
 }
 
 // logStartTest modifies a testtuple by changing its status from todo to doing
-func logStartTest(db LedgerDB, args []string) (outputTesttuple outputTesttuple, err error) {
+func logStartTest(db *LedgerDB, args []string) (outputTesttuple outputTesttuple, err error) {
 	inp := inputHash{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -278,7 +278,7 @@ func logStartTest(db LedgerDB, args []string) (outputTesttuple outputTesttuple, 
 }
 
 // logSuccessTest modifies a testtuple by changing its status to done, reports perf and logs
-func logSuccessTest(db LedgerDB, args []string) (outputTesttuple outputTesttuple, err error) {
+func logSuccessTest(db *LedgerDB, args []string) (outputTesttuple outputTesttuple, err error) {
 	inp := inputLogSuccessTest{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -304,7 +304,7 @@ func logSuccessTest(db LedgerDB, args []string) (outputTesttuple outputTesttuple
 }
 
 // logFailTest modifies a testtuple by changing its status to fail and reports associated logs
-func logFailTest(db LedgerDB, args []string) (outputTesttuple outputTesttuple, err error) {
+func logFailTest(db *LedgerDB, args []string) (outputTesttuple outputTesttuple, err error) {
 	inp := inputLogFailTest{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -330,7 +330,7 @@ func logFailTest(db LedgerDB, args []string) (outputTesttuple outputTesttuple, e
 }
 
 // queryTesttuple returns a testtuple of the ledger given its key
-func queryTesttuple(db LedgerDB, args []string) (out outputTesttuple, err error) {
+func queryTesttuple(db *LedgerDB, args []string) (out outputTesttuple, err error) {
 	inp := inputHash{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -349,7 +349,7 @@ func queryTesttuple(db LedgerDB, args []string) (out outputTesttuple, err error)
 }
 
 // queryTesttuples returns all testtuples of the ledger
-func queryTesttuples(db LedgerDB, args []string) ([]outputTesttuple, error) {
+func queryTesttuples(db *LedgerDB, args []string) ([]outputTesttuple, error) {
 	outTesttuples := []outputTesttuple{}
 
 	if len(args) != 0 {
@@ -376,7 +376,7 @@ func queryTesttuples(db LedgerDB, args []string) ([]outputTesttuple, error) {
 // -----------------------------------------------
 
 // getOutputTesttuple takes as input a testtuple key and returns the outputTesttuple
-func getOutputTesttuple(db LedgerDB, testtupleKey string) (outTesttuple outputTesttuple, err error) {
+func getOutputTesttuple(db *LedgerDB, testtupleKey string) (outTesttuple outputTesttuple, err error) {
 	testtuple, err := db.GetTesttuple(testtupleKey)
 	if err != nil {
 		return
@@ -386,7 +386,7 @@ func getOutputTesttuple(db LedgerDB, testtupleKey string) (outTesttuple outputTe
 }
 
 // getOutputTesttuples takes as input a list of keys and returns a paylaod containing a list of associated retrieved elements
-func getOutputTesttuples(db LedgerDB, testtupleKeys []string) (outTesttuples []outputTesttuple, err error) {
+func getOutputTesttuples(db *LedgerDB, testtupleKeys []string) (outTesttuples []outputTesttuple, err error) {
 	for _, key := range testtupleKeys {
 		var outputTesttuple outputTesttuple
 		outputTesttuple, err = getOutputTesttuple(db, key)
@@ -399,13 +399,13 @@ func getOutputTesttuples(db LedgerDB, testtupleKeys []string) (outTesttuples []o
 }
 
 // validateNewStatus verifies that the new status is consistent with the tuple current status
-func (testtuple *Testtuple) validateNewStatus(db LedgerDB, status string) error {
+func (testtuple *Testtuple) validateNewStatus(db *LedgerDB, status string) error {
 	// check validity of worker and change of status
 	return checkUpdateTuple(db, testtuple.Dataset.Worker, testtuple.Status, status)
 }
 
 // commitStatusUpdate update the testtuple status in the ledger
-func (testtuple *Testtuple) commitStatusUpdate(db LedgerDB, testtupleKey string, newStatus string) error {
+func (testtuple *Testtuple) commitStatusUpdate(db *LedgerDB, testtupleKey string, newStatus string) error {
 	if err := testtuple.validateNewStatus(db, newStatus); err != nil {
 		return fmt.Errorf("update testtuple %s failed: %s", testtupleKey, err.Error())
 	}

--- a/chaincode/traintuple.go
+++ b/chaincode/traintuple.go
@@ -148,14 +148,14 @@ func (traintuple *Traintuple) AddToComputePlan(db LedgerDB, inp inputTraintuple,
 		return nil
 	}
 	var ttKeys []string
-	ttKeys, err = db.GetIndexKeys("traintuple~computeplanid~worker~rank~key", []string{"traintuple", inp.ComputePlanID})
+	ttKeys, err = db.GetIndexKeys("computePlan~computeplanid~worker~rank~key", []string{"computePlan", inp.ComputePlanID})
 	if err != nil {
 		return err
 	}
 	if len(ttKeys) == 0 {
 		return errors.BadRequest("cannot find the ComputePlanID %s", inp.ComputePlanID)
 	}
-	ttKeys, err = db.GetIndexKeys("traintuple~computeplanid~worker~rank~key", []string{"traintuple", inp.ComputePlanID, traintuple.Dataset.Worker, inp.Rank})
+	ttKeys, err = db.GetIndexKeys("computePlan~computeplanid~worker~rank~key", []string{"computePlan", inp.ComputePlanID, traintuple.Dataset.Worker, inp.Rank})
 	if err != nil {
 		return err
 	} else if len(ttKeys) > 0 {
@@ -190,7 +190,7 @@ func (traintuple *Traintuple) Save(db LedgerDB, traintupleKey string) error {
 		}
 	}
 	if traintuple.ComputePlanID != "" {
-		if err := db.CreateIndex("traintuple~computeplanid~worker~rank~key", []string{"traintuple", traintuple.ComputePlanID, traintuple.Dataset.Worker, strconv.Itoa(traintuple.Rank), traintupleKey}); err != nil {
+		if err := db.CreateIndex("computePlan~computeplanid~worker~rank~key", []string{"computePlan", traintuple.ComputePlanID, traintuple.Dataset.Worker, strconv.Itoa(traintuple.Rank), traintupleKey}); err != nil {
 			return err
 		}
 		if err := db.CreateIndex("computeplan~id", []string{"computeplan", traintuple.ComputePlanID}); err != nil {

--- a/chaincode/traintuple.go
+++ b/chaincode/traintuple.go
@@ -32,7 +32,7 @@ import (
 //  - Tag
 //  - AlgoKey & ObjectiveKey
 //  - Dataset
-func (traintuple *Traintuple) SetFromInput(db LedgerDB, inp inputTraintuple) error {
+func (traintuple *Traintuple) SetFromInput(db *LedgerDB, inp inputTraintuple) error {
 
 	// TODO later: check permissions
 	// find associated creator and check permissions (TODO later)
@@ -93,7 +93,7 @@ func (traintuple *Traintuple) SetFromInput(db LedgerDB, inp inputTraintuple) err
 // SetFromParents set the status of the traintuple depending on its "parents",
 // i.e. the traintuples from which it received the outModels as inModels.
 // Also it's InModelKeys are set.
-func (traintuple *Traintuple) SetFromParents(db LedgerDB, inModels []string) error {
+func (traintuple *Traintuple) SetFromParents(db *LedgerDB, inModels []string) error {
 	status := StatusTodo
 	parentTraintupleKeys := inModels
 	for _, parentTraintupleKey := range parentTraintupleKeys {
@@ -126,7 +126,7 @@ func (traintuple *Traintuple) GetKey() string {
 //  - If neither ComputePlanID nor rank is set it returns immediately
 //  - If rank is 0 and ComputePlanID empty, it's start a new one using this traintuple key
 //  - If rank and ComputePlanID are set, it checks if there are coherent with previous ones and set it.
-func (traintuple *Traintuple) AddToComputePlan(db LedgerDB, inp inputTraintuple, traintupleKey string, fromComputePlan bool) error {
+func (traintuple *Traintuple) AddToComputePlan(db *LedgerDB, inp inputTraintuple, traintupleKey string, fromComputePlan bool) error {
 	// check ComputePlanID and Rank and set it when required
 	var err error
 	if inp.Rank == "" {
@@ -172,7 +172,7 @@ func (traintuple *Traintuple) AddToComputePlan(db LedgerDB, inp inputTraintuple,
 
 // Save will put in the legder interface both the traintuple with its key
 // and all the associated composite keys
-func (traintuple *Traintuple) Save(db LedgerDB, traintupleKey string) error {
+func (traintuple *Traintuple) Save(db *LedgerDB, traintupleKey string) error {
 
 	// store in ledger
 	if err := db.Add(traintupleKey, traintuple); err != nil {
@@ -213,7 +213,7 @@ func (traintuple *Traintuple) Save(db LedgerDB, traintupleKey string) error {
 // -------------------------------------------------------------------------------------------
 
 // createTraintuple adds a Traintuple in the ledger
-func createTraintuple(db LedgerDB, args []string) (map[string]string, error) {
+func createTraintuple(db *LedgerDB, args []string) (map[string]string, error) {
 	inp := inputTraintuple{}
 	err := AssetFromJSON(args, &inp)
 	if err != nil {
@@ -229,7 +229,7 @@ func createTraintuple(db LedgerDB, args []string) (map[string]string, error) {
 	return map[string]string{"key": key}, nil
 }
 
-func createTraintupleInternal(db LedgerDB, inp inputTraintuple, fromComputePlan bool) (string, error) {
+func createTraintupleInternal(db *LedgerDB, inp inputTraintuple, fromComputePlan bool) (string, error) {
 	traintuple := Traintuple{}
 	err := traintuple.SetFromInput(db, inp)
 	if err != nil {
@@ -267,7 +267,7 @@ func createTraintupleInternal(db LedgerDB, inp inputTraintuple, fromComputePlan 
 }
 
 // logStartTrain modifies a traintuple by changing its status from todo to doing
-func logStartTrain(db LedgerDB, args []string) (outputTraintuple outputTraintuple, err error) {
+func logStartTrain(db *LedgerDB, args []string) (outputTraintuple outputTraintuple, err error) {
 	inp := inputHash{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -291,7 +291,7 @@ func logStartTrain(db LedgerDB, args []string) (outputTraintuple outputTraintupl
 
 // logSuccessTrain modifies a traintuple by changing its status from doing to done
 // reports logs and associated performances
-func logSuccessTrain(db LedgerDB, args []string) (outputTraintuple outputTraintuple, err error) {
+func logSuccessTrain(db *LedgerDB, args []string) (outputTraintuple outputTraintuple, err error) {
 	inp := inputLogSuccessTrain{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -337,7 +337,7 @@ func logSuccessTrain(db LedgerDB, args []string) (outputTraintuple outputTraintu
 }
 
 // logFailTrain modifies a traintuple by changing its status to fail and reports associated logs
-func logFailTrain(db LedgerDB, args []string) (outputTraintuple outputTraintuple, err error) {
+func logFailTrain(db *LedgerDB, args []string) (outputTraintuple outputTraintuple, err error) {
 	inp := inputLogFailTrain{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -373,7 +373,7 @@ func logFailTrain(db LedgerDB, args []string) (outputTraintuple outputTraintuple
 }
 
 // queryTraintuple returns info about a traintuple given its key
-func queryTraintuple(db LedgerDB, args []string) (outputTraintuple outputTraintuple, err error) {
+func queryTraintuple(db *LedgerDB, args []string) (outputTraintuple outputTraintuple, err error) {
 	inp := inputHash{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -392,7 +392,7 @@ func queryTraintuple(db LedgerDB, args []string) (outputTraintuple outputTraintu
 }
 
 // queryTraintuples returns all traintuples
-func queryTraintuples(db LedgerDB, args []string) ([]outputTraintuple, error) {
+func queryTraintuples(db *LedgerDB, args []string) ([]outputTraintuple, error) {
 	outTraintuples := []outputTraintuple{}
 
 	if len(args) != 0 {
@@ -418,7 +418,7 @@ func queryTraintuples(db LedgerDB, args []string) ([]outputTraintuple, error) {
 // -----------------------------------------------
 
 // getOutputTraintuple takes as input a traintuple key and returns the outputTraintuple
-func getOutputTraintuple(db LedgerDB, traintupleKey string) (outTraintuple outputTraintuple, err error) {
+func getOutputTraintuple(db *LedgerDB, traintupleKey string) (outTraintuple outputTraintuple, err error) {
 	traintuple, err := db.GetTraintuple(traintupleKey)
 	if err != nil {
 		return
@@ -428,7 +428,7 @@ func getOutputTraintuple(db LedgerDB, traintupleKey string) (outTraintuple outpu
 }
 
 // getOutputTraintuples takes as input a list of keys and returns a paylaod containing a list of associated retrieved elements
-func getOutputTraintuples(db LedgerDB, traintupleKeys []string) (outTraintuples []outputTraintuple, err error) {
+func getOutputTraintuples(db *LedgerDB, traintupleKeys []string) (outTraintuples []outputTraintuple, err error) {
 	for _, key := range traintupleKeys {
 		var outputTraintuple outputTraintuple
 		outputTraintuple, err = getOutputTraintuple(db, key)
@@ -441,13 +441,13 @@ func getOutputTraintuples(db LedgerDB, traintupleKeys []string) (outTraintuples 
 }
 
 // validateNewStatus verifies that the new status is consistent with the tuple current status
-func (traintuple *Traintuple) validateNewStatus(db LedgerDB, status string) error {
+func (traintuple *Traintuple) validateNewStatus(db *LedgerDB, status string) error {
 	// check validity of worker and change of status
 	return checkUpdateTuple(db, traintuple.Dataset.Worker, traintuple.Status, status)
 }
 
 // UpdateTraintupleChildren updates the status of waiting trainuples  InModels of traintuples once they have been trained (succesfully or failed)
-func UpdateTraintupleChildren(db LedgerDB, traintupleKey string, traintupleStatus string) error {
+func UpdateTraintupleChildren(db *LedgerDB, traintupleKey string, traintupleStatus string) error {
 	// get traintuples having as inModels the input traintuple
 	childTraintupleKeys, err := db.GetIndexKeys("traintuple~inModel~key", []string{"traintuple", traintupleKey})
 	if err != nil {
@@ -516,7 +516,7 @@ func UpdateTraintupleChildren(db LedgerDB, traintupleKey string, traintupleStatu
 }
 
 // UpdateTraintupleChild updates the status of a waiting trainuple, given the new parent traintuple status
-func UpdateTraintupleChild(db LedgerDB, parentTraintupleKey string, childTraintupleKey string, traintupleStatus string) (childStatus string, err error) {
+func UpdateTraintupleChild(db *LedgerDB, parentTraintupleKey string, childTraintupleKey string, traintupleStatus string) (childStatus string, err error) {
 	// get and update traintuple
 	childTraintuple, err := db.GetTraintuple(childTraintupleKey)
 	if err != nil {
@@ -556,12 +556,12 @@ func UpdateTraintupleChild(db LedgerDB, parentTraintupleKey string, childTraintu
 	return
 }
 
-func (traintuple *Traintuple) isReady(db LedgerDB, newDoneTraintupleKey string) (ready bool, err error) {
+func (traintuple *Traintuple) isReady(db *LedgerDB, newDoneTraintupleKey string) (ready bool, err error) {
 	return IsReady(db, traintuple.InModelKeys, newDoneTraintupleKey)
 }
 
 // IsReady checks if inModels of a traintuple have been trained, except the newDoneTraintupleKey (since the transaction is not commited)
-func IsReady(db LedgerDB, inModelKeys []string, newDoneTraintupleKey string) (ready bool, err error) {
+func IsReady(db *LedgerDB, inModelKeys []string, newDoneTraintupleKey string) (ready bool, err error) {
 	for _, key := range inModelKeys {
 		// don't check newly done traintuple
 		if key == newDoneTraintupleKey {
@@ -579,7 +579,7 @@ func IsReady(db LedgerDB, inModelKeys []string, newDoneTraintupleKey string) (re
 }
 
 // commitStatusUpdate update the traintuple status in the ledger
-func (traintuple *Traintuple) commitStatusUpdate(db LedgerDB, traintupleKey string, newStatus string) error {
+func (traintuple *Traintuple) commitStatusUpdate(db *LedgerDB, traintupleKey string, newStatus string) error {
 	if traintuple.Status == newStatus {
 		return fmt.Errorf("cannot update traintuple %s - status already %s", traintupleKey, newStatus)
 	}
@@ -606,7 +606,7 @@ func (traintuple *Traintuple) commitStatusUpdate(db LedgerDB, traintupleKey stri
 }
 
 // UpdateTesttupleChildren update testtuples status associated with a done or failed traintuple
-func UpdateTesttupleChildren(db LedgerDB, traintupleKey string, traintupleStatus string) error {
+func UpdateTesttupleChildren(db *LedgerDB, traintupleKey string, traintupleStatus string) error {
 	var newStatus string
 	switch {
 	case traintupleStatus == StatusFailed:

--- a/chaincode/traintuple_composite.go
+++ b/chaincode/traintuple_composite.go
@@ -32,7 +32,7 @@ import (
 //  - Tag
 //  - AlgoKey & ObjectiveKey
 //  - Dataset
-func (traintuple *CompositeTraintuple) SetFromInput(db LedgerDB, inp inputCompositeTraintuple) error {
+func (traintuple *CompositeTraintuple) SetFromInput(db *LedgerDB, inp inputCompositeTraintuple) error {
 
 	creator, err := GetTxCreator(db.cc)
 	if err != nil {
@@ -104,7 +104,7 @@ func (traintuple *CompositeTraintuple) SetFromInput(db LedgerDB, inp inputCompos
 // i.e. the traintuples from which it received the outModels as inModels.
 // Also it's InModelKeys are set.
 // TODO: rename to SetInModels
-func (traintuple *CompositeTraintuple) SetFromParents(db LedgerDB, inp inputCompositeTraintuple) error {
+func (traintuple *CompositeTraintuple) SetFromParents(db *LedgerDB, inp inputCompositeTraintuple) error {
 	traintuple.Status = StatusTodo
 	if inp.InHeadModelKey == "" || inp.InTrunkModelKey == "" {
 		return nil
@@ -155,7 +155,7 @@ func (traintuple *CompositeTraintuple) GetKey() string {
 //  - If neither ComputePlanID nor rank is set it returns immediately
 //  - If rank is 0 and ComputePlanID empty, it's start a new one using this traintuple key
 //  - If rank and ComputePlanID are set, it checks if there are coherent with previous ones and set it.
-func (traintuple *CompositeTraintuple) AddToComputePlan(db LedgerDB, inp inputCompositeTraintuple, traintupleKey string, fromComputePlan bool) error {
+func (traintuple *CompositeTraintuple) AddToComputePlan(db *LedgerDB, inp inputCompositeTraintuple, traintupleKey string, fromComputePlan bool) error {
 	// check ComputePlanID and Rank and set it when required
 	var err error
 	if inp.Rank == "" {
@@ -202,7 +202,7 @@ func (traintuple *CompositeTraintuple) AddToComputePlan(db LedgerDB, inp inputCo
 
 // Save will put in the legder interface both the traintuple with its key
 // and all the associated composite keys
-func (traintuple *CompositeTraintuple) Save(db LedgerDB, traintupleKey string) error {
+func (traintuple *CompositeTraintuple) Save(db *LedgerDB, traintupleKey string) error {
 
 	// store in ledger
 	if err := db.Add(traintupleKey, traintuple); err != nil {
@@ -246,7 +246,7 @@ func (traintuple *CompositeTraintuple) Save(db LedgerDB, traintupleKey string) e
 // -------------------------------------------------
 
 // createCompositeTraintuple is the wrapper for the substra smartcontract createCompositeTraintuple
-func createCompositeTraintuple(db LedgerDB, args []string) (map[string]string, error) {
+func createCompositeTraintuple(db *LedgerDB, args []string) (map[string]string, error) {
 	inp := inputCompositeTraintuple{}
 	err := AssetFromJSON(args, &inp)
 	if err != nil {
@@ -262,7 +262,7 @@ func createCompositeTraintuple(db LedgerDB, args []string) (map[string]string, e
 }
 
 // createCompositeTraintupleInternal adds a CompositeTraintuple in the ledger
-func createCompositeTraintupleInternal(db LedgerDB, inp inputCompositeTraintuple, fromComputePlan bool) (string, error) {
+func createCompositeTraintupleInternal(db *LedgerDB, inp inputCompositeTraintuple, fromComputePlan bool) (string, error) {
 	traintuple := CompositeTraintuple{}
 	err := traintuple.SetFromInput(db, inp)
 	if err != nil {
@@ -300,7 +300,7 @@ func createCompositeTraintupleInternal(db LedgerDB, inp inputCompositeTraintuple
 }
 
 // logStartCompositeTrain modifies a traintuple by changing its status from todo to doing
-func logStartCompositeTrain(db LedgerDB, args []string) (outputTraintuple outputCompositeTraintuple, err error) {
+func logStartCompositeTrain(db *LedgerDB, args []string) (outputTraintuple outputCompositeTraintuple, err error) {
 	inp := inputHash{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -324,7 +324,7 @@ func logStartCompositeTrain(db LedgerDB, args []string) (outputTraintuple output
 
 // logSuccessCompositeTrain modifies a traintuple by changing its status from doing to done
 // reports logs and associated performances
-func logSuccessCompositeTrain(db LedgerDB, args []string) (outputTraintuple outputCompositeTraintuple, err error) {
+func logSuccessCompositeTrain(db *LedgerDB, args []string) (outputTraintuple outputCompositeTraintuple, err error) {
 	inp := inputLogSuccessCompositeTrain{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -369,7 +369,7 @@ func logSuccessCompositeTrain(db LedgerDB, args []string) (outputTraintuple outp
 }
 
 // logFailCompositeTrain modifies a traintuple by changing its status to fail and reports associated logs
-func logFailCompositeTrain(db LedgerDB, args []string) (outputTraintuple outputCompositeTraintuple, err error) {
+func logFailCompositeTrain(db *LedgerDB, args []string) (outputTraintuple outputCompositeTraintuple, err error) {
 	inp := inputLogFailTrain{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -407,7 +407,7 @@ func logFailCompositeTrain(db LedgerDB, args []string) (outputTraintuple outputC
 }
 
 // queryCompositeTraintuple returns info about a composite traintuple given its key
-func queryCompositeTraintuple(db LedgerDB, args []string) (outputTraintuple outputCompositeTraintuple, err error) {
+func queryCompositeTraintuple(db *LedgerDB, args []string) (outputTraintuple outputCompositeTraintuple, err error) {
 	inp := inputHash{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -426,7 +426,7 @@ func queryCompositeTraintuple(db LedgerDB, args []string) (outputTraintuple outp
 }
 
 // queryCompositeTraintuples returns all composite traintuples
-func queryCompositeTraintuples(db LedgerDB, args []string) ([]outputCompositeTraintuple, error) {
+func queryCompositeTraintuples(db *LedgerDB, args []string) ([]outputCompositeTraintuple, error) {
 	outTraintuples := []outputCompositeTraintuple{}
 
 	if len(args) != 0 {
@@ -452,7 +452,7 @@ func queryCompositeTraintuples(db LedgerDB, args []string) ([]outputCompositeTra
 // ----------------------------------------------------------
 
 // UpdateCompositeTraintupleChild updates the status of a waiting trainuple, given the new parent traintuple status
-func UpdateCompositeTraintupleChild(db LedgerDB, parentTraintupleKey string, childTraintupleKey string, traintupleStatus string) (childStatus string, err error) {
+func UpdateCompositeTraintupleChild(db *LedgerDB, parentTraintupleKey string, childTraintupleKey string, traintupleStatus string) (childStatus string, err error) {
 	// get and update traintuple
 	childTraintuple, err := db.GetCompositeTraintuple(childTraintupleKey)
 	if err != nil {
@@ -492,7 +492,7 @@ func UpdateCompositeTraintupleChild(db LedgerDB, parentTraintupleKey string, chi
 }
 
 // getOutputCompositeTraintuple takes as input a traintuple key and returns the outputCompositeTraintuple
-func getOutputCompositeTraintuple(db LedgerDB, traintupleKey string) (outTraintuple outputCompositeTraintuple, err error) {
+func getOutputCompositeTraintuple(db *LedgerDB, traintupleKey string) (outTraintuple outputCompositeTraintuple, err error) {
 	traintuple, err := db.GetCompositeTraintuple(traintupleKey)
 	if err != nil {
 		return
@@ -502,7 +502,7 @@ func getOutputCompositeTraintuple(db LedgerDB, traintupleKey string) (outTraintu
 }
 
 // getOutputCompositeTraintuples takes as input a list of keys and returns a paylaod containing a list of associated retrieved elements
-func getOutputCompositeTraintuples(db LedgerDB, traintupleKeys []string) (outTraintuples []outputCompositeTraintuple, err error) {
+func getOutputCompositeTraintuples(db *LedgerDB, traintupleKeys []string) (outTraintuples []outputCompositeTraintuple, err error) {
 	for _, key := range traintupleKeys {
 		var outputTraintuple outputCompositeTraintuple
 		outputTraintuple, err = getOutputCompositeTraintuple(db, key)
@@ -515,7 +515,7 @@ func getOutputCompositeTraintuples(db LedgerDB, traintupleKeys []string) (outTra
 }
 
 // validateNewStatus verifies that the new status is consistent with the tuple current status
-func (traintuple *CompositeTraintuple) validateNewStatus(db LedgerDB, status string) error {
+func (traintuple *CompositeTraintuple) validateNewStatus(db *LedgerDB, status string) error {
 	// check validity of worker and change of status
 	if err := checkUpdateTuple(db, traintuple.Dataset.Worker, traintuple.Status, status); err != nil {
 		return err
@@ -523,12 +523,12 @@ func (traintuple *CompositeTraintuple) validateNewStatus(db LedgerDB, status str
 	return nil
 }
 
-func (traintuple *CompositeTraintuple) isReady(db LedgerDB, newDoneTraintupleKey string) (ready bool, err error) {
+func (traintuple *CompositeTraintuple) isReady(db *LedgerDB, newDoneTraintupleKey string) (ready bool, err error) {
 	return IsReady(db, []string{traintuple.InHeadModel, traintuple.InTrunkModel}, newDoneTraintupleKey)
 }
 
 // commitStatusUpdate update the traintuple status in the ledger
-func (traintuple *CompositeTraintuple) commitStatusUpdate(db LedgerDB, traintupleKey string, newStatus string) error {
+func (traintuple *CompositeTraintuple) commitStatusUpdate(db *LedgerDB, traintupleKey string, newStatus string) error {
 	if traintuple.Status == newStatus {
 		return fmt.Errorf("cannot update traintuple %s - status already %s", traintupleKey, newStatus)
 	}

--- a/chaincode/traintuple_composite.go
+++ b/chaincode/traintuple_composite.go
@@ -226,6 +226,9 @@ func (traintuple *CompositeTraintuple) Save(db LedgerDB, traintupleKey string) e
 		if err := db.CreateIndex("computePlan~computeplanid~worker~rank~key", []string{"computePlan", traintuple.ComputePlanID, traintuple.Dataset.Worker, strconv.Itoa(traintuple.Rank), traintupleKey}); err != nil {
 			return err
 		}
+		if err := db.CreateIndex("computeplan~id", []string{"computeplan", traintuple.ComputePlanID}); err != nil {
+			return err
+		}
 	}
 	if traintuple.Tag != "" {
 		err := db.CreateIndex("compositeTraintuple~tag~key", []string{"compositeTraintuple", traintuple.Tag, traintupleKey})

--- a/chaincode/traintuple_composite_test.go
+++ b/chaincode/traintuple_composite_test.go
@@ -239,24 +239,6 @@ func TestTraintupleMultipleCommputePlanCreationsComposite(t *testing.T) {
 	err = json.Unmarshal(resp.Payload, &res)
 	assert.NoError(t, err, "should unmarshal without problem")
 	assert.Contains(t, res, "key")
-	ttkey := res["key"]
-	// Add new algo to check all ComputePlan algo consistency
-	newAlgoHash := strings.Replace(compositeAlgoHash, "a", "b", 1)
-	inpAlgo := inputCompositeAlgo{inputAlgo{Hash: newAlgoHash}}
-	args = inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("42", args)
-	assert.EqualValues(t, 200, resp.Status)
-
-	inpTraintuple = inputCompositeTraintuple{
-		AlgoKey:         newAlgoHash,
-		InHeadModelKey:  ttkey,
-		InTrunkModelKey: ttkey,
-		Rank:            "2",
-		ComputePlanID:   key}
-	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
-	assert.EqualValues(t, 400, resp.Status, resp.Message, "should fail for it doesn't have the same composite algo key")
-	assert.Contains(t, resp.Message, "does not have the same algo key")
 }
 
 func TestTraintupleComposite(t *testing.T) {

--- a/chaincode/tuple.go
+++ b/chaincode/tuple.go
@@ -36,7 +36,7 @@ const (
 // ------------------------------------------------
 
 // queryModelDetails returns info about the testtuple and algo related to a traintuple
-func queryModelDetails(db LedgerDB, args []string) (outModelDetails outputModelDetails, err error) {
+func queryModelDetails(db *LedgerDB, args []string) (outModelDetails outputModelDetails, err error) {
 	inp := inputHash{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -95,7 +95,7 @@ func queryModelDetails(db LedgerDB, args []string) (outModelDetails outputModelD
 }
 
 // queryModels returns all traintuples and associated testuples
-func queryModels(db LedgerDB, args []string) (outModels []outputModel, err error) {
+func queryModels(db *LedgerDB, args []string) (outModels []outputModel, err error) {
 	outModels = []outputModel{}
 
 	if len(args) != 0 {
@@ -175,7 +175,7 @@ func checkLog(log string) (err error) {
 }
 */
 
-func validateTupleOwner(db LedgerDB, worker string) error {
+func validateTupleOwner(db *LedgerDB, worker string) error {
 	txCreator, err := GetTxCreator(db.cc)
 	if err != nil {
 		return err
@@ -187,7 +187,7 @@ func validateTupleOwner(db LedgerDB, worker string) error {
 }
 
 // check validity of traintuple update: consistent status and agent submitting the transaction
-func checkUpdateTuple(db LedgerDB, worker string, oldStatus string, newStatus string) error {
+func checkUpdateTuple(db *LedgerDB, worker string, oldStatus string, newStatus string) error {
 	statusPossibilities := map[string]string{
 		StatusWaiting: StatusTodo,
 		StatusTodo:    StatusDoing,
@@ -209,7 +209,7 @@ func HashForKey(objectType string, hashElements ...string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-func getCertifiedOutputTesttuple(db LedgerDB, traintupleKey string) (outputTesttuple, error) {
+func getCertifiedOutputTesttuple(db *LedgerDB, traintupleKey string) (outputTesttuple, error) {
 	var out outputTesttuple
 	// get associated testtuple
 	var testtupleKeys []string

--- a/chaincode/tuple_aggregate.go
+++ b/chaincode/tuple_aggregate.go
@@ -282,8 +282,8 @@ func createAggregatetupleInternal(db *LedgerDB, inp inputAggregatetuple, checkCo
 	return aggregatetupleKey, nil
 }
 
-// logStartAggregateTrain modifies a aggregatetuple by changing its status from todo to doing
-func logStartAggregateTrain(db *LedgerDB, args []string) (outputAggregatetuple outputAggregatetuple, err error) {
+// logStartAggregate modifies a aggregatetuple by changing its status from todo to doing
+func logStartAggregate(db *LedgerDB, args []string) (outputAggregatetuple outputAggregatetuple, err error) {
 	inp := inputHash{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -305,8 +305,8 @@ func logStartAggregateTrain(db *LedgerDB, args []string) (outputAggregatetuple o
 	return
 }
 
-// logFailAggregateTrain modifies a aggregatetuple by changing its status to fail and reports associated logs
-func logFailAggregateTrain(db *LedgerDB, args []string) (outputAggregatetuple outputAggregatetuple, err error) {
+// logFailAggregate modifies a aggregatetuple by changing its status to fail and reports associated logs
+func logFailAggregate(db *LedgerDB, args []string) (outputAggregatetuple outputAggregatetuple, err error) {
 	inp := inputLogFailTrain{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -343,9 +343,9 @@ func logFailAggregateTrain(db *LedgerDB, args []string) (outputAggregatetuple ou
 	return
 }
 
-// logSuccessAggregateTrain modifies an aggregateTupl by changing its status from doing to done
+// logSuccessAggregate modifies an aggregateTupl by changing its status from doing to done
 // reports logs and associated performances
-func logSuccessAggregateTrain(db *LedgerDB, args []string) (outputAggregatetuple outputAggregatetuple, err error) {
+func logSuccessAggregate(db *LedgerDB, args []string) (outputAggregatetuple outputAggregatetuple, err error) {
 	inp := inputLogSuccessTrain{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {

--- a/chaincode/tuple_aggregate.go
+++ b/chaincode/tuple_aggregate.go
@@ -161,24 +161,15 @@ func (tuple *Aggregatetuple) AddToComputePlan(db LedgerDB, inp inputAggregatetup
 		return nil
 	}
 	var ttKeys []string
-	ttKeys, err = db.GetIndexKeys("aggregatetuple~computeplanid~worker~rank~key", []string{"aggregatetuple", inp.ComputePlanID})
+	ttKeys, err = db.GetIndexKeys("computePlan~computeplanid~worker~rank~key", []string{"computePlan", inp.ComputePlanID})
 	if err != nil {
 		return err
 	}
 	if len(ttKeys) == 0 {
 		return errors.BadRequest("cannot find the ComputePlanID %s", inp.ComputePlanID)
 	}
-	for _, ttKey := range ttKeys {
-		FLTraintuple, err := db.GetAggregatetuple(ttKey)
-		if err != nil {
-			return err
-		}
-		if FLTraintuple.AlgoKey != inp.AlgoKey {
-			return errors.BadRequest("previous traintuple for ComputePlanID %s does not have the same algo key %s", inp.ComputePlanID, inp.AlgoKey)
-		}
-	}
 
-	ttKeys, err = db.GetIndexKeys("aggregatetuple~computeplanid~worker~rank~key", []string{"aggregatetuple", inp.ComputePlanID, tuple.Worker, inp.Rank})
+	ttKeys, err = db.GetIndexKeys("computePlan~computeplanid~worker~rank~key", []string{"computePlan", inp.ComputePlanID, tuple.Worker, inp.Rank})
 	if err != nil {
 		return err
 	} else if len(ttKeys) > 0 {
@@ -213,7 +204,7 @@ func (tuple *Aggregatetuple) Save(db LedgerDB, aggregatetupleKey string) error {
 		}
 	}
 	if tuple.ComputePlanID != "" {
-		if err := db.CreateIndex("aggregatetuple~computeplanid~worker~rank~key", []string{"aggregatetuple", tuple.ComputePlanID, tuple.Worker, strconv.Itoa(tuple.Rank), aggregatetupleKey}); err != nil {
+		if err := db.CreateIndex("computePlan~computeplanid~worker~rank~key", []string{"computePlan", tuple.ComputePlanID, tuple.Worker, strconv.Itoa(tuple.Rank), aggregateTupleKey}); err != nil {
 			return err
 		}
 	}

--- a/chaincode/tuple_aggregate.go
+++ b/chaincode/tuple_aggregate.go
@@ -31,7 +31,7 @@ import (
 //  - Creator & permissions
 //  - Tag
 //  - AlgoKey & ObjectiveKey
-func (tuple *Aggregatetuple) SetFromInput(db LedgerDB, inp inputAggregatetuple) error {
+func (tuple *Aggregatetuple) SetFromInput(db *LedgerDB, inp inputAggregatetuple) error {
 	creator, err := GetTxCreator(db.cc)
 	if err != nil {
 		return err
@@ -66,7 +66,7 @@ func (tuple *Aggregatetuple) SetFromInput(db LedgerDB, inp inputAggregatetuple) 
 // SetFromParents set the status of the aggregate tuple depending on its "parents",
 // i.e. the traintuples from which it received the outModels as inModels.
 // Also it's InModelKeys are set.
-func (tuple *Aggregatetuple) SetFromParents(db LedgerDB, inModels []string) error {
+func (tuple *Aggregatetuple) SetFromParents(db *LedgerDB, inModels []string) error {
 	status := StatusTodo
 	inModelKeys := tuple.InModelKeys
 	permissions, err := NewPermissions(db, OpenPermissions)
@@ -139,7 +139,7 @@ func (tuple *Aggregatetuple) GetKey() string {
 //  - If neither ComputePlanID nor rank is set it returns immediately
 //  - If rank is 0 and ComputePlanID empty, it's start a new one using this traintuple key
 //  - If rank and ComputePlanID are set, it checks if there are coherent with previous ones and set it.
-func (tuple *Aggregatetuple) AddToComputePlan(db LedgerDB, inp inputAggregatetuple, traintupleKey string, fromComputePlan bool) error {
+func (tuple *Aggregatetuple) AddToComputePlan(db *LedgerDB, inp inputAggregatetuple, traintupleKey string, fromComputePlan bool) error {
 	// check ComputePlanID and Rank and set it when required
 	var err error
 	if inp.Rank == "" {
@@ -187,7 +187,7 @@ func (tuple *Aggregatetuple) AddToComputePlan(db LedgerDB, inp inputAggregatetup
 
 // Save will put in the legder interface both the aggregate tuple with its key
 // and all the associated composite keys
-func (tuple *Aggregatetuple) Save(db LedgerDB, aggregatetupleKey string) error {
+func (tuple *Aggregatetuple) Save(db *LedgerDB, aggregatetupleKey string) error {
 
 	// store in ledger
 	if err := db.Add(aggregatetupleKey, tuple); err != nil {
@@ -227,7 +227,7 @@ func (tuple *Aggregatetuple) Save(db LedgerDB, aggregatetupleKey string) error {
 // Smart contracts related to aggregate tuples
 // -------------------------------------------------------------------------------------------
 // createAggregatetuple is the wrapper for the substra smartcontract createAggregatetuple
-func createAggregatetuple(db LedgerDB, args []string) (map[string]string, error) {
+func createAggregatetuple(db *LedgerDB, args []string) (map[string]string, error) {
 	inp := inputAggregatetuple{}
 	err := AssetFromJSON(args, &inp)
 	if err != nil {
@@ -243,7 +243,7 @@ func createAggregatetuple(db LedgerDB, args []string) (map[string]string, error)
 }
 
 // createAggregatetupleInternal adds a Aggregatetuple in the ledger
-func createAggregatetupleInternal(db LedgerDB, inp inputAggregatetuple, fromComputePlan bool) (string, error) {
+func createAggregatetupleInternal(db *LedgerDB, inp inputAggregatetuple, fromComputePlan bool) (string, error) {
 
 	aggregatetuple := Aggregatetuple{}
 	err := aggregatetuple.SetFromInput(db, inp)
@@ -282,7 +282,7 @@ func createAggregatetupleInternal(db LedgerDB, inp inputAggregatetuple, fromComp
 }
 
 // logStartAggregateTrain modifies a aggregatetuple by changing its status from todo to doing
-func logStartAggregateTrain(db LedgerDB, args []string) (outputAggregatetuple outputAggregatetuple, err error) {
+func logStartAggregateTrain(db *LedgerDB, args []string) (outputAggregatetuple outputAggregatetuple, err error) {
 	inp := inputHash{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -305,7 +305,7 @@ func logStartAggregateTrain(db LedgerDB, args []string) (outputAggregatetuple ou
 }
 
 // logFailAggregateTrain modifies a aggregatetuple by changing its status to fail and reports associated logs
-func logFailAggregateTrain(db LedgerDB, args []string) (outputAggregatetuple outputAggregatetuple, err error) {
+func logFailAggregateTrain(db *LedgerDB, args []string) (outputAggregatetuple outputAggregatetuple, err error) {
 	inp := inputLogFailTrain{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -344,7 +344,7 @@ func logFailAggregateTrain(db LedgerDB, args []string) (outputAggregatetuple out
 
 // logSuccessAggregateTrain modifies an aggregateTupl by changing its status from doing to done
 // reports logs and associated performances
-func logSuccessAggregateTrain(db LedgerDB, args []string) (outputAggregatetuple outputAggregatetuple, err error) {
+func logSuccessAggregateTrain(db *LedgerDB, args []string) (outputAggregatetuple outputAggregatetuple, err error) {
 	inp := inputLogSuccessTrain{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -384,7 +384,7 @@ func logSuccessAggregateTrain(db LedgerDB, args []string) (outputAggregatetuple 
 }
 
 // queryAggregatetuple returns info about an aggregate tuple given its key
-func queryAggregatetuple(db LedgerDB, args []string) (outputAggregatetuple outputAggregatetuple, err error) {
+func queryAggregatetuple(db *LedgerDB, args []string) (outputAggregatetuple outputAggregatetuple, err error) {
 	inp := inputHash{}
 	err = AssetFromJSON(args, &inp)
 	if err != nil {
@@ -403,7 +403,7 @@ func queryAggregatetuple(db LedgerDB, args []string) (outputAggregatetuple outpu
 }
 
 // queryAggregatetuples returns all aggregate tuples
-func queryAggregatetuples(db LedgerDB, args []string) ([]outputAggregatetuple, error) {
+func queryAggregatetuples(db *LedgerDB, args []string) ([]outputAggregatetuple, error) {
 	outputAggregatetuples := []outputAggregatetuple{}
 
 	if len(args) != 0 {
@@ -429,7 +429,7 @@ func queryAggregatetuples(db LedgerDB, args []string) ([]outputAggregatetuple, e
 // ----------------------------------------------------------
 
 // getOutputAggregatetuple takes as input a aggregatetuple key and returns the outputAggregatetuple
-func getOutputAggregatetuple(db LedgerDB, aggregatetupleKey string) (outAggreagateTuple outputAggregatetuple, err error) {
+func getOutputAggregatetuple(db *LedgerDB, aggregatetupleKey string) (outAggreagateTuple outputAggregatetuple, err error) {
 	aggregatetuple, err := db.GetAggregatetuple(aggregatetupleKey)
 	if err != nil {
 		return
@@ -439,7 +439,7 @@ func getOutputAggregatetuple(db LedgerDB, aggregatetupleKey string) (outAggreaga
 }
 
 // UpdateAggregatetupleChild updates the status of a waiting trainuple, given the new parent tuple status
-func UpdateAggregatetupleChild(db LedgerDB, parentAggregatetupleKey string, childAggregatetupleKey string, aggregatetupleStatus string) (childStatus string, err error) {
+func UpdateAggregatetupleChild(db *LedgerDB, parentAggregatetupleKey string, childAggregatetupleKey string, aggregatetupleStatus string) (childStatus string, err error) {
 	// get and update aggregatetuple
 	childAggregatetuple, err := db.GetAggregatetuple(childAggregatetupleKey)
 	if err != nil {
@@ -478,12 +478,12 @@ func UpdateAggregatetupleChild(db LedgerDB, parentAggregatetupleKey string, chil
 	return
 }
 
-func (tuple *Aggregatetuple) isReady(db LedgerDB, newDoneAggregatetupleKey string) (ready bool, err error) {
+func (tuple *Aggregatetuple) isReady(db *LedgerDB, newDoneAggregatetupleKey string) (ready bool, err error) {
 	return IsReady(db, tuple.InModelKeys, newDoneAggregatetupleKey)
 }
 
 // getOutputAggregatetuples takes as input a list of keys and returns a paylaod containing a list of associated retrieved elements
-func getOutputAggregatetuples(db LedgerDB, aggregatetupleKeys []string) (outAggreagateTuples []outputAggregatetuple, err error) {
+func getOutputAggregatetuples(db *LedgerDB, aggregatetupleKeys []string) (outAggreagateTuples []outputAggregatetuple, err error) {
 	for _, key := range aggregatetupleKeys {
 		var outputAggregatetuple outputAggregatetuple
 		outputAggregatetuple, err = getOutputAggregatetuple(db, key)
@@ -496,7 +496,7 @@ func getOutputAggregatetuples(db LedgerDB, aggregatetupleKeys []string) (outAggr
 }
 
 // commitStatusUpdate update the aggregatetuple status in the ledger
-func (tuple *Aggregatetuple) commitStatusUpdate(db LedgerDB, aggregatetupleKey string, newStatus string) error {
+func (tuple *Aggregatetuple) commitStatusUpdate(db *LedgerDB, aggregatetupleKey string, newStatus string) error {
 	if tuple.Status == newStatus {
 		return fmt.Errorf("cannot update aggregatetuple %s - status already %s", aggregatetupleKey, newStatus)
 	}
@@ -523,7 +523,7 @@ func (tuple *Aggregatetuple) commitStatusUpdate(db LedgerDB, aggregatetupleKey s
 }
 
 // validateNewStatus verifies that the new status is consistent with the tuple current status
-func (tuple *Aggregatetuple) validateNewStatus(db LedgerDB, status string) error {
+func (tuple *Aggregatetuple) validateNewStatus(db *LedgerDB, status string) error {
 	// check validity of worker and change of status
 	if err := checkUpdateTuple(db, tuple.Worker, tuple.Status, status); err != nil {
 		return err

--- a/chaincode/tuple_aggregate.go
+++ b/chaincode/tuple_aggregate.go
@@ -207,6 +207,9 @@ func (tuple *Aggregatetuple) Save(db LedgerDB, aggregatetupleKey string) error {
 		if err := db.CreateIndex("computePlan~computeplanid~worker~rank~key", []string{"computePlan", tuple.ComputePlanID, tuple.Worker, strconv.Itoa(tuple.Rank), aggregatetupleKey}); err != nil {
 			return err
 		}
+		if err := db.CreateIndex("computeplan~id", []string{"computeplan", tuple.ComputePlanID}); err != nil {
+			return err
+		}
 	}
 	if tuple.Tag != "" {
 		err := db.CreateIndex("aggregatetuple~tag~key", []string{"aggregatetuple", tuple.Tag, aggregatetupleKey})

--- a/chaincode/tuple_aggregate_test.go
+++ b/chaincode/tuple_aggregate_test.go
@@ -208,23 +208,6 @@ func TestTraintupleMultipleCommputePlanCreationsAggregate(t *testing.T) {
 	err = json.Unmarshal(resp.Payload, &res)
 	assert.NoError(t, err, "should unmarshal without problem")
 	assert.Contains(t, res, "key")
-	ttkey := res["key"]
-	// Add new algo to check all ComputePlan algo consistency
-	newAlgoHash := strings.Replace(aggregateAlgoHash, "a", "b", 1)
-	inpAlgo := inputAggregateAlgo{inputAlgo{Hash: newAlgoHash}}
-	args = inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("42", args)
-	assert.EqualValues(t, 200, resp.Status)
-
-	inpTraintuple = inputAggregatetuple{
-		AlgoKey:       newAlgoHash,
-		InModels:      []string{ttkey},
-		Rank:          "2",
-		ComputePlanID: key}
-	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
-	assert.EqualValues(t, 400, resp.Status, resp.Message, "should fail for it doesn't have the same aggregate algo key")
-	assert.Contains(t, resp.Message, "does not have the same algo key")
 }
 
 func TestTraintupleAggregate(t *testing.T) {

--- a/chaincode/utils.go
+++ b/chaincode/utils.go
@@ -90,20 +90,6 @@ func AssetFromJSON(args []string, asset interface{}) error {
 	return nil
 }
 
-// SendTuplesEvent sends an event with updated traintuples and testtuples
-// Only one event can be sent per transaction
-func SendTuplesEvent(stub shim.ChaincodeStubInterface, event interface{}) error {
-	payload, err := json.Marshal(event)
-	if err != nil {
-		return err
-	}
-	err = stub.SetEvent("tuples-updated", payload)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // GetTxCreator returns the transaction creator
 func GetTxCreator(stub shim.ChaincodeStubInterface) (string, error) {
 	creator, err := stub.GetCreator()


### PR DESCRIPTION
Companion PR: [substra-backend](https://github.com/SubstraFoundation/substra-backend/pull/57)

This updates the compute plan structures to support composite/aggregate.

Fixes https://github.com/SubstraFoundation/substra-chaincode/issues/31

Fixes https://github.com/SubstraFoundation/substra-chaincode/issues/36
