### PR TITLE
calculate compute plan ranks from DAG depth

### DIFF
--- a/chaincode/compute_plan.go
+++ b/chaincode/compute_plan.go
@@ -122,7 +122,7 @@ func createComputePlanInternal(db *LedgerDB, inp inputComputePlan) (resp outputC
 		case TraintupleType:
 			computeTraintuple := inp.Traintuples[task.InputIndex]
 			inpTraintuple := inputTraintuple{
-				Rank: strconv.Itoa(i),
+				Rank: strconv.Itoa(task.Depth),
 			}
 			if i != 0 {
 				inpTraintuple.ComputePlanID = resp.ComputePlanID
@@ -148,7 +148,7 @@ func createComputePlanInternal(db *LedgerDB, inp inputComputePlan) (resp outputC
 		case CompositeTraintupleType:
 			computeCompositeTraintuple := inp.CompositeTraintuples[task.InputIndex]
 			inpCompositeTraintuple := inputCompositeTraintuple{
-				Rank: strconv.Itoa(i),
+				Rank: strconv.Itoa(task.Depth),
 			}
 			if i != 0 {
 				inpCompositeTraintuple.ComputePlanID = resp.ComputePlanID
@@ -174,7 +174,7 @@ func createComputePlanInternal(db *LedgerDB, inp inputComputePlan) (resp outputC
 		case AggregatetupleType:
 			computeAggregatetuple := inp.Aggregatetuples[task.InputIndex]
 			inpAggregatetuple := inputAggregatetuple{
-				Rank: strconv.Itoa(i),
+				Rank: strconv.Itoa(task.Depth),
 			}
 			if i != 0 {
 				inpAggregatetuple.ComputePlanID = resp.ComputePlanID

--- a/chaincode/compute_plan_dag.go
+++ b/chaincode/compute_plan_dag.go
@@ -59,17 +59,17 @@ func createComputeDAG(cp inputComputePlan) (ComputeDAG, error) {
 func (dag *ComputeDAG) sort() error {
 	current := dag.OrderTasks
 	var temp, final []TrainingTask
-	var depth int
 	IDPresents := map[string]int{}
 	for i := 0; len(current) != 0; {
+		depth := 0
 		ready := true
 		for _, ID := range current[i].InModelsIDs {
 			if ID == "" {
 				continue
 			}
-			nextDepth, ok := IDPresents[ID]
+			parentDepth, ok := IDPresents[ID]
 			ready = ready && ok
-			depth = max(depth, nextDepth)
+			depth = max(depth, parentDepth+1)
 		}
 		if ready {
 			current[i].Depth = depth
@@ -77,7 +77,7 @@ func (dag *ComputeDAG) sort() error {
 			if _, ok := IDPresents[current[i].ID]; ok {
 				return fmt.Errorf("compute plan error: Duplicate training task ID: %s", current[i].ID)
 			}
-			IDPresents[current[i].ID] = current[i].Depth + 1
+			IDPresents[current[i].ID] = current[i].Depth
 		} else {
 			temp = append(temp, current[i])
 		}

--- a/chaincode/compute_plan_dag.go
+++ b/chaincode/compute_plan_dag.go
@@ -8,6 +8,7 @@ type TrainingTask struct {
 	ID          string
 	InModelsIDs []string
 	InputIndex  int
+	Depth       int
 	TaskType    AssetType
 }
 
@@ -58,22 +59,25 @@ func createComputeDAG(cp inputComputePlan) (ComputeDAG, error) {
 func (dag *ComputeDAG) sort() error {
 	current := dag.OrderTasks
 	var temp, final []TrainingTask
-	IDPresents := map[string]bool{}
+	var depth int
+	IDPresents := map[string]int{}
 	for i := 0; len(current) != 0; {
 		ready := true
 		for _, ID := range current[i].InModelsIDs {
 			if ID == "" {
 				continue
 			}
-			_, ok := IDPresents[ID]
+			nextDepth, ok := IDPresents[ID]
 			ready = ready && ok
+			depth = max(depth, nextDepth)
 		}
 		if ready {
+			current[i].Depth = depth
 			final = append(final, current[i])
 			if _, ok := IDPresents[current[i].ID]; ok {
 				return fmt.Errorf("compute plan error: Duplicate training task ID: %s", current[i].ID)
 			}
-			IDPresents[current[i].ID] = true
+			IDPresents[current[i].ID] = current[i].Depth + 1
 		} else {
 			temp = append(temp, current[i])
 		}
@@ -94,4 +98,11 @@ func (dag *ComputeDAG) sort() error {
 	}
 	dag.OrderTasks = final
 	return nil
+}
+
+func max(x, y int) int {
+	if x < y {
+		return y
+	}
+	return x
 }

--- a/chaincode/compute_plan_dag_test.go
+++ b/chaincode/compute_plan_dag_test.go
@@ -10,6 +10,7 @@ func TestDAGSort(t *testing.T) {
 	ts := []struct {
 		name        string
 		list        []TrainingTask
+		depths      []int
 		expectError bool
 		errorStr    string
 	}{
@@ -20,6 +21,7 @@ func TestDAGSort(t *testing.T) {
 				{ID: "three"},
 				{ID: "four"},
 			},
+			depths:      []int{0, 0, 0, 0},
 			expectError: false},
 		{name: "some inModels",
 			list: []TrainingTask{
@@ -28,6 +30,7 @@ func TestDAGSort(t *testing.T) {
 				{ID: "four", InModelsIDs: []string{"two", "three"}},
 				{ID: "two"},
 			},
+			depths:      []int{0, 0, 1, 2},
 			expectError: false},
 		{name: "all-inModels",
 			list: []TrainingTask{
@@ -36,6 +39,7 @@ func TestDAGSort(t *testing.T) {
 				{ID: "four", InModelsIDs: []string{"three", "one"}},
 				{ID: "two", InModelsIDs: []string{"one"}},
 			},
+			depths:      []int{0, 1, 2, 3},
 			expectError: false},
 		{name: "wrong ID inModels",
 			list: []TrainingTask{
@@ -78,6 +82,7 @@ func TestDAGSort(t *testing.T) {
 			assert.NoError(t, err)
 			for i, ID := range []string{"one", "two", "three", "four"} {
 				assert.Equal(t, ID, dag.OrderTasks[i].ID)
+				assert.Equal(t, tc.depths[i], dag.OrderTasks[i].Depth)
 			}
 		})
 	}


### PR DESCRIPTION
- [x] Generate the compute plan's ranks from the DAG depth 

See also: [Fail fast: move objective to testtuple](https://github.com/SubstraFoundation/substra-chaincode/pull/50)