### PR TITLE
Harmonize the status determination between tuples

### DIFF
--- a/chaincode/traintuple.go
+++ b/chaincode/traintuple.go
@@ -94,21 +94,22 @@ func (traintuple *Traintuple) SetFromInput(db *LedgerDB, inp inputTraintuple) er
 // i.e. the traintuples from which it received the outModels as inModels.
 // Also it's InModelKeys are set.
 func (traintuple *Traintuple) SetFromParents(db *LedgerDB, inModels []string) error {
-	status := StatusTodo
-	parentTraintupleKeys := inModels
-	for _, parentTraintupleKey := range parentTraintupleKeys {
-		parentTraintuple, err := db.GetTraintuple(parentTraintupleKey)
+	var parentStatuses []string
+	inModelKeys := traintuple.InModelKeys
+
+	for _, parentTraintupleKey := range inModels {
+		tuple, err := db.GetGenericTuple(parentTraintupleKey)
 		if err != nil {
-			err = errors.BadRequest(err, "could not retrieve parent traintuple with key %s %d", parentTraintupleKeys, len(parentTraintupleKeys))
-			return err
+			return errors.BadRequest(err, "could not retrieve parent traintuple with key %s", parentTraintupleKey)
 		}
-		// set traintuple to waiting if one of the parent traintuples is not done
-		if parentTraintuple.OutModel == nil {
-			status = StatusWaiting
+		if !typeInSlice(tuple.AssetType, []AssetType{TraintupleType, CompositeTraintupleType, AggregatetupleType}) {
+			return fmt.Errorf("aggregate.SetFromParents: Unsupported parent type %s", tuple.AssetType)
 		}
-		traintuple.InModelKeys = append(traintuple.InModelKeys, parentTraintupleKey)
+		parentStatuses = append(parentStatuses, tuple.Status)
+		inModelKeys = append(inModelKeys, parentTraintupleKey)
 	}
-	traintuple.Status = status
+	traintuple.Status = determineStatusFromInModels(parentStatuses)
+	traintuple.InModelKeys = inModelKeys
 	return nil
 }
 

--- a/chaincode/traintuple_composite.go
+++ b/chaincode/traintuple_composite.go
@@ -112,29 +112,34 @@ func (traintuple *CompositeTraintuple) SetFromParents(db *LedgerDB, inp inputCom
 
 	// [Head]
 	// It can only be a composite traintuple's head out model
-	hashDress, err := db.GetOutModelHashDress(inp.InHeadModelKey, HeadType, []AssetType{CompositeTraintupleType})
+	traintuple.InHeadModel = inp.InHeadModelKey
+	head, err := db.GetGenericTuple(inp.InHeadModelKey)
 	if err != nil {
 		return err
 	}
-	if hashDress == nil {
-		traintuple.Status = StatusWaiting
+	if !typeInSlice(head.AssetType, []AssetType{CompositeTraintupleType}) {
+		return errors.BadRequest(
+			"tuple type %s from key %s is not supported as head InModel",
+			head.AssetType,
+			inp.InHeadModelKey)
 	}
-	traintuple.InHeadModel = inp.InHeadModelKey
-
 	// [Trunk]
 	// It can be either:
 	// - a traintuple's out model
-	// - a composite traintuple's head out model
+	// - a composite traintuple's trunk out model
 	// - an aggregate tuple's out model
-	hashDress, err = db.GetOutModelHashDress(inp.InTrunkModelKey, TrunkType, []AssetType{TraintupleType, CompositeTraintupleType, AggregatetupleType})
+	traintuple.InTrunkModel = inp.InTrunkModelKey
+	trunk, err := db.GetGenericTuple(inp.InTrunkModelKey)
 	if err != nil {
 		return err
 	}
-	if hashDress == nil {
-		traintuple.Status = StatusWaiting
+	if !typeInSlice(trunk.AssetType, []AssetType{TraintupleType, CompositeTraintupleType, AggregatetupleType}) {
+		return errors.BadRequest(
+			"tuple type %s from key %s is not supported as trunk InModel",
+			trunk.AssetType,
+			inp.InTrunkModelKey)
 	}
-	traintuple.InTrunkModel = inp.InTrunkModelKey
-
+	traintuple.Status = determineStatusFromInModels([]string{head.Status, trunk.Status})
 	return nil
 }
 

--- a/chaincode/traintuple_composite_test.go
+++ b/chaincode/traintuple_composite_test.go
@@ -631,7 +631,7 @@ func testCompositeTraintupleInModelTypes(t *testing.T, headType AssetType, trunk
 	resp := mockStub.MockInvoke("42", args)
 
 	if !shouldSucceed {
-		assert.EqualValues(t, 404, resp.Status, "It should NOT be possible to register a traintuple with a %s head and a %s trunk: %s", headType, trunkType, resp.Message)
+		assert.EqualValues(t, http.StatusBadRequest, resp.Status, "It should NOT be possible to register a traintuple with a %s head and a %s trunk: %s", headType, trunkType, resp.Message)
 		return
 	}
 

--- a/chaincode/utils.go
+++ b/chaincode/utils.go
@@ -38,6 +38,16 @@ func stringInSlice(a string, list []string) bool {
 	return false
 }
 
+// typeInSlice check if an AssetType is in a slice
+func typeInSlice(a AssetType, list []AssetType) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
 // inputStructToBytes converts fields of a struct (with string fields only, such as input struct defined in ledger.go) to a [][]byte
 func inputStructToBytes(v interface{}) (sb [][]byte, err error) {
 


### PR DESCRIPTION
Follows #56 where we updated how the status of an new aggregate tuple is determined. Here we apply the same strategy for the traintuples and the composite traintules.