### PR TITLE
remove internal-only link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ See [chaincode-docker-devmode](./chaincode-docker-devmode/README.rst)
 
 ## Documentation
 
-
-Note for internal use only: See the [technical specifications](https://github.com/SubstraFoundation/substra-spec/blob/master/technical_spec_substra.md#smartcontract).
-
 ### Implemented smart contracts
 
 - `createAggregatetuple`


### PR DESCRIPTION
What do you think of removing this link that 404s for people who don't have access to the private repo substra-specs?