### PR TITLE
Failed InModels

### DIFF
--- a/chaincode/tuple.go
+++ b/chaincode/tuple.go
@@ -218,3 +218,16 @@ func getCertifiedOutputTesttuple(db *LedgerDB, traintupleKey string) (outputTest
 
 	return out, nil
 }
+
+func determineStatusFromInModels(statuses []string) string {
+	// TODO: Add the canceled case when it's ready
+	if stringInSlice(StatusFailed, statuses) {
+		return StatusFailed
+	}
+	for _, s := range statuses {
+		if s != StatusDone {
+			return StatusWaiting
+		}
+	}
+	return StatusTodo
+}

--- a/chaincode/tuple_aggregate_test.go
+++ b/chaincode/tuple_aggregate_test.go
@@ -568,3 +568,27 @@ func TestQueryAggregatetuple(t *testing.T) {
 	assert.Equal(t, objectiveMetricsHash, out.Objective.Metrics.Hash)
 	assert.Equal(t, objectiveMetricsStorageAddress, out.Objective.Metrics.StorageAddress)
 }
+
+func TestCreateFailedAggregate(t *testing.T) {
+	scc := new(SubstraChaincode)
+	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	registerItem(t, *mockStub, "compositeTraintuple")
+	mockStub.MockTransactionStart("42")
+	db := NewLedgerDB(mockStub)
+
+	_, err := logStartCompositeTrain(db, assetToArgs(inputHash{Key: compositeTraintupleKey}))
+	assert.NoError(t, err)
+
+	_, err = logFailCompositeTrain(db, assetToArgs(inputLogFailTrain{inputLog{Key: compositeTraintupleKey}}))
+	assert.NoError(t, err)
+
+	in := inputAggregatetuple{}
+	in.fillDefaults()
+	in.InModels = []string{compositeTraintupleKey}
+	key, err := createAggregatetupleInternal(db, in, true)
+	assert.NoError(t, err)
+
+	out, err := queryAggregatetuple(db, assetToArgs(inputHash{Key: key}))
+	assert.NoError(t, err)
+	assert.Equal(t, StatusFailed, out.Status)
+}

--- a/chaincode/tuple_aggregate_test.go
+++ b/chaincode/tuple_aggregate_test.go
@@ -584,7 +584,7 @@ func TestCreateFailedAggregate(t *testing.T) {
 
 	in := inputAggregatetuple{}
 	in.fillDefaults()
-	in.InModels = []string{compositeTraintupleKey}
+	in.InModels = []string{compositeTraintupleKey, traintupleKey}
 	key, err := createAggregatetupleInternal(db, in, true)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Fixes #55.
There is a question raised by the chosen approach. Now the aggregatetuple's status is determined solely by its InModels status and not by there availability anymore. So we assume that a `StatusDone` parent tuple have an available `OutModel` and that we don't re-check that at the creation of the aggregate tuple using this `OutModel` as `InModel`.
If we confirmed this strategy, we should apply the same approach to traintuple and composite traintuple.