### PR TITLE
travis: cache go modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ branches:
   only:
     - master
 
+cache:
+  directories:
+    - $HOME/.cache/go-build
+    - $HOME/gopath/pkg/mod   
+    
 install: skip
 
 before_script:
@@ -20,4 +25,3 @@ script:
   - golint
   - go test -v ./...
   - go build -v
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
   directories:
     - $HOME/.cache/go-build
     - $HOME/gopath/pkg/mod   
-    
+
 install: skip
 
 before_script:


### PR DESCRIPTION
speed up builds!

Source: https://restic.net/blog/2018-09-02/travis-build-cache