### PR TITLE
Fail fast: move objective to testtuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,6 +739,7 @@ peer chaincode invoke -n mycc -c '{"Args":["queryFilter","{\"indexName\":\"testt
    "storageAddress": "https://toto/algo/222/algo"
   },
   "certified": true,
+  "computePlanID": "",
   "creator": "SampleOrg",
   "dataset": {
    "keys": [
@@ -758,6 +759,7 @@ peer chaincode invoke -n mycc -c '{"Args":["queryFilter","{\"indexName\":\"testt
     "storageAddress": "https://toto/objective/222/metrics"
    }
   },
+  "rank": 0,
   "status": "todo",
   "tag": "",
   "traintupleKey": "9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3",
@@ -770,6 +772,7 @@ peer chaincode invoke -n mycc -c '{"Args":["queryFilter","{\"indexName\":\"testt
    "storageAddress": "https://toto/algo/222/algo"
   },
   "certified": false,
+  "computePlanID": "",
   "creator": "SampleOrg",
   "dataset": {
    "keys": [
@@ -789,6 +792,7 @@ peer chaincode invoke -n mycc -c '{"Args":["queryFilter","{\"indexName\":\"testt
     "storageAddress": "https://toto/objective/222/metrics"
    }
   },
+  "rank": 0,
   "status": "todo",
   "tag": "",
   "traintupleKey": "9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3",
@@ -818,6 +822,7 @@ peer chaincode invoke -n mycc -c '{"Args":["logStartTest","{\"key\":\"5ae68332a1
   "storageAddress": "https://toto/algo/222/algo"
  },
  "certified": true,
+ "computePlanID": "",
  "creator": "SampleOrg",
  "dataset": {
   "keys": [
@@ -837,6 +842,7 @@ peer chaincode invoke -n mycc -c '{"Args":["logStartTest","{\"key\":\"5ae68332a1
    "storageAddress": "https://toto/objective/222/metrics"
   }
  },
+ "rank": 0,
  "status": "doing",
  "tag": "",
  "traintupleKey": "9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3",
@@ -867,6 +873,7 @@ peer chaincode invoke -n mycc -c '{"Args":["logSuccessTest","{\"key\":\"5ae68332
   "storageAddress": "https://toto/algo/222/algo"
  },
  "certified": true,
+ "computePlanID": "",
  "creator": "SampleOrg",
  "dataset": {
   "keys": [
@@ -886,6 +893,7 @@ peer chaincode invoke -n mycc -c '{"Args":["logSuccessTest","{\"key\":\"5ae68332
    "storageAddress": "https://toto/objective/222/metrics"
   }
  },
+ "rank": 0,
  "status": "done",
  "tag": "",
  "traintupleKey": "9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3",
@@ -914,6 +922,7 @@ peer chaincode query -n mycc -c '{"Args":["queryTesttuple","{\"key\":\"5ae68332a
   "storageAddress": "https://toto/algo/222/algo"
  },
  "certified": true,
+ "computePlanID": "",
  "creator": "SampleOrg",
  "dataset": {
   "keys": [
@@ -933,6 +942,7 @@ peer chaincode query -n mycc -c '{"Args":["queryTesttuple","{\"key\":\"5ae68332a
    "storageAddress": "https://toto/objective/222/metrics"
   }
  },
+ "rank": 0,
  "status": "done",
  "tag": "",
  "traintupleKey": "9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3",
@@ -954,6 +964,7 @@ peer chaincode query -n mycc -c '{"Args":["queryTesttuples"]}' -C myc
    "storageAddress": "https://toto/algo/222/algo"
   },
   "certified": true,
+  "computePlanID": "",
   "creator": "SampleOrg",
   "dataset": {
    "keys": [
@@ -973,6 +984,7 @@ peer chaincode query -n mycc -c '{"Args":["queryTesttuples"]}' -C myc
     "storageAddress": "https://toto/objective/222/metrics"
    }
   },
+  "rank": 0,
   "status": "waiting",
   "tag": "",
   "traintupleKey": "720f778397fa07e24c2f314599725bf97727ded07ff65a51fa1a97b24d11ecab",
@@ -985,6 +997,7 @@ peer chaincode query -n mycc -c '{"Args":["queryTesttuples"]}' -C myc
    "storageAddress": "https://toto/algo/222/algo"
   },
   "certified": false,
+  "computePlanID": "",
   "creator": "SampleOrg",
   "dataset": {
    "keys": [
@@ -1004,6 +1017,7 @@ peer chaincode query -n mycc -c '{"Args":["queryTesttuples"]}' -C myc
     "storageAddress": "https://toto/objective/222/metrics"
    }
   },
+  "rank": 0,
   "status": "todo",
   "tag": "",
   "traintupleKey": "9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3",
@@ -1016,6 +1030,7 @@ peer chaincode query -n mycc -c '{"Args":["queryTesttuples"]}' -C myc
    "storageAddress": "https://toto/algo/222/algo"
   },
   "certified": true,
+  "computePlanID": "",
   "creator": "SampleOrg",
   "dataset": {
    "keys": [
@@ -1035,6 +1050,7 @@ peer chaincode query -n mycc -c '{"Args":["queryTesttuples"]}' -C myc
     "storageAddress": "https://toto/objective/222/metrics"
    }
   },
+  "rank": 0,
   "status": "done",
   "tag": "",
   "traintupleKey": "9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3",
@@ -1066,6 +1082,7 @@ peer chaincode query -n mycc -c '{"Args":["queryModelDetails","{\"key\":\"9da043
     "storageAddress": "https://toto/algo/222/algo"
    },
    "certified": false,
+   "computePlanID": "",
    "creator": "SampleOrg",
    "dataset": {
     "keys": [
@@ -1085,6 +1102,7 @@ peer chaincode query -n mycc -c '{"Args":["queryModelDetails","{\"key\":\"9da043
      "storageAddress": "https://toto/objective/222/metrics"
     }
    },
+   "rank": 0,
    "status": "todo",
    "tag": "",
    "traintupleKey": "9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3",
@@ -1098,6 +1116,7 @@ peer chaincode query -n mycc -c '{"Args":["queryModelDetails","{\"key\":\"9da043
    "storageAddress": "https://toto/algo/222/algo"
   },
   "certified": true,
+  "computePlanID": "",
   "creator": "SampleOrg",
   "dataset": {
    "keys": [
@@ -1117,6 +1136,7 @@ peer chaincode query -n mycc -c '{"Args":["queryModelDetails","{\"key\":\"9da043
     "storageAddress": "https://toto/objective/222/metrics"
    }
   },
+  "rank": 0,
   "status": "done",
   "tag": "",
   "traintupleKey": "9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3",
@@ -1174,6 +1194,7 @@ peer chaincode query -n mycc -c '{"Args":["queryModels"]}' -C myc
     "storageAddress": "https://toto/algo/222/algo"
    },
    "certified": true,
+   "computePlanID": "",
    "creator": "SampleOrg",
    "dataset": {
     "keys": [
@@ -1193,6 +1214,7 @@ peer chaincode query -n mycc -c '{"Args":["queryModels"]}' -C myc
      "storageAddress": "https://toto/objective/222/metrics"
     }
    },
+   "rank": 0,
    "status": "waiting",
    "tag": "",
    "traintupleKey": "720f778397fa07e24c2f314599725bf97727ded07ff65a51fa1a97b24d11ecab",
@@ -1244,6 +1266,7 @@ peer chaincode query -n mycc -c '{"Args":["queryModels"]}' -C myc
     "storageAddress": "https://toto/algo/222/algo"
    },
    "certified": true,
+   "computePlanID": "",
    "creator": "SampleOrg",
    "dataset": {
     "keys": [
@@ -1263,6 +1286,7 @@ peer chaincode query -n mycc -c '{"Args":["queryModels"]}' -C myc
      "storageAddress": "https://toto/objective/222/metrics"
     }
    },
+   "rank": 0,
    "status": "done",
    "tag": "",
    "traintupleKey": "9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3",

--- a/README.md
+++ b/README.md
@@ -474,7 +474,6 @@ peer chaincode invoke -n mycc -c '{"Args":["queryFilter","{\"indexName\":\"train
     "aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc"
    ],
    "openerHash": "da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
-   "perf": 0,
    "worker": "SampleOrg"
   },
   "inModels": null,
@@ -522,7 +521,6 @@ peer chaincode invoke -n mycc -c '{"Args":["logStartTrain","{\"key\":\"9da043ddc
    "aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc"
   ],
   "openerHash": "da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
-  "perf": 0,
   "worker": "SampleOrg"
  },
  "inModels": null,
@@ -552,12 +550,11 @@ Smart contract: `logSuccessTrain`
    "hash": string (required,len=64,hexadecimal),
    "storageAddress": string (required),
  },
- "perf": float32 (omitempty),
 }
 ```
 ##### Command peer example:
 ```bash
