### PR TITLE
update go version from 1.11 to 1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project is developed under the Apache License, Version 2.0 (Apache-2.0), lo
 
 ### Prerequisites
 
-go version 1.11.x
+go version 1.12.x
 
 ### Run the tests
 

--- a/chaincode/go.mod
+++ b/chaincode/go.mod
@@ -1,6 +1,6 @@
 module chaincode
 
-go 1.11
+go 1.12
 
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible // indirect


### PR DESCRIPTION
HLF supports version 1.12. See https://hyperledger-fabric.readthedocs.io/en/release-1.4/prereqs.html#go-programming-language