-peer chaincode invoke -n mycc -c '{"Args":["logSuccessTrain","{\"key\":\"9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3\",\"log\":\"no error, ah ah ah\",\"outModel\":{\"hash\":\"eedbb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482eed\",\"storageAddress\":\"https://substrabac/model/toto\"},\"perf\":0.9}"]}' -C myc
+peer chaincode invoke -n mycc -c '{"Args":["logSuccessTrain","{\"key\":\"9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3\",\"log\":\"no error, ah ah ah\",\"outModel\":{\"hash\":\"eedbb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482eed\",\"storageAddress\":\"https://substrabac/model/toto\"}}"]}' -C myc
 ```
 ##### Command output:
 ```json
@@ -575,7 +572,6 @@ peer chaincode invoke -n mycc -c '{"Args":["logSuccessTrain","{\"key\":\"9da043d
    "aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc"
   ],
   "openerHash": "da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
-  "perf": 0.9,
   "worker": "SampleOrg"
  },
  "inModels": null,
@@ -625,7 +621,6 @@ peer chaincode invoke -n mycc -c '{"Args":["queryTraintuple","{\"key\":\"9da043d
    "aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc"
   ],
   "openerHash": "da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
-  "perf": 0.9,
   "worker": "SampleOrg"
  },
  "inModels": null,
@@ -1156,7 +1151,6 @@ peer chaincode query -n mycc -c '{"Args":["queryModelDetails","{\"key\":\"9da043
     "aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc"
    ],
    "openerHash": "da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
-   "perf": 0.9,
    "worker": "SampleOrg"
   },
   "inModels": null,
@@ -1234,7 +1228,6 @@ peer chaincode query -n mycc -c '{"Args":["queryModels"]}' -C myc
      "aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc"
     ],
     "openerHash": "da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
-    "perf": 0,
     "worker": "SampleOrg"
    },
    "inModels": [
@@ -1306,7 +1299,6 @@ peer chaincode query -n mycc -c '{"Args":["queryModels"]}' -C myc
      "aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc"
     ],
     "openerHash": "da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
-    "perf": 0.9,
     "worker": "SampleOrg"
    },
    "inModels": null,

--- a/README.md
+++ b/README.md
@@ -394,7 +394,6 @@ Smart contract: `createTraintuple`
 ```go
 {
  "algoKey": string (required,len=64,hexadecimal),
- "objectiveKey": string (required,len=64,hexadecimal),
  "inModels": [string] (omitempty,dive,len=64,hexadecimal),
  "dataManagerKey": string (required,len=64,hexadecimal),
  "dataSampleKeys": [string] (required,unique,gt=0,dive,len=64,hexadecimal),
@@ -405,7 +404,7 @@ Smart contract: `createTraintuple`
 ```
 ##### Command peer example:
 ```bash
-peer chaincode invoke -n mycc -c '{"Args":["createTraintuple","{\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"objectiveKey\":\"5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379\",\"inModels\":[],\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"computePlanID\":\"\",\"rank\":\"\",\"tag\":\"\"}"]}' -C myc
+peer chaincode invoke -n mycc -c '{"Args":["createTraintuple","{\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"inModels\":[],\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"computePlanID\":\"\",\"rank\":\"\",\"tag\":\"\"}"]}' -C myc
 ```
 ##### Command output:
 ```json
@@ -420,7 +419,6 @@ Smart contract: `createTraintuple`
 ```go
 {
  "algoKey": string (required,len=64,hexadecimal),
- "objectiveKey": string (required,len=64,hexadecimal),
  "inModels": [string] (omitempty,dive,len=64,hexadecimal),
  "dataManagerKey": string (required,len=64,hexadecimal),
  "dataSampleKeys": [string] (required,unique,gt=0,dive,len=64,hexadecimal),
@@ -431,7 +429,7 @@ Smart contract: `createTraintuple`
 ```
 ##### Command peer example:
 ```bash
-peer chaincode invoke -n mycc -c '{"Args":["createTraintuple","{\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"objectiveKey\":\"5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379\",\"inModels\":[\"9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3\"],\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"computePlanID\":\"\",\"rank\":\"\",\"tag\":\"\"}"]}' -C myc
+peer chaincode invoke -n mycc -c '{"Args":["createTraintuple","{\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"inModels\":[\"9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3\"],\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"computePlanID\":\"\",\"rank\":\"\",\"tag\":\"\"}"]}' -C myc
 ```
 ##### Command output:
 ```json
@@ -482,13 +480,6 @@ peer chaincode invoke -n mycc -c '{"Args":["queryFilter","{\"indexName\":\"train
   "inModels": null,
   "key": "9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3",
   "log": "",
-  "objective": {
-   "hash": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-   "metrics": {
-    "hash": "4a1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-    "storageAddress": "https://toto/objective/222/metrics"
-   }
-  },
   "outModel": null,
   "permissions": {
    "process": {
@@ -537,13 +528,6 @@ peer chaincode invoke -n mycc -c '{"Args":["logStartTrain","{\"key\":\"9da043ddc
  "inModels": null,
  "key": "9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3",
  "log": "",
- "objective": {
-  "hash": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-  "metrics": {
-   "hash": "4a1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-   "storageAddress": "https://toto/objective/222/metrics"
-  }
- },
  "outModel": null,
  "permissions": {
   "process": {
@@ -597,13 +581,6 @@ peer chaincode invoke -n mycc -c '{"Args":["logSuccessTrain","{\"key\":\"9da043d
  "inModels": null,
  "key": "9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3",
  "log": "no error, ah ah ah",
- "objective": {
-  "hash": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-  "metrics": {
-   "hash": "4a1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-   "storageAddress": "https://toto/objective/222/metrics"
-  }
- },
  "outModel": {
   "hash": "eedbb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482eed",
   "storageAddress": "https://substrabac/model/toto"
@@ -654,13 +631,6 @@ peer chaincode invoke -n mycc -c '{"Args":["queryTraintuple","{\"key\":\"9da043d
  "inModels": null,
  "key": "9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3",
  "log": "no error, ah ah ah",
- "objective": {
-  "hash": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-  "metrics": {
-   "hash": "4a1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-   "storageAddress": "https://toto/objective/222/metrics"
-  }
- },
  "outModel": {
   "hash": "eedbb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482eed",
   "storageAddress": "https://substrabac/model/toto"
@@ -682,15 +652,16 @@ Smart contract: `createTesttuple`
 ##### JSON Inputs:
 ```go
 {
- "traintupleKey": string (required,len=64,hexadecimal),
  "dataManagerKey": string (omitempty,len=64,hexadecimal),
  "dataSampleKeys": [string] (omitempty,dive,len=64,hexadecimal),
+ "objectiveKey": string (required,len=64,hexadecimal),
  "tag": string (omitempty,lte=64),
+ "traintupleKey": string (required,len=64,hexadecimal),
 }
 ```
 ##### Command peer example:
 ```bash
-peer chaincode invoke -n mycc -c '{"Args":["createTesttuple","{\"traintupleKey\":\"9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3\",\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"tag\":\"\"}"]}' -C myc
+peer chaincode invoke -n mycc -c '{"Args":["createTesttuple","{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"objectiveKey\":\"5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379\",\"tag\":\"\",\"traintupleKey\":\"9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3\"}"]}' -C myc
 ```
 ##### Command output:
 ```json
@@ -704,15 +675,16 @@ Smart contract: `createTesttuple`
 ##### JSON Inputs:
 ```go
 {
- "traintupleKey": string (required,len=64,hexadecimal),
  "dataManagerKey": string (omitempty,len=64,hexadecimal),
  "dataSampleKeys": [string] (omitempty,dive,len=64,hexadecimal),
+ "objectiveKey": string (required,len=64,hexadecimal),
  "tag": string (omitempty,lte=64),
+ "traintupleKey": string (required,len=64,hexadecimal),
 }
 ```
 ##### Command peer example:
 ```bash
-peer chaincode invoke -n mycc -c '{"Args":["createTesttuple","{\"traintupleKey\":\"9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3\",\"dataManagerKey\":\"\",\"dataSampleKeys\":null,\"tag\":\"\"}"]}' -C myc
+peer chaincode invoke -n mycc -c '{"Args":["createTesttuple","{\"dataManagerKey\":\"\",\"dataSampleKeys\":null,\"objectiveKey\":\"5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379\",\"tag\":\"\",\"traintupleKey\":\"9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3\"}"]}' -C myc
 ```
 ##### Command output:
 ```json
@@ -726,15 +698,16 @@ Smart contract: `createTesttuple`
 ##### JSON Inputs:
 ```go
 {
- "traintupleKey": string (required,len=64,hexadecimal),
  "dataManagerKey": string (omitempty,len=64,hexadecimal),
  "dataSampleKeys": [string] (omitempty,dive,len=64,hexadecimal),
+ "objectiveKey": string (required,len=64,hexadecimal),
  "tag": string (omitempty,lte=64),
+ "traintupleKey": string (required,len=64,hexadecimal),
 }
 ```
 ##### Command peer example:
 ```bash
-peer chaincode invoke -n mycc -c '{"Args":["createTesttuple","{\"traintupleKey\":\"720f778397fa07e24c2f314599725bf97727ded07ff65a51fa1a97b24d11ecab\",\"dataManagerKey\":\"\",\"dataSampleKeys\":null,\"tag\":\"\"}"]}' -C myc
+peer chaincode invoke -n mycc -c '{"Args":["createTesttuple","{\"dataManagerKey\":\"\",\"dataSampleKeys\":null,\"objectiveKey\":\"5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379\",\"tag\":\"\",\"traintupleKey\":\"720f778397fa07e24c2f314599725bf97727ded07ff65a51fa1a97b24d11ecab\"}"]}' -C myc
 ```
 ##### Command output:
 ```json
@@ -1169,13 +1142,6 @@ peer chaincode query -n mycc -c '{"Args":["queryModelDetails","{\"key\":\"9da043
   "inModels": null,
   "key": "9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3",
   "log": "no error, ah ah ah",
-  "objective": {
-   "hash": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-   "metrics": {
-    "hash": "4a1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-    "storageAddress": "https://toto/objective/222/metrics"
-   }
-  },
   "outModel": {
    "hash": "eedbb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482eed",
    "storageAddress": "https://substrabac/model/toto"
@@ -1258,13 +1224,6 @@ peer chaincode query -n mycc -c '{"Args":["queryModels"]}' -C myc
    ],
    "key": "720f778397fa07e24c2f314599725bf97727ded07ff65a51fa1a97b24d11ecab",
    "log": "",
-   "objective": {
-    "hash": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-    "metrics": {
-     "hash": "4a1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-     "storageAddress": "https://toto/objective/222/metrics"
-    }
-   },
    "outModel": null,
    "permissions": {
     "process": {
@@ -1329,13 +1288,6 @@ peer chaincode query -n mycc -c '{"Args":["queryModels"]}' -C myc
    "inModels": null,
    "key": "9da043ddc233996d2e62c196471290de4726fc59d65dbbd2b32a920326e8adf3",
    "log": "no error, ah ah ah",
-   "objective": {
-    "hash": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-    "metrics": {
-     "hash": "4a1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-     "storageAddress": "https://toto/objective/222/metrics"
-    }
-   },
    "outModel": {
     "hash": "eedbb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482eed",
     "storageAddress": "https://substrabac/model/toto"
@@ -1478,7 +1430,6 @@ Smart contract: `createComputePlan`
 ##### JSON Inputs:
 ```go
 {
- "objectiveKey": string (required,len=64,hexadecimal),
  "traintuples": (omitempty) [{
    "dataManagerKey": string (required,len=64,hexadecimal),
    "dataSampleKeys": [string] (required,dive,len=64,hexadecimal),
@@ -1512,6 +1463,7 @@ Smart contract: `createComputePlan`
  "testtuples": (omitempty) [{
    "dataManagerKey": string (omitempty,len=64,hexadecimal),
    "dataSampleKeys": [string] (omitempty,dive,len=64,hexadecimal),
+   "objectiveKey": string (required,len=64,hexadecimal),
    "tag": string (omitempty,lte=64),
    "traintupleID": string (required,lte=64),
  }],
@@ -1519,7 +1471,7 @@ Smart contract: `createComputePlan`
 ```
 ##### Command peer example:
 ```bash
-peer chaincode invoke -n mycc -c '{"Args":["createComputePlan","{\"objectiveKey\":\"5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379\",\"traintuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"firstTraintupleID\",\"inModelsIDs\":null,\"tag\":\"\"},{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"secondTraintupleID\",\"inModelsIDs\":[\"firstTraintupleID\"],\"tag\":\"\"}],\"aggregatetuples\":null,\"compositeTraintuples\":null,\"testtuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"bb1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"bb2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"tag\":\"\",\"traintupleID\":\"secondTraintupleID\"}]}"]}' -C myc
+peer chaincode invoke -n mycc -c '{"Args":["createComputePlan","{\"traintuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"firstTraintupleID\",\"inModelsIDs\":null,\"tag\":\"\"},{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"secondTraintupleID\",\"inModelsIDs\":[\"firstTraintupleID\"],\"tag\":\"\"}],\"aggregatetuples\":null,\"compositeTraintuples\":null,\"testtuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"bb1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"bb2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"objectiveKey\":\"5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379\",\"tag\":\"\",\"traintupleID\":\"secondTraintupleID\"}]}"]}' -C myc
 ```
 ##### Command output:
 ```json
@@ -1527,7 +1479,6 @@ peer chaincode invoke -n mycc -c '{"Args":["createComputePlan","{\"objectiveKey\
  "aggregatetupleKeys": null,
  "compositeTraintupleKeys": null,
  "computePlanID": "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
- "objectiveKey": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
  "testtupleKeys": [
   "1dbd49d84e00ad6f339f416af0decfaf2db8f14412786de65b597e49a6820f96"
  ],
@@ -1616,7 +1567,6 @@ peer chaincode invoke -n mycc -c '{"Args":["queryComputePlan","{\"key\":\"432fcf
  "aggregatetupleKeys": [],
  "compositeTraintupleKeys": [],
  "computePlanID": "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
- "objectiveKey": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
  "testtupleKeys": [
   "1dbd49d84e00ad6f339f416af0decfaf2db8f14412786de65b597e49a6820f96"
  ],
@@ -1637,7 +1587,6 @@ peer chaincode invoke -n mycc -c '{"Args":["queryComputePlans"]}' -C myc
   "aggregatetupleKeys": [],
   "compositeTraintupleKeys": [],
   "computePlanID": "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
-  "objectiveKey": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
   "testtupleKeys": [
    "1dbd49d84e00ad6f339f416af0decfaf2db8f14412786de65b597e49a6820f96"
   ],

--- a/chaincode/compute_plan.go
+++ b/chaincode/compute_plan.go
@@ -93,6 +93,7 @@ func (inpTesttuple *inputTesttuple) Fill(inpCP inputComputePlanTesttuple, traint
 	inpTesttuple.DataManagerKey = inpCP.DataManagerKey
 	inpTesttuple.DataSampleKeys = inpCP.DataSampleKeys
 	inpTesttuple.Tag = inpCP.Tag
+	inpTesttuple.ObjectiveKey = inpCP.ObjectiveKey
 
 	return nil
 }
@@ -110,7 +111,6 @@ func createComputePlan(db *LedgerDB, args []string) (resp outputComputePlan, err
 func createComputePlanInternal(db *LedgerDB, inp inputComputePlan) (resp outputComputePlan, err error) {
 	traintupleKeysByID := map[string]string{}
 
-	resp.ObjectiveKey = inp.ObjectiveKey
 	resp.TraintupleKeys = []string{}
 
 	DAG, err := createComputeDAG(inp)
@@ -122,8 +122,7 @@ func createComputePlanInternal(db *LedgerDB, inp inputComputePlan) (resp outputC
 		case TraintupleType:
 			computeTraintuple := inp.Traintuples[task.InputIndex]
 			inpTraintuple := inputTraintuple{
-				Rank:         strconv.Itoa(i),
-				ObjectiveKey: inp.ObjectiveKey,
+				Rank: strconv.Itoa(i),
 			}
 			if i != 0 {
 				inpTraintuple.ComputePlanID = resp.ComputePlanID
@@ -149,8 +148,7 @@ func createComputePlanInternal(db *LedgerDB, inp inputComputePlan) (resp outputC
 		case CompositeTraintupleType:
 			computeCompositeTraintuple := inp.CompositeTraintuples[task.InputIndex]
 			inpCompositeTraintuple := inputCompositeTraintuple{
-				Rank:         strconv.Itoa(i),
-				ObjectiveKey: inp.ObjectiveKey,
+				Rank: strconv.Itoa(i),
 			}
 			if i != 0 {
 				inpCompositeTraintuple.ComputePlanID = resp.ComputePlanID
@@ -176,8 +174,7 @@ func createComputePlanInternal(db *LedgerDB, inp inputComputePlan) (resp outputC
 		case AggregatetupleType:
 			computeAggregatetuple := inp.Aggregatetuples[task.InputIndex]
 			inpAggregatetuple := inputAggregatetuple{
-				Rank:         strconv.Itoa(i),
-				ObjectiveKey: inp.ObjectiveKey,
+				Rank: strconv.Itoa(i),
 			}
 			if i != 0 {
 				inpAggregatetuple.ComputePlanID = resp.ComputePlanID
@@ -313,7 +310,6 @@ func getComputePlan(db *LedgerDB, key string) (resp outputComputePlan, err error
 
 	resp = outputComputePlan{
 		ComputePlanID:           key,
-		ObjectiveKey:            objectiveKey,
 		TraintupleKeys:          traintupleKeys,
 		CompositeTraintupleKeys: compositeTraintupleKeys,
 		AggregatetupleKeys:      aggregatetupleKeys,

--- a/chaincode/compute_plan.go
+++ b/chaincode/compute_plan.go
@@ -259,16 +259,12 @@ func getComputePlan(db *LedgerDB, key string) (resp outputComputePlan, err error
 		err = errors.E("No traintuple found for compute plan %s", key)
 		return
 	}
-	objectiveKey := ""
 	tuples := map[string]GenericTuple{}
 	for _, tupleKey := range tupleKeys {
 		var tuple GenericTuple
 		tuple, err = db.GetGenericTuple(tupleKey)
 		if err != nil {
 			return
-		}
-		if objectiveKey == "" {
-			objectiveKey = tuple.ObjectiveKey
 		}
 		tuples[tupleKey] = tuple
 	}

--- a/chaincode/compute_plan_test.go
+++ b/chaincode/compute_plan_test.go
@@ -23,7 +23,6 @@ import (
 
 var (
 	defaultComputePlan = inputComputePlan{
-		ObjectiveKey: objectiveDescriptionHash,
 		Traintuples: []inputComputePlanTraintuple{
 			inputComputePlanTraintuple{
 				DataManagerKey: dataManagerOpenerHash,
@@ -43,6 +42,7 @@ var (
 			inputComputePlanTesttuple{
 				DataManagerKey: dataManagerOpenerHash,
 				DataSampleKeys: []string{testDataSampleHash1, testDataSampleHash2},
+				ObjectiveKey:   objectiveDescriptionHash,
 				TraintupleID:   traintupleID2,
 			},
 		},
@@ -78,7 +78,6 @@ var (
 	//
 	//
 	modelCompositionComputePlan = inputComputePlan{
-		ObjectiveKey: objectiveDescriptionHash,
 		CompositeTraintuples: []inputComputePlanCompositeTraintuple{
 			{
 				ID:             "step_1_composite_A",
@@ -124,26 +123,31 @@ var (
 			inputComputePlanTesttuple{
 				DataManagerKey: dataManagerOpenerHash,
 				DataSampleKeys: []string{testDataSampleHash1, testDataSampleHash2},
+				ObjectiveKey:   objectiveDescriptionHash,
 				TraintupleID:   "step_1_composite_A",
 			},
 			inputComputePlanTesttuple{
 				DataManagerKey: dataManagerOpenerHash,
 				DataSampleKeys: []string{testDataSampleHash1, testDataSampleHash2},
+				ObjectiveKey:   objectiveDescriptionHash,
 				TraintupleID:   "step_1_composite_B",
 			},
 			inputComputePlanTesttuple{
 				DataManagerKey: dataManagerOpenerHash,
 				DataSampleKeys: []string{testDataSampleHash1, testDataSampleHash2},
+				ObjectiveKey:   objectiveDescriptionHash,
 				TraintupleID:   "step_2_aggregate",
 			},
 			inputComputePlanTesttuple{
 				DataManagerKey: dataManagerOpenerHash,
 				DataSampleKeys: []string{testDataSampleHash1, testDataSampleHash2},
+				ObjectiveKey:   objectiveDescriptionHash,
 				TraintupleID:   "step_3_composite_A",
 			},
 			inputComputePlanTesttuple{
 				DataManagerKey: dataManagerOpenerHash,
 				DataSampleKeys: []string{testDataSampleHash1, testDataSampleHash2},
+				ObjectiveKey:   objectiveDescriptionHash,
 				TraintupleID:   "step_3_composite_B",
 			},
 		},
@@ -225,7 +229,6 @@ func TestCreateComputePlanCompositeAggregate(t *testing.T) {
 	tag := []string{"compositeTraintuple1", "compositeTraintuple2", "aggregatetuple1", "aggregatetuple2"}
 
 	inCP := inputComputePlan{
-		ObjectiveKey: objectiveDescriptionHash,
 		CompositeTraintuples: []inputComputePlanCompositeTraintuple{
 			{
 				DataManagerKey: dataManagerOpenerHash,
@@ -384,14 +387,10 @@ func TestQueryComputePlans(t *testing.T) {
 }
 
 func validateDefaultComputePlan(t *testing.T, cp outputComputePlan) {
-	in := defaultComputePlan
 	assert.Len(t, cp.TraintupleKeys, 2)
 	cpID := cp.TraintupleKeys[0]
 
-	assert.Equal(t, in.ObjectiveKey, cp.ObjectiveKey)
-
 	assert.Equal(t, cpID, cp.ComputePlanID)
-	assert.Equal(t, in.ObjectiveKey, cp.ObjectiveKey)
 
 	assert.NotEmpty(t, cp.TraintupleKeys[0])
 	assert.NotEmpty(t, cp.TraintupleKeys[1])
@@ -409,7 +408,6 @@ func TestComputePlanEmptyTesttuples(t *testing.T) {
 	db := NewLedgerDB(mockStub)
 
 	inCP := inputComputePlan{
-		ObjectiveKey: objectiveDescriptionHash,
 		Traintuples: []inputComputePlanTraintuple{
 			inputComputePlanTraintuple{
 				DataManagerKey: dataManagerOpenerHash,

--- a/chaincode/input.go
+++ b/chaincode/input.go
@@ -115,7 +115,6 @@ type inputHash struct {
 type inputLogSuccessTrain struct {
 	inputLog
 	OutModel inputHashDress `validate:"required" json:"outModel"`
-	Perf     float32        `validate:"omitempty" json:"perf"`
 }
 type inputLogSuccessTest struct {
 	inputLog

--- a/chaincode/input.go
+++ b/chaincode/input.go
@@ -91,7 +91,6 @@ type inputUpdateDataSample struct {
 // inputTraintuple is the representation of input args to register a Traintuple
 type inputTraintuple struct {
 	AlgoKey        string   `validate:"required,len=64,hexadecimal" json:"algoKey"`
-	ObjectiveKey   string   `validate:"required,len=64,hexadecimal" json:"objectiveKey"`
 	InModels       []string `validate:"omitempty,dive,len=64,hexadecimal" json:"inModels"`
 	DataManagerKey string   `validate:"required,len=64,hexadecimal" json:"dataManagerKey"`
 	DataSampleKeys []string `validate:"required,unique,gt=0,dive,len=64,hexadecimal" json:"dataSampleKeys"`
@@ -102,10 +101,11 @@ type inputTraintuple struct {
 
 // inputTestuple is the representation of input args to register a Testtuple
 type inputTesttuple struct {
-	TraintupleKey  string   `validate:"required,len=64,hexadecimal" json:"traintupleKey"`
 	DataManagerKey string   `validate:"omitempty,len=64,hexadecimal" json:"dataManagerKey"`
 	DataSampleKeys []string `validate:"omitempty,dive,len=64,hexadecimal" json:"dataSampleKeys"`
+	ObjectiveKey   string   `validate:"required,len=64,hexadecimal" json:"objectiveKey"`
 	Tag            string   `validate:"omitempty,lte=64" json:"tag"`
+	TraintupleKey  string   `validate:"required,len=64,hexadecimal" json:"traintupleKey"`
 }
 
 type inputHash struct {
@@ -148,7 +148,6 @@ type inputQueryFilter struct {
 // Beware, it's order sensitive since the `InModelsIDs` can only be interpreted
 // if the training tasks matching those IDs have already been created.
 type inputComputePlan struct {
-	ObjectiveKey         string                                `validate:"required,len=64,hexadecimal" json:"objectiveKey"`
 	Traintuples          []inputComputePlanTraintuple          `validate:"omitempty" json:"traintuples"`
 	Aggregatetuples      []inputComputePlanAggregatetuple      `validate:"omitempty" json:"aggregatetuples"`
 	CompositeTraintuples []inputComputePlanCompositeTraintuple `validate:"omitempty" json:"compositeTraintuples"`
@@ -186,6 +185,7 @@ type inputComputePlanCompositeTraintuple struct {
 type inputComputePlanTesttuple struct {
 	DataManagerKey string   `validate:"omitempty,len=64,hexadecimal" json:"dataManagerKey"`
 	DataSampleKeys []string `validate:"omitempty,dive,len=64,hexadecimal" json:"dataSampleKeys"`
+	ObjectiveKey   string   `validate:"required,len=64,hexadecimal" json:"objectiveKey"`
 	Tag            string   `validate:"omitempty,lte=64" json:"tag"`
 	TraintupleID   string   `validate:"required,lte=64" json:"traintupleID"`
 }

--- a/chaincode/input_aggregate.go
+++ b/chaincode/input_aggregate.go
@@ -17,7 +17,6 @@ package main
 // inputAggregatetuple is the representation of input args to register an aggregate Tuple
 type inputAggregatetuple struct {
 	AlgoKey       string   `validate:"required,len=64,hexadecimal" json:"algoKey"`
-	ObjectiveKey  string   `validate:"required,len=64,hexadecimal" json:"objectiveKey"`
 	InModels      []string `validate:"omitempty,dive,len=64,hexadecimal" json:"inModels"`
 	ComputePlanID string   `validate:"omitempty" json:"computePlanID"`
 	Rank          string   `validate:"omitempty" json:"rank"`

--- a/chaincode/input_composite.go
+++ b/chaincode/input_composite.go
@@ -17,7 +17,6 @@ package main
 // inputCompositeTraintuple is the representation of input args to register a composite Traintuple
 type inputCompositeTraintuple struct {
 	AlgoKey                  string           `validate:"required,len=64,hexadecimal" json:"algoKey"`
-	ObjectiveKey             string           `validate:"required,len=64,hexadecimal" json:"objectiveKey"`
 	InHeadModelKey           string           `validate:"required_with=InTrunkModelKey,omitempty,len=64,hexadecimal" json:"inHeadModelKey"`
 	InTrunkModelKey          string           `validate:"required_with=InHeadModelKey,omitempty,len=64,hexadecimal" json:"inTrunkModelKey"`
 	OutTrunkModelPermissions inputPermissions `validate:"required" json:"OutTrunkModelPermissions"`

--- a/chaincode/input_composite.go
+++ b/chaincode/input_composite.go
@@ -35,5 +35,4 @@ type inputLogSuccessCompositeTrain struct {
 	inputLog
 	OutHeadModel  inputHashDress `validate:"required" json:"outHeadModel"`
 	OutTrunkModel inputHashDress `validate:"required" json:"outTrunkModel"`
-	Perf          float32        `validate:"omitempty" json:"perf"`
 }

--- a/chaincode/input_test.go
+++ b/chaincode/input_test.go
@@ -165,9 +165,6 @@ func (traintuple *inputTraintuple) createDefault() [][]byte {
 	if traintuple.InModels == nil {
 		traintuple.InModels = []string{}
 	}
-	if traintuple.ObjectiveKey == "" {
-		traintuple.ObjectiveKey = objectiveDescriptionHash
-	}
 	if traintuple.DataManagerKey == "" {
 		traintuple.DataManagerKey = dataManagerOpenerHash
 	}
@@ -186,9 +183,6 @@ func (traintuple *inputCompositeTraintuple) createDefault() [][]byte {
 func (traintuple *inputCompositeTraintuple) fillDefaults() {
 	if traintuple.AlgoKey == "" {
 		traintuple.AlgoKey = compositeAlgoHash
-	}
-	if traintuple.ObjectiveKey == "" {
-		traintuple.ObjectiveKey = objectiveDescriptionHash
 	}
 	if traintuple.DataManagerKey == "" {
 		traintuple.DataManagerKey = dataManagerOpenerHash
@@ -212,9 +206,6 @@ func (aggregatetuple *inputAggregatetuple) createDefault() [][]byte {
 func (aggregatetuple *inputAggregatetuple) fillDefaults() {
 	if aggregatetuple.AlgoKey == "" {
 		aggregatetuple.AlgoKey = aggregateAlgoHash
-	}
-	if aggregatetuple.ObjectiveKey == "" {
-		aggregatetuple.ObjectiveKey = objectiveDescriptionHash
 	}
 	if aggregatetuple.Worker == "" {
 		aggregatetuple.Worker = worker
@@ -343,6 +334,9 @@ func (testtuple *inputTesttuple) createDefault() [][]byte {
 func (testtuple *inputTesttuple) fillDefaults() {
 	if testtuple.TraintupleKey == "" {
 		testtuple.TraintupleKey = traintupleKey
+	}
+	if testtuple.ObjectiveKey == "" {
+		testtuple.ObjectiveKey = objectiveDescriptionHash
 	}
 }
 

--- a/chaincode/input_test.go
+++ b/chaincode/input_test.go
@@ -229,9 +229,6 @@ func (success *inputLogSuccessTrain) fillDefaults() {
 	if success.Log == "" {
 		success.Log = "no error, ah ah ah"
 	}
-	if success.Perf == 0 {
-		success.Perf = 0.9
-	}
 	if success.OutModel.Hash == "" {
 		success.OutModel.Hash = modelHash
 	}
@@ -255,9 +252,6 @@ func (success *inputLogSuccessCompositeTrain) fillDefaults() {
 	}
 	if success.Log == "" {
 		success.Log = "no error, ah ah ah"
-	}
-	if success.Perf == 0 {
-		success.Perf = 0.9
 	}
 	if success.OutHeadModel.Hash == "" {
 		success.OutHeadModel.Hash = headModelHash

--- a/chaincode/ledger.go
+++ b/chaincode/ledger.go
@@ -93,7 +93,6 @@ type AggregateAlgo struct {
 // AggregateTuple
 type GenericTuple struct {
 	AssetType     AssetType `json:"assetType"`
-	ObjectiveKey  string    `json:"objectiveKey"`
 	AlgoKey       string    `json:"algoKey"`
 	ComputePlanID string    `json:"computePlanID"`
 	Creator       string    `json:"creator"`

--- a/chaincode/ledger.go
+++ b/chaincode/ledger.go
@@ -115,7 +115,6 @@ type Traintuple struct {
 	Dataset       *Dataset    `json:"dataset"`
 	InModelKeys   []string    `json:"inModels"`
 	OutModel      *HashDress  `json:"outModel"`
-	Perf          float32     `json:"perf"`
 	Permissions   Permissions `json:"permissions"`
 }
 
@@ -134,7 +133,6 @@ type CompositeTraintuple struct {
 	InTrunkModel  string                      `json:"inTrunkModel"`
 	OutHeadModel  CompositeTraintupleOutModel `json:"outHeadModel"`
 	OutTrunkModel CompositeTraintupleOutModel `json:"outTrunkModel"`
-	Perf          float32                     `json:"perf"`
 }
 
 // Aggregatetuple is like a traintuple, but for aggregate model composition

--- a/chaincode/ledger.go
+++ b/chaincode/ledger.go
@@ -161,17 +161,19 @@ type CompositeTraintupleOutModel struct {
 
 // Testtuple is the representation of one the element type stored in the ledger. It describes a training task occuring on the platform
 type Testtuple struct {
-	AssetType     AssetType   `json:"assetType"`
 	AlgoKey       string      `json:"algo"`
+	AssetType     AssetType   `json:"assetType"`
 	Certified     bool        `json:"certified"`
+	ComputePlanID string      `json:"computePlanID"`
 	Creator       string      `json:"creator"`
 	Dataset       *TtDataset  `json:"dataset"`
 	Log           string      `json:"log"`
-	TraintupleKey string      `json:"traintupleKey"`
 	ObjectiveKey  string      `json:"objective"`
 	Permissions   Permissions `json:"permissions"`
+	Rank          int         `json:"rank"`
 	Status        string      `json:"status"`
 	Tag           string      `json:"tag"`
+	TraintupleKey string      `json:"traintupleKey"`
 }
 
 // ---------------------------------------------------------------------------------

--- a/chaincode/ledger.go
+++ b/chaincode/ledger.go
@@ -106,7 +106,6 @@ type GenericTuple struct {
 // Traintuple is the representation of one the element type stored in the ledger. It describes a training task occuring on the platform
 type Traintuple struct {
 	AssetType     AssetType   `json:"assetType"`
-	ObjectiveKey  string      `json:"objectiveKey"`
 	AlgoKey       string      `json:"algoKey"`
 	ComputePlanID string      `json:"computePlanID"`
 	Creator       string      `json:"creator"`
@@ -124,7 +123,6 @@ type Traintuple struct {
 // CompositeTraintuple is like a traintuple, but for composite model composition
 type CompositeTraintuple struct {
 	AssetType     AssetType                   `json:"assetType"`
-	ObjectiveKey  string                      `json:"objectiveKey"`
 	AlgoKey       string                      `json:"algoKey"`
 	ComputePlanID string                      `json:"computePlanID"`
 	Creator       string                      `json:"creator"`
@@ -143,7 +141,6 @@ type CompositeTraintuple struct {
 // Aggregatetuple is like a traintuple, but for aggregate model composition
 type Aggregatetuple struct {
 	AssetType     AssetType   `json:"assetType"`
-	ObjectiveKey  string      `json:"objectiveKey"`
 	AlgoKey       string      `json:"algoKey"`
 	ComputePlanID string      `json:"computePlanID"`
 	Creator       string      `json:"creator"`

--- a/chaincode/objective_test.go
+++ b/chaincode/objective_test.go
@@ -32,6 +32,7 @@ func TestLeaderBoard(t *testing.T) {
 	// Add a certified testtuple
 	inputTest := inputTesttuple{
 		TraintupleKey: traintupleKey,
+		ObjectiveKey:  objectiveDescriptionHash,
 	}
 	keyMap, err := createTesttuple(db, assetToArgs(inputTest))
 	assert.NoError(t, err)

--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -108,13 +108,20 @@ func (out *outputAlgo) Fill(key string, in Algo) {
 	out.Permissions.Fill(in.Permissions)
 }
 
+// outputTtDataset is the representation of a Traintuple Dataset
+type outputTtDataset struct {
+	Worker         string   `json:"worker"`
+	DataSampleKeys []string `json:"keys"`
+	OpenerHash     string   `json:"openerHash"`
+}
+
 // outputTraintuple is the representation of one the element type stored in the
 // ledger. It describes a training task occuring on the platform
 type outputTraintuple struct {
 	Key           string            `json:"key"`
 	Algo          *HashDressName    `json:"algo"`
 	Creator       string            `json:"creator"`
-	Dataset       *TtDataset        `json:"dataset"`
+	Dataset       *outputTtDataset  `json:"dataset"`
 	ComputePlanID string            `json:"computePlanID"`
 	InModels      []*Model          `json:"inModels"`
 	Log           string            `json:"log"`
@@ -168,11 +175,10 @@ func (outputTraintuple *outputTraintuple) Fill(db *LedgerDB, traintuple Traintup
 	}
 
 	// fill dataset
-	outputTraintuple.Dataset = &TtDataset{
+	outputTraintuple.Dataset = &outputTtDataset{
 		Worker:         traintuple.Dataset.Worker,
 		DataSampleKeys: traintuple.Dataset.DataSampleKeys,
 		OpenerHash:     traintuple.Dataset.DataManagerKey,
-		Perf:           traintuple.Perf,
 	}
 
 	return

--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -179,28 +179,32 @@ func (outputTraintuple *outputTraintuple) Fill(db *LedgerDB, traintuple Traintup
 }
 
 type outputTesttuple struct {
-	Key            string         `json:"key"`
 	Algo           *HashDressName `json:"algo"`
 	Certified      bool           `json:"certified"`
+	ComputePlanID  string         `json:"computePlanID"`
 	Creator        string         `json:"creator"`
 	Dataset        *TtDataset     `json:"dataset"`
+	Key            string         `json:"key"`
 	Log            string         `json:"log"`
-	TraintupleType string         `json:"traintupleType"`
-	TraintupleKey  string         `json:"traintupleKey"`
 	Objective      *TtObjective   `json:"objective"`
+	Rank           int            `json:"rank"`
 	Status         string         `json:"status"`
 	Tag            string         `json:"tag"`
+	TraintupleKey  string         `json:"traintupleKey"`
+	TraintupleType string         `json:"traintupleType"`
 }
 
 func (out *outputTesttuple) Fill(db *LedgerDB, key string, in Testtuple) error {
-	out.Key = key
 	out.Certified = in.Certified
+	out.ComputePlanID = in.ComputePlanID
 	out.Creator = in.Creator
 	out.Dataset = in.Dataset
+	out.Key = key
 	out.Log = in.Log
-	out.TraintupleKey = in.TraintupleKey
+	out.Rank = in.Rank
 	out.Status = in.Status
 	out.Tag = in.Tag
+	out.TraintupleKey = in.TraintupleKey
 
 	// fill type
 	traintupleType, err := db.GetAssetType(in.TraintupleKey)

--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -118,7 +118,6 @@ type outputTraintuple struct {
 	ComputePlanID string            `json:"computePlanID"`
 	InModels      []*Model          `json:"inModels"`
 	Log           string            `json:"log"`
-	Objective     *TtObjective      `json:"objective"`
 	OutModel      *HashDress        `json:"outModel"`
 	Permissions   outputPermissions `json:"permissions"`
 	Rank          int               `json:"rank"`
@@ -148,25 +147,6 @@ func (outputTraintuple *outputTraintuple) Fill(db *LedgerDB, traintuple Traintup
 		Name:           algo.Name,
 		Hash:           traintuple.AlgoKey,
 		StorageAddress: algo.StorageAddress}
-
-	// fill objective
-	objective, err := db.GetObjective(traintuple.ObjectiveKey)
-	if err != nil {
-		err = fmt.Errorf("could not retrieve associated objective with key %s- %s", traintuple.ObjectiveKey, err.Error())
-		return
-	}
-	if objective.Metrics == nil {
-		err = fmt.Errorf("objective %s is missing metrics values", traintuple.ObjectiveKey)
-		return
-	}
-	metrics := HashDress{
-		Hash:           objective.Metrics.Hash,
-		StorageAddress: objective.Metrics.StorageAddress,
-	}
-	outputTraintuple.Objective = &TtObjective{
-		Key:     traintuple.ObjectiveKey,
-		Metrics: &metrics,
-	}
 
 	// fill inModels
 	for _, inModelKey := range traintuple.InModelKeys {
@@ -299,7 +279,6 @@ type TuplesEvent struct {
 
 type outputComputePlan struct {
 	ComputePlanID           string   `json:"computePlanID"`
-	ObjectiveKey            string   `json:"objectiveKey"`
 	TraintupleKeys          []string `json:"traintupleKeys"`
 	AggregatetupleKeys      []string `json:"aggregatetupleKeys"`
 	CompositeTraintupleKeys []string `json:"compositeTraintupleKeys"`

--- a/chaincode/output_aggregate.go
+++ b/chaincode/output_aggregate.go
@@ -22,7 +22,6 @@ type outputAggregatetuple struct {
 	Creator       string            `json:"creator"`
 	ComputePlanID string            `json:"computePlanID"`
 	Log           string            `json:"log"`
-	Objective     *TtObjective      `json:"objective"`
 	InModels      []*Model          `json:"inModels"`
 	OutModel      *HashDress        `json:"outModel"`
 	Rank          int               `json:"rank"`
@@ -59,25 +58,6 @@ func (outputAggregatetuple *outputAggregatetuple) Fill(db *LedgerDB, traintuple 
 		Name:           algo.Name,
 		Hash:           traintuple.AlgoKey,
 		StorageAddress: algo.StorageAddress}
-
-	// fill objective
-	objective, err := db.GetObjective(traintuple.ObjectiveKey)
-	if err != nil {
-		err = fmt.Errorf("could not retrieve associated objective with key %s- %s", traintuple.ObjectiveKey, err.Error())
-		return
-	}
-	if objective.Metrics == nil {
-		err = fmt.Errorf("objective %s is missing metrics values", traintuple.ObjectiveKey)
-		return
-	}
-	metrics := HashDress{
-		Hash:           objective.Metrics.Hash,
-		StorageAddress: objective.Metrics.StorageAddress,
-	}
-	outputAggregatetuple.Objective = &TtObjective{
-		Key:     traintuple.ObjectiveKey,
-		Metrics: &metrics,
-	}
 
 	// fill inModels
 	for _, inModelKey := range traintuple.InModelKeys {

--- a/chaincode/output_composite.go
+++ b/chaincode/output_composite.go
@@ -26,7 +26,7 @@ type outputCompositeTraintuple struct {
 	Key           string            `json:"key"`
 	Algo          *HashDressName    `json:"algo"`
 	Creator       string            `json:"creator"`
-	Dataset       *TtDataset        `json:"dataset"`
+	Dataset       *outputTtDataset  `json:"dataset"`
 	ComputePlanID string            `json:"computePlanID"`
 	InHeadModel   *Model            `json:"inHeadModel"`
 	InTrunkModel  *Model            `json:"inTrunkModel"`
@@ -108,11 +108,10 @@ func (outputCompositeTraintuple *outputCompositeTraintuple) Fill(db *LedgerDB, t
 	}
 
 	// fill dataset
-	outputCompositeTraintuple.Dataset = &TtDataset{
+	outputCompositeTraintuple.Dataset = &outputTtDataset{
 		Worker:         traintuple.Dataset.Worker,
 		DataSampleKeys: traintuple.Dataset.DataSampleKeys,
 		OpenerHash:     traintuple.Dataset.DataManagerKey,
-		Perf:           traintuple.Perf,
 	}
 
 	return

--- a/chaincode/output_composite.go
+++ b/chaincode/output_composite.go
@@ -31,7 +31,6 @@ type outputCompositeTraintuple struct {
 	InHeadModel   *Model            `json:"inHeadModel"`
 	InTrunkModel  *Model            `json:"inTrunkModel"`
 	Log           string            `json:"log"`
-	Objective     *TtObjective      `json:"objective"`
 	OutHeadModel  outModelComposite `json:"outHeadModel"`
 	OutTrunkModel outModelComposite `json:"outTrunkModel"`
 	Rank          int               `json:"rank"`
@@ -70,25 +69,6 @@ func (outputCompositeTraintuple *outputCompositeTraintuple) Fill(db *LedgerDB, t
 		Name:           algo.Name,
 		Hash:           traintuple.AlgoKey,
 		StorageAddress: algo.StorageAddress}
-
-	// fill objective
-	objective, err := db.GetObjective(traintuple.ObjectiveKey)
-	if err != nil {
-		err = fmt.Errorf("could not retrieve associated objective with key %s- %s", traintuple.ObjectiveKey, err.Error())
-		return
-	}
-	if objective.Metrics == nil {
-		err = fmt.Errorf("objective %s is missing metrics values", traintuple.ObjectiveKey)
-		return
-	}
-	metrics := HashDress{
-		Hash:           objective.Metrics.Hash,
-		StorageAddress: objective.Metrics.StorageAddress,
-	}
-	outputCompositeTraintuple.Objective = &TtObjective{
-		Key:     traintuple.ObjectiveKey,
-		Metrics: &metrics,
-	}
 
 	// fill in-model (head)
 	if traintuple.InHeadModel != "" {

--- a/chaincode/testtuple.go
+++ b/chaincode/testtuple.go
@@ -44,10 +44,11 @@ func (testtuple *Testtuple) SetFromInput(db *LedgerDB, inp inputTesttuple) error
 	testtuple.AssetType = TesttupleType
 
 	// Get test dataset from objective
-	objective, err := db.GetObjective(testtuple.ObjectiveKey)
+	objective, err := db.GetObjective(inp.ObjectiveKey)
 	if err != nil {
-		return errors.BadRequest(err, "could not retrieve objective with key %s", testtuple.ObjectiveKey)
+		return errors.BadRequest(err, "could not retrieve objective with key %s", inp.ObjectiveKey)
 	}
+	testtuple.ObjectiveKey = inp.ObjectiveKey
 	var objectiveDataManagerKey string
 	var objectiveDataSampleKeys []string
 	if objective.TestDataset != nil {
@@ -123,7 +124,6 @@ func (testtuple *Testtuple) SetFromTraintuple(db *LedgerDB, traintupleKey string
 		permissions = traintuple.Permissions
 		tupleCreator = traintuple.Creator
 		status = traintuple.Status
-		testtuple.ObjectiveKey = traintuple.ObjectiveKey
 		testtuple.AlgoKey = traintuple.AlgoKey
 	case CompositeTraintupleType:
 		compositeTraintuple, err := db.GetCompositeTraintuple(traintupleKey)
@@ -133,7 +133,6 @@ func (testtuple *Testtuple) SetFromTraintuple(db *LedgerDB, traintupleKey string
 		permissions = compositeTraintuple.OutHeadModel.Permissions
 		tupleCreator = compositeTraintuple.Creator
 		status = compositeTraintuple.Status
-		testtuple.ObjectiveKey = compositeTraintuple.ObjectiveKey
 		testtuple.AlgoKey = compositeTraintuple.AlgoKey
 	case AggregatetupleType:
 		tuple, err := db.GetAggregatetuple(traintupleKey)
@@ -143,7 +142,6 @@ func (testtuple *Testtuple) SetFromTraintuple(db *LedgerDB, traintupleKey string
 		permissions = tuple.Permissions
 		tupleCreator = tuple.Creator
 		status = tuple.Status
-		testtuple.ObjectiveKey = tuple.ObjectiveKey
 		testtuple.AlgoKey = tuple.AlgoKey
 	default:
 		return errors.BadRequest("key %s is not a valid traintuple", traintupleKey)

--- a/chaincode/testtuple.go
+++ b/chaincode/testtuple.go
@@ -125,6 +125,8 @@ func (testtuple *Testtuple) SetFromTraintuple(db *LedgerDB, traintupleKey string
 		tupleCreator = traintuple.Creator
 		status = traintuple.Status
 		testtuple.AlgoKey = traintuple.AlgoKey
+		testtuple.ComputePlanID = traintuple.ComputePlanID
+		testtuple.Rank = traintuple.Rank
 	case CompositeTraintupleType:
 		compositeTraintuple, err := db.GetCompositeTraintuple(traintupleKey)
 		if err != nil {
@@ -134,6 +136,8 @@ func (testtuple *Testtuple) SetFromTraintuple(db *LedgerDB, traintupleKey string
 		tupleCreator = compositeTraintuple.Creator
 		status = compositeTraintuple.Status
 		testtuple.AlgoKey = compositeTraintuple.AlgoKey
+		testtuple.ComputePlanID = compositeTraintuple.ComputePlanID
+		testtuple.Rank = compositeTraintuple.Rank
 	case AggregatetupleType:
 		tuple, err := db.GetAggregatetuple(traintupleKey)
 		if err != nil {
@@ -143,6 +147,8 @@ func (testtuple *Testtuple) SetFromTraintuple(db *LedgerDB, traintupleKey string
 		tupleCreator = tuple.Creator
 		status = tuple.Status
 		testtuple.AlgoKey = tuple.AlgoKey
+		testtuple.ComputePlanID = tuple.ComputePlanID
+		testtuple.Rank = tuple.Rank
 	default:
 		return errors.BadRequest("key %s is not a valid traintuple", traintupleKey)
 	}

--- a/chaincode/traintuple.go
+++ b/chaincode/traintuple.go
@@ -295,7 +295,6 @@ func logSuccessTrain(db *LedgerDB, args []string) (outputTraintuple outputTraint
 	if err != nil {
 		return
 	}
-	traintuple.Perf = inp.Perf
 	traintuple.OutModel = &HashDress{
 		Hash:           inp.OutModel.Hash,
 		StorageAddress: inp.OutModel.StorageAddress}

--- a/chaincode/traintuple.go
+++ b/chaincode/traintuple.go
@@ -52,16 +52,6 @@ func (traintuple *Traintuple) SetFromInput(db *LedgerDB, inp inputTraintuple) er
 	}
 	traintuple.AlgoKey = inp.AlgoKey
 
-	// check objective exists
-	objective, err := db.GetObjective(inp.ObjectiveKey)
-	if err != nil {
-		return errors.BadRequest(err, "could not retrieve objective with key %s", inp.ObjectiveKey)
-	}
-	if !objective.Permissions.CanProcess(objective.Owner, creator) {
-		return errors.Forbidden("not authorized to process objective %s", inp.ObjectiveKey)
-	}
-	traintuple.ObjectiveKey = inp.ObjectiveKey
-
 	// check if DataSampleKeys are from the same dataManager and if they are not test only dataSample
 	_, trainOnly, err := checkSameDataManager(db, inp.DataManagerKey, inp.DataSampleKeys)
 	if err != nil {

--- a/chaincode/traintuple_composite.go
+++ b/chaincode/traintuple_composite.go
@@ -328,7 +328,6 @@ func logSuccessCompositeTrain(db *LedgerDB, args []string) (outputTraintuple out
 	if err != nil {
 		return
 	}
-	traintuple.Perf = inp.Perf
 	traintuple.OutHeadModel.OutModel = &HashDress{
 		Hash:           inp.OutHeadModel.Hash,
 		StorageAddress: inp.OutHeadModel.StorageAddress}

--- a/chaincode/traintuple_composite.go
+++ b/chaincode/traintuple_composite.go
@@ -50,16 +50,6 @@ func (traintuple *CompositeTraintuple) SetFromInput(db *LedgerDB, inp inputCompo
 	}
 	traintuple.AlgoKey = inp.AlgoKey
 
-	// check objective exists
-	objective, err := db.GetObjective(inp.ObjectiveKey)
-	if err != nil {
-		return errors.BadRequest(err, "could not retrieve objective with key %s", inp.ObjectiveKey)
-	}
-	if !objective.Permissions.CanProcess(objective.Owner, creator) {
-		return errors.Forbidden("not authorized to process objective %s", inp.ObjectiveKey)
-	}
-	traintuple.ObjectiveKey = inp.ObjectiveKey
-
 	// check if DataSampleKeys are from the same dataManager and if they are not test only dataSample
 	_, trainOnly, err := checkSameDataManager(db, inp.DataManagerKey, inp.DataSampleKeys)
 	if err != nil {

--- a/chaincode/traintuple_composite_test.go
+++ b/chaincode/traintuple_composite_test.go
@@ -281,10 +281,9 @@ func TestTraintupleComposite(t *testing.T) {
 			StorageAddress: compositeAlgoStorageAddress,
 		},
 		Creator: worker,
-		Dataset: &TtDataset{
+		Dataset: &outputTtDataset{
 			DataSampleKeys: []string{trainDataSampleHash1, trainDataSampleHash2},
 			OpenerHash:     dataManagerOpenerHash,
-			Perf:           0.0,
 			Worker:         worker,
 		},
 		OutHeadModel: outModelComposite{
@@ -365,7 +364,6 @@ func TestTraintupleComposite(t *testing.T) {
 	assert.EqualValuesf(t, 200, resp.Status, "when querying composite traintuple with status %d and message %s", resp.Status, resp.Message)
 	endTraintuple := outputCompositeTraintuple{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &endTraintuple))
-	expected.Dataset.Perf = success.Perf
 	expected.Log = success.Log
 	expected.OutHeadModel.OutModel = &HashDress{
 		Hash:           headModelHash,

--- a/chaincode/traintuple_composite_test.go
+++ b/chaincode/traintuple_composite_test.go
@@ -49,7 +49,7 @@ func TestTraintupleWithNoTestDatasetComposite(t *testing.T) {
 	resp = mockStub.MockInvoke("42", args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
-	inpTraintuple := inputCompositeTraintuple{ObjectiveKey: objHash}
+	inpTraintuple := inputCompositeTraintuple{}
 	args = inpTraintuple.createDefault()
 	resp = mockStub.MockInvoke("42", args)
 
@@ -80,7 +80,6 @@ func TestTraintupleWithSingleDatasampleComposite(t *testing.T) {
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	inpTraintuple := inputCompositeTraintuple{
-		ObjectiveKey:   objHash,
 		AlgoKey:        compositeAlgoHash,
 		DataSampleKeys: []string{trainDataSampleHash1},
 	}
@@ -114,7 +113,6 @@ func TestTraintupleWithDuplicatedDatasamplesComposite(t *testing.T) {
 	assert.EqualValues(t, 200, resp.Status, "when adding composite algo it should work: ", resp.Message)
 
 	inpTraintuple := inputCompositeTraintuple{
-		ObjectiveKey:   objHash,
 		DataSampleKeys: []string{trainDataSampleHash1, trainDataSampleHash2, trainDataSampleHash1},
 	}
 	args = inpTraintuple.createDefault()
@@ -288,13 +286,6 @@ func TestTraintupleComposite(t *testing.T) {
 			OpenerHash:     dataManagerOpenerHash,
 			Perf:           0.0,
 			Worker:         worker,
-		},
-		Objective: &TtObjective{
-			Key: objectiveDescriptionHash,
-			Metrics: &HashDress{
-				Hash:           objectiveMetricsHash,
-				StorageAddress: objectiveMetricsStorageAddress,
-			},
 		},
 		OutHeadModel: outModelComposite{
 			Permissions: outputPermissions{
@@ -522,11 +513,11 @@ func TestCreateCompositeTraintupleInModels(t *testing.T) {
 			resp = mockStub.MockInvoke("42", args)
 			assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
-			inpTraintuple := inputCompositeTraintuple{ObjectiveKey: objHash}
+			inpTraintuple := inputCompositeTraintuple{}
 
 			if tt.withInHeadModel {
 				// create head traintuple
-				inpHeadTraintuple := inputCompositeTraintuple{ObjectiveKey: objHash}
+				inpHeadTraintuple := inputCompositeTraintuple{}
 				// make the traintuple unique so that it has a unique hash
 				inpHeadTraintuple.DataSampleKeys = []string{trainDataSampleHash1}
 				args = inpHeadTraintuple.createDefault()
@@ -540,7 +531,7 @@ func TestCreateCompositeTraintupleInModels(t *testing.T) {
 
 			if tt.withInTrunkModel {
 				// create trunk traintuple
-				inpTrunkTraintuple := inputCompositeTraintuple{ObjectiveKey: objHash}
+				inpTrunkTraintuple := inputCompositeTraintuple{}
 				// make the traintuple unique so that it has a unique hash
 				inpTrunkTraintuple.DataSampleKeys = []string{trainDataSampleHash2}
 				args = inpTrunkTraintuple.createDefault()
@@ -658,7 +649,7 @@ func TestCompositeTraintuplePermissions(t *testing.T) {
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
 	registerItem(t, *mockStub, "compositeAlgo")
 
-	inpTraintuple := inputCompositeTraintuple{ObjectiveKey: objectiveDescriptionHash}
+	inpTraintuple := inputCompositeTraintuple{}
 	inpTraintuple.fillDefaults()
 	// Grant trunk model permissions to no-one
 	inpTraintuple.OutTrunkModelPermissions = inputPermissions{Process: inputPermission{Public: false, AuthorizedIDs: []string{}}}

--- a/chaincode/traintuple_test.go
+++ b/chaincode/traintuple_test.go
@@ -41,7 +41,7 @@ func TestTraintupleWithNoTestDataset(t *testing.T) {
 	resp = mockStub.MockInvoke("42", args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
-	inpTraintuple := inputTraintuple{ObjectiveKey: objHash}
+	inpTraintuple := inputTraintuple{}
 	args = inpTraintuple.createDefault()
 	resp = mockStub.MockInvoke("42", args)
 	assert.EqualValues(t, 200, resp.Status, "when adding traintuple without test dataset it should work: ", resp.Message)
@@ -69,7 +69,6 @@ func TestTraintupleWithSingleDatasample(t *testing.T) {
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	inpTraintuple := inputTraintuple{
-		ObjectiveKey:   objHash,
 		DataSampleKeys: []string{trainDataSampleHash1},
 	}
 	args = inpTraintuple.createDefault()
@@ -102,7 +101,6 @@ func TestTraintupleWithDuplicatedDatasamples(t *testing.T) {
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	inpTraintuple := inputTraintuple{
-		ObjectiveKey:   objHash,
 		DataSampleKeys: []string{trainDataSampleHash1, trainDataSampleHash2, trainDataSampleHash1},
 	}
 	args = inpTraintuple.createDefault()
@@ -289,13 +287,6 @@ func TestTraintuple(t *testing.T) {
 			OpenerHash:     dataManagerOpenerHash,
 			Perf:           0.0,
 			Worker:         worker,
-		},
-		Objective: &TtObjective{
-			Key: objectiveDescriptionHash,
-			Metrics: &HashDress{
-				Hash:           objectiveMetricsHash,
-				StorageAddress: objectiveMetricsStorageAddress,
-			},
 		},
 		Permissions: outputPermissions{
 			Process: Permission{Public: true, AuthorizedIDs: []string{}},

--- a/chaincode/traintuple_test.go
+++ b/chaincode/traintuple_test.go
@@ -282,10 +282,9 @@ func TestTraintuple(t *testing.T) {
 			StorageAddress: algoStorageAddress,
 		},
 		Creator: worker,
-		Dataset: &TtDataset{
+		Dataset: &outputTtDataset{
 			DataSampleKeys: []string{trainDataSampleHash1, trainDataSampleHash2},
 			OpenerHash:     dataManagerOpenerHash,
-			Perf:           0.0,
 			Worker:         worker,
 		},
 		Permissions: outputPermissions{
@@ -359,7 +358,6 @@ func TestTraintuple(t *testing.T) {
 	assert.EqualValuesf(t, 200, resp.Status, "when querying traintuple with status %d and message %s", resp.Status, resp.Message)
 	endTraintuple := outputTraintuple{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &endTraintuple))
-	expected.Dataset.Perf = success.Perf
 	expected.Log = success.Log
 	expected.OutModel = &HashDress{
 		Hash:           modelHash,

--- a/chaincode/tuple_aggregate.go
+++ b/chaincode/tuple_aggregate.go
@@ -47,19 +47,7 @@ func (tuple *Aggregatetuple) SetFromInput(db *LedgerDB, inp inputAggregatetuple)
 		return errors.Forbidden("not authorized to process algo %s", inp.AlgoKey)
 	}
 	tuple.AlgoKey = inp.AlgoKey
-
-	// check objective exists
-	objective, err := db.GetObjective(inp.ObjectiveKey)
-	if err != nil {
-		return errors.BadRequest(err, "could not retrieve objective with key %s", inp.ObjectiveKey)
-	}
-	if !objective.Permissions.CanProcess(objective.Owner, creator) {
-		return errors.Forbidden("not authorized to process objective %s", inp.ObjectiveKey)
-	}
-
-	tuple.ObjectiveKey = inp.ObjectiveKey
 	tuple.Worker = inp.Worker
-
 	return nil
 }
 

--- a/chaincode/tuple_aggregate_test.go
+++ b/chaincode/tuple_aggregate_test.go
@@ -48,7 +48,7 @@ func TestTraintupleWithNoTestDatasetAggregate(t *testing.T) {
 	resp = mockStub.MockInvoke("42", args)
 	assert.EqualValues(t, 200, resp.Status, "when adding aggregate algo it should work: ", resp.Message)
 
-	inpTraintuple := inputAggregatetuple{ObjectiveKey: objHash}
+	inpTraintuple := inputAggregatetuple{}
 	args = inpTraintuple.createDefault()
 	resp = mockStub.MockInvoke("42", args)
 
@@ -79,8 +79,7 @@ func TestTraintupleWithSingleDatasampleAggregate(t *testing.T) {
 	assert.EqualValues(t, 200, resp.Status, "when adding aggregate algo it should work: ", resp.Message)
 
 	inpTraintuple := inputAggregatetuple{
-		ObjectiveKey: objHash,
-		AlgoKey:      aggregateAlgoHash,
+		AlgoKey: aggregateAlgoHash,
 	}
 	args = inpTraintuple.createDefault()
 	resp = mockStub.MockInvoke("42", args)
@@ -253,14 +252,7 @@ func TestTraintupleAggregate(t *testing.T) {
 		},
 		Creator: worker,
 		Worker:  worker,
-		Objective: &TtObjective{
-			Key: objectiveDescriptionHash,
-			Metrics: &HashDress{
-				Hash:           objectiveMetricsHash,
-				StorageAddress: objectiveMetricsStorageAddress,
-			},
-		},
-		Status: StatusTodo,
+		Status:  StatusTodo,
 		Permissions: outputPermissions{
 			Process: Permission{
 				Public:        true,
@@ -564,7 +556,4 @@ func TestQueryAggregatetuple(t *testing.T) {
 	assert.Equal(t, in.AlgoKey, out.Algo.Hash)
 	assert.Equal(t, aggregateAlgoStorageAddress, out.Algo.StorageAddress)
 	assert.Equal(t, StatusWaiting, out.Status)
-	assert.Equal(t, objectiveDescriptionHash, out.Objective.Key)
-	assert.Equal(t, objectiveMetricsHash, out.Objective.Metrics.Hash)
-	assert.Equal(t, objectiveMetricsStorageAddress, out.Objective.Metrics.StorageAddress)
 }

--- a/chaincode/tuple_test.go
+++ b/chaincode/tuple_test.go
@@ -40,7 +40,10 @@ func TestRecursiveLogFailed(t *testing.T) {
 	grandChildresp, err := createTraintuple(db, assetToArgs(grandChildtraintuple))
 	assert.NoError(t, err)
 
-	grandChildtesttuple := inputTesttuple{TraintupleKey: traintupleKey}
+	grandChildtesttuple := inputTesttuple{
+		TraintupleKey: traintupleKey,
+		ObjectiveKey:  objectiveDescriptionHash,
+	}
 	testResp, err := createTesttuple(db, assetToArgs(grandChildtesttuple))
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Companion PR: [backend](https://github.com/SubstraFoundation/substra-backend/pull/63)

- [x] Remove the relation between train/computeTrain/aggregate tuples & objective
- [x] Change the objective key in compute plan from a global one to one for each testtuple

See also: [Fail fast: calculate compute plan ranks from DAG depth ](https://github.com/SubstraFoundation/substra-chaincode/pull/51)

In this PR, two fields (`ComputePlanID` & `Rank`) have been added to the test tuples. They have the same values in the test tuple as the ones in the associated train/composite/aggregate tuple. Their purpose is mainly to help the front to filter test tuples by compute plan. 