### PR TITLE
Refacto compute plan count

### DIFF
--- a/chaincode/algo_aggregate_test.go
+++ b/chaincode/algo_aggregate_test.go
@@ -51,7 +51,7 @@ func TestAggregateAlgo(t *testing.T) {
 	resp = mockStub.MockInvoke("42", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying an aggregate algo with status %d and message %s", resp.Status, resp.Message)
 	algo := outputAggregateAlgo{}
-	err = bytesToStruct(resp.Payload, &algo)
+	err = json.Unmarshal(resp.Payload, &algo)
 	assert.NoError(t, err, "when unmarshalling queried aggregate  algo")
 	expectedAlgo := outputAggregateAlgo{
 		outputAlgo: outputAlgo{

--- a/chaincode/algo_composite_test.go
+++ b/chaincode/algo_composite_test.go
@@ -51,7 +51,7 @@ func TestCompositeAlgo(t *testing.T) {
 	resp = mockStub.MockInvoke("42", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying a composite algo with status %d and message %s", resp.Status, resp.Message)
 	algo := outputCompositeAlgo{}
-	err = bytesToStruct(resp.Payload, &algo)
+	err = json.Unmarshal(resp.Payload, &algo)
 	assert.NoError(t, err, "when unmarshalling queried composite algo")
 	expectedAlgo := outputCompositeAlgo{
 		outputAlgo: outputAlgo{

--- a/chaincode/algo_test.go
+++ b/chaincode/algo_test.go
@@ -49,7 +49,7 @@ func TestAlgo(t *testing.T) {
 	resp = mockStub.MockInvoke("42", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying an algo with status %d and message %s", resp.Status, resp.Message)
 	algo := outputAlgo{}
-	err = bytesToStruct(resp.Payload, &algo)
+	err = json.Unmarshal(resp.Payload, &algo)
 	assert.NoError(t, err, "when unmarshalling queried objective")
 	expectedAlgo := outputAlgo{
 		Key:  algoKey,

--- a/chaincode/common.go
+++ b/chaincode/common.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"fmt"
+	"chaincode/errors"
 	"strings"
 )
 
@@ -39,7 +39,7 @@ func queryFilter(db *LedgerDB, args []string) (elements interface{}, err error) 
 		"aggregatetuple~tag",
 	}
 	if !stringInSlice(inp.IndexName, validIndexNames) {
-		err = fmt.Errorf("invalid indexName filter query: %s", inp.IndexName)
+		err = errors.BadRequest("invalid indexName filter query: %s", inp.IndexName)
 		return
 	}
 	indexName := inp.IndexName + "~key"

--- a/chaincode/compute_plan.go
+++ b/chaincode/compute_plan.go
@@ -292,7 +292,6 @@ func cancelComputePlan(db *LedgerDB, args []string) (resp outputComputePlan, err
 func (cp *ComputePlan) Create(db *LedgerDB) (string, error) {
 	ID := GetRandomHash()
 	cp.AssetType = ComputePlanType
-	cp.TupleCount = 1
 	err := db.Add(ID, cp)
 	if err != nil {
 		return "", err
@@ -346,13 +345,32 @@ func (cp *ComputePlan) CheckNewTupleStatus(tupleStatus string) bool {
 			cp.Status = tupleStatus
 			return true
 		}
+	case "":
+		cp.Status = tupleStatus
+		return true
 	}
 	return false
 }
 
+// AddTuple add the tuple key to the compute plan and update it accordingly
+func (cp *ComputePlan) AddTuple(tupleType AssetType, key, status string) {
+	switch tupleType {
+	case TraintupleType:
+		cp.TraintupleKeys = append(cp.TraintupleKeys, key)
+	case CompositeTraintupleType:
+		cp.CompositeTraintupleKeys = append(cp.CompositeTraintupleKeys, key)
+	case AggregatetupleType:
+		cp.AggregatetupleKeys = append(cp.AggregatetupleKeys, key)
+	case TesttupleType:
+		cp.TesttupleKeys = append(cp.TesttupleKeys, key)
+	}
+	cp.TupleCount++
+	cp.CheckNewTupleStatus(status)
+}
+
 // UpdateComputePlan retreive the compute plan if the ID is not empty,
 // check if the updated status change anything and save it if it's the case
-func UpdateComputePlan(db *LedgerDB, ComputePlanID, tupleStatus string) error {
+func UpdateComputePlan(db *LedgerDB, ComputePlanID, tupleStatus, tupleKey string) error {
 	if ComputePlanID == "" {
 		return nil
 	}

--- a/chaincode/compute_plan.go
+++ b/chaincode/compute_plan.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"chaincode/errors"
-	"fmt"
 	"strconv"
 )
 
@@ -31,7 +30,7 @@ func (inpTraintuple *inputTraintuple) Fill(inpCP inputComputePlanTraintuple, tra
 	for _, InModelID := range inpCP.InModelsIDs {
 		inModelKey, ok := traintupleKeysByID[InModelID]
 		if !ok {
-			return fmt.Errorf("model ID %s not found", InModelID)
+			return errors.BadRequest("model ID %s not found", InModelID)
 		}
 		inpTraintuple.InModels = append(inpTraintuple.InModels, inModelKey)
 	}
@@ -49,7 +48,7 @@ func (inpAggregatetuple *inputAggregatetuple) Fill(inpCP inputComputePlanAggrega
 	for _, InModelID := range inpCP.InModelsIDs {
 		inModelKey, ok := aggregatetupleKeysByID[InModelID]
 		if !ok {
-			return fmt.Errorf("model ID %s not found", InModelID)
+			return errors.BadRequest("model ID %s not found", InModelID)
 		}
 		inpAggregatetuple.InModels = append(inpAggregatetuple.InModels, inModelKey)
 	}
@@ -70,14 +69,14 @@ func (inpCompositeTraintuple *inputCompositeTraintuple) Fill(inpCP inputComputeP
 		var ok bool
 		inpCompositeTraintuple.InHeadModelKey, ok = traintupleKeysByID[inpCP.InHeadModelID]
 		if !ok {
-			return fmt.Errorf("head model ID %s not found", inpCP.InHeadModelID)
+			return errors.BadRequest("head model ID %s not found", inpCP.InHeadModelID)
 		}
 	}
 	if inpCP.InTrunkModelID != "" {
 		var ok bool
 		inpCompositeTraintuple.InTrunkModelKey, ok = traintupleKeysByID[inpCP.InTrunkModelID]
 		if !ok {
-			return fmt.Errorf("trunk model ID %s not found", inpCP.InTrunkModelID)
+			return errors.BadRequest("trunk model ID %s not found", inpCP.InTrunkModelID)
 		}
 	}
 	return nil
@@ -86,7 +85,7 @@ func (inpCompositeTraintuple *inputCompositeTraintuple) Fill(inpCP inputComputeP
 func (inpTesttuple *inputTesttuple) Fill(inpCP inputComputePlanTesttuple, traintupleKeysByID map[string]string) error {
 	traintupleKey, ok := traintupleKeysByID[inpCP.TraintupleID]
 	if !ok {
-		return fmt.Errorf("traintuple ID %s not found", inpCP.TraintupleID)
+		return errors.BadRequest("traintuple ID %s not found", inpCP.TraintupleID)
 	}
 	inpTesttuple.TraintupleKey = traintupleKey
 	inpTesttuple.DataManagerKey = inpCP.DataManagerKey

--- a/chaincode/compute_plan_dag.go
+++ b/chaincode/compute_plan_dag.go
@@ -1,6 +1,6 @@
 package main
 
-import "fmt"
+import "chaincode/errors"
 
 // TrainingTask is a node of a ComputeDAG. It represents a training task
 // (i.e. a Traintuple, a CompositeTraintuple or an Aggregatetuple)
@@ -75,7 +75,7 @@ func (dag *ComputeDAG) sort() error {
 			current[i].Depth = depth
 			final = append(final, current[i])
 			if _, ok := IDPresents[current[i].ID]; ok {
-				return fmt.Errorf("compute plan error: Duplicate training task ID: %s", current[i].ID)
+				return errors.BadRequest("compute plan error: Duplicate training task ID: %s", current[i].ID)
 			}
 			IDPresents[current[i].ID] = current[i].Depth
 		} else {
@@ -90,7 +90,7 @@ func (dag *ComputeDAG) sort() error {
 			for _, c := range current {
 				errorIDs = append(errorIDs, c.ID)
 			}
-			return fmt.Errorf("compute plan error: Cyclic or missing dependency among inModels IDs: %v", errorIDs)
+			return errors.BadRequest("compute plan error: Cyclic or missing dependency among inModels IDs: %v", errorIDs)
 		}
 		i = 0
 		current = temp

--- a/chaincode/compute_plan_test.go
+++ b/chaincode/compute_plan_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -240,7 +239,7 @@ func validateTupleRank(t *testing.T, db *LedgerDB, expectedRank int, key string,
 		assert.NoError(t, err)
 		rank = tuple.Rank
 	default:
-		assert.NoError(t, fmt.Errorf("not implemented: %v", assetType))
+		t.Errorf("not implemented: %s", assetType)
 	}
 	assert.Equal(t, expectedRank, rank, "Rank for tuple of type %v with key \"%s\" should be %d", assetType, key, expectedRank)
 }

--- a/chaincode/data.go
+++ b/chaincode/data.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"chaincode/errors"
-	"fmt"
 	"strconv"
 	"strings"
 )
@@ -53,10 +52,6 @@ func (dataManager *DataManager) Set(db *LedgerDB, inp inputDataManager) (string,
 // and returning corresponding dataSample hashes, associated dataManagers, testOnly and errors
 func setDataSample(db *LedgerDB, inp inputDataSample) (dataSampleHashes []string, dataSample DataSample, err error) {
 	dataSampleHashes = inp.Hashes
-	if err = checkHashes(dataSampleHashes); err != nil {
-		err = errors.BadRequest(err)
-		return
-	}
 	// check dataSample is not already in the ledger
 	if existingKeys := checkDataSamplesExist(db, dataSampleHashes); existingKeys != nil {
 		err = errors.Conflict("data samples with keys %s already exist", existingKeys).WithKeys(existingKeys)
@@ -92,11 +87,6 @@ func setDataSample(db *LedgerDB, inp inputDataSample) (dataSampleHashes []string
 // one or more dataSamplef
 func validateUpdateDataSample(db *LedgerDB, inp inputUpdateDataSample) (dataSampleHashes []string, dataManagerKeys []string, err error) {
 	// TODO return full dataSample
-	// check validity of dataSampleHashes
-	if err = checkHashes(inp.Hashes); err != nil {
-		err = errors.BadRequest(err)
-		return
-	}
 	// check dataManagers exist and are owned by the transaction requester
 	if err = checkDataManagerOwner(db, inp.DataManagerKeys); err != nil {
 		return
@@ -323,7 +313,7 @@ func queryDataset(db *LedgerDB, args []string) (outputDataset, error) {
 func queryDataSamples(db *LedgerDB, args []string) ([]outputDataSample, error) {
 	outDataSamples := []outputDataSample{}
 	if len(args) != 0 {
-		err := fmt.Errorf("incorrect number of arguments, expecting nothing")
+		err := errors.BadRequest("incorrect number of arguments, expecting nothing")
 		return outDataSamples, err
 	}
 	elementsKeys, err := db.GetIndexKeys("dataSample~dataManager~key", []string{"dataSample"})
@@ -393,7 +383,7 @@ func checkSameDataManager(db *LedgerDB, dataManagerKey string, dataSampleKeys []
 			return testOnly, trainOnly, err
 		}
 		if !stringInSlice(dataManagerKey, dataSample.DataManagerKeys) {
-			err = fmt.Errorf("dataSample do not belong to the same dataManager")
+			err = errors.BadRequest("dataSample do not belong to the same dataManager")
 			return testOnly, trainOnly, err
 		}
 		testOnly = testOnly && dataSample.TestOnly

--- a/chaincode/data_test.go
+++ b/chaincode/data_test.go
@@ -66,7 +66,7 @@ func TestDataManager(t *testing.T) {
 	resp = mockStub.MockInvoke("42", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the dataManager, status %d and message %s", resp.Status, resp.Message)
 	dataManager := outputDataManager{}
-	err = bytesToStruct(resp.Payload, &dataManager)
+	err = json.Unmarshal(resp.Payload, &dataManager)
 	assert.NoError(t, err, "when unmarshalling queried dataManager")
 	expectedDataManager := outputDataManager{
 		ObjectiveKey: inpDataManager.ObjectiveKey,

--- a/chaincode/generate_examples_test.go
+++ b/chaincode/generate_examples_test.go
@@ -123,7 +123,7 @@ func TestPipeline(t *testing.T) {
 	assert.EqualValuesf(t, 200, resp.Status, "when adding traintuple with status %d and message %s", resp.Status, resp.Message)
 	traintuple := outputTraintuple{}
 	respTraintuple := resp.Payload
-	if err := bytesToStruct(respTraintuple, &traintuple); err != nil {
+	if err := json.Unmarshal(respTraintuple, &traintuple); err != nil {
 		t.Errorf("when unmarshalling queried traintuple with error %s", err)
 	}
 	trainWorker := traintuple.Dataset.Worker
@@ -185,7 +185,7 @@ func TestPipeline(t *testing.T) {
 	resp = mockStub.MockInvoke("42", args)
 	respTesttuple := resp.Payload
 	testtuple := outputTesttuple{}
-	if err := bytesToStruct(respTesttuple, &testtuple); err != nil {
+	if err := json.Unmarshal(respTesttuple, &testtuple); err != nil {
 		t.Errorf("when unmarshalling queried testtuple with error %s", err)
 	}
 	testWorker := testtuple.Dataset.Worker

--- a/chaincode/ledger_db.go
+++ b/chaincode/ledger_db.go
@@ -17,7 +17,6 @@ package main
 import (
 	"chaincode/errors"
 	"encoding/json"
-	"fmt"
 	"sync"
 
 	"github.com/hyperledger/fabric/core/chaincode/shim"
@@ -129,11 +128,11 @@ func (db *LedgerDB) Add(key string, object interface{}) error {
 func (db *LedgerDB) CreateIndex(index string, attributes []string) error {
 	compositeKey, err := db.cc.CreateCompositeKey(index, attributes)
 	if err != nil {
-		return fmt.Errorf("cannot create index %s: %s", index, err.Error())
+		return errors.Internal("cannot create index %s: %s", index, err.Error())
 	}
 	value := []byte{0x00}
 	if err = db.cc.PutState(compositeKey, value); err != nil {
-		return fmt.Errorf("cannot create index %s: %s", index, err.Error())
+		return errors.Internal("cannot create index %s: %s", index, err.Error())
 	}
 	return nil
 }
@@ -160,7 +159,7 @@ func (db *LedgerDB) GetIndexKeys(index string, attributes []string) ([]string, e
 	keys := make([]string, 0)
 	iterator, err := db.cc.GetStateByPartialCompositeKey(index, attributes)
 	if err != nil {
-		return nil, fmt.Errorf("get index %s failed: %s", index, err.Error())
+		return nil, errors.Internal("get index %s failed: %s", index, err.Error())
 	}
 	defer iterator.Close()
 	for iterator.HasNext() {
@@ -170,7 +169,7 @@ func (db *LedgerDB) GetIndexKeys(index string, attributes []string) ([]string, e
 		}
 		_, keyParts, err := db.cc.SplitCompositeKey(compositeKey.Key)
 		if err != nil {
-			return nil, fmt.Errorf("get index %s failed: cannot split key %s: %s", index, compositeKey.Key, err.Error())
+			return nil, errors.Internal("get index %s failed: cannot split key %s: %s", index, compositeKey.Key, err.Error())
 		}
 		keys = append(keys, keyParts[len(keyParts)-1])
 	}
@@ -393,7 +392,7 @@ func (db *LedgerDB) GetOutModelHashDress(traintupleKey string, modelType Composi
 			case TrunkType:
 				return tuple.OutTrunkModel.OutModel, nil
 			default:
-				return nil, fmt.Errorf("GetOutModelHashDress: Unsupported composite model type %s", modelType)
+				return nil, errors.Internal("GetOutModelHashDress: Unsupported composite model type %s", modelType)
 			}
 
 		case TraintupleType:
@@ -407,7 +406,7 @@ func (db *LedgerDB) GetOutModelHashDress(traintupleKey string, modelType Composi
 				return tuple.OutModel, nil
 			}
 		default:
-			return nil, fmt.Errorf("GetOutModelHashDress: Unsupported asset type %s", assetType)
+			return nil, errors.Internal("GetOutModelHashDress: Unsupported asset type %s", assetType)
 		}
 	}
 

--- a/chaincode/main.go
+++ b/chaincode/main.go
@@ -167,7 +167,7 @@ func (t *SubstraChaincode) Invoke(stub shim.ChaincodeStubInterface) peer.Respons
 	case "queryNodes":
 		result, err = queryNodes(db, args)
 	default:
-		err = fmt.Errorf("function \"%s\" not implemented", fn)
+		err = errors.BadRequest("function \"%s\" not implemented", fn)
 	}
 	logger.Infof("Response from chaincode: %#v, error: %s", result, err)
 	// Return the result as success payload
@@ -178,12 +178,12 @@ func (t *SubstraChaincode) Invoke(stub shim.ChaincodeStubInterface) peer.Respons
 	// one event per call
 	err = db.SendTuplesEvent()
 	if err != nil {
-		return formatErrorResponse(fmt.Errorf("could not send event: %s", err.Error()))
+		return formatErrorResponse(errors.Internal("could not send event: %s", err.Error()))
 	}
 	// Marshal to json the smartcontract result
 	resp, err := json.Marshal(result)
 	if err != nil {
-		return formatErrorResponse(fmt.Errorf("could not format response: %s", err.Error()))
+		return formatErrorResponse(errors.Internal("could not format response: %s", err.Error()))
 	}
 
 	return shim.Success(resp)

--- a/chaincode/objective.go
+++ b/chaincode/objective.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"chaincode/errors"
-	"fmt"
 	"sort"
 )
 
@@ -116,7 +115,7 @@ func queryObjective(db *LedgerDB, args []string) (out outputObjective, err error
 func queryObjectives(db *LedgerDB, args []string) (outObjectives []outputObjective, err error) {
 	outObjectives = []outputObjective{}
 	if len(args) != 0 {
-		err = fmt.Errorf("incorrect number of arguments, expecting nothing")
+		err = errors.BadRequest("incorrect number of arguments, expecting nothing")
 		return
 	}
 	elementsKeys, err := db.GetIndexKeys("objective~owner~key", []string{"objective"})

--- a/chaincode/objective_test.go
+++ b/chaincode/objective_test.go
@@ -145,7 +145,7 @@ func TestObjective(t *testing.T) {
 	resp = mockStub.MockInvoke("42", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying a dataManager with status %d and message %s", resp.Status, resp.Message)
 	objective := outputObjective{}
-	err = bytesToStruct(resp.Payload, &objective)
+	err = json.Unmarshal(resp.Payload, &objective)
 	assert.NoError(t, err, "when unmarshalling queried objective")
 	expectedObjective := outputObjective{
 		Key:   objectiveKey,

--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"fmt"
+	"chaincode/errors"
 	"math"
 )
 
@@ -151,7 +151,7 @@ func (outputTraintuple *outputTraintuple) Fill(db *LedgerDB, traintuple Traintup
 	// fill algo
 	algo, err := db.GetAlgo(traintuple.AlgoKey)
 	if err != nil {
-		err = fmt.Errorf("could not retrieve algo with key %s - %s", traintuple.AlgoKey, err.Error())
+		err = errors.Internal("could not retrieve algo with key %s - %s", traintuple.AlgoKey, err.Error())
 		return
 	}
 	outputTraintuple.Algo = &HashDressName{
@@ -166,7 +166,7 @@ func (outputTraintuple *outputTraintuple) Fill(db *LedgerDB, traintuple Traintup
 		}
 		parentTraintuple, err := db.GetTraintuple(inModelKey)
 		if err != nil {
-			return fmt.Errorf("could not retrieve parent traintuple with key %s - %s", inModelKey, err.Error())
+			return errors.Internal("could not retrieve parent traintuple with key %s - %s", inModelKey, err.Error())
 		}
 		inModel := &Model{
 			TraintupleKey: inModelKey,
@@ -219,7 +219,7 @@ func (out *outputTesttuple) Fill(db *LedgerDB, key string, in Testtuple) error {
 	// fill type
 	traintupleType, err := db.GetAssetType(in.TraintupleKey)
 	if err != nil {
-		return fmt.Errorf("could not retrieve traintuple type with key %s - %s", in.TraintupleKey, err.Error())
+		return errors.Internal("could not retrieve traintuple type with key %s - %s", in.TraintupleKey, err.Error())
 	}
 	out.TraintupleType = LowerFirst(traintupleType.String())
 
@@ -229,18 +229,18 @@ func (out *outputTesttuple) Fill(db *LedgerDB, key string, in Testtuple) error {
 	case TraintupleType:
 		algo, err = db.GetAlgo(in.AlgoKey)
 		if err != nil {
-			return fmt.Errorf("could not retrieve algo with key %s - %s", in.AlgoKey, err.Error())
+			return errors.Internal("could not retrieve algo with key %s - %s", in.AlgoKey, err.Error())
 		}
 	case CompositeTraintupleType:
 		compositeAlgo, err := db.GetCompositeAlgo(in.AlgoKey)
 		if err != nil {
-			return fmt.Errorf("could not retrieve composite algo with key %s - %s", in.AlgoKey, err.Error())
+			return errors.Internal("could not retrieve composite algo with key %s - %s", in.AlgoKey, err.Error())
 		}
 		algo = compositeAlgo.Algo
 	case AggregatetupleType:
 		aggregateAlgo, err := db.GetAggregateAlgo(in.AlgoKey)
 		if err != nil {
-			return fmt.Errorf("could not retrieve aggregate algo with key %s - %s", in.AlgoKey, err.Error())
+			return errors.Internal("could not retrieve aggregate algo with key %s - %s", in.AlgoKey, err.Error())
 		}
 		algo = aggregateAlgo.Algo
 	}
@@ -252,10 +252,10 @@ func (out *outputTesttuple) Fill(db *LedgerDB, key string, in Testtuple) error {
 	// fill objective
 	objective, err := db.GetObjective(in.ObjectiveKey)
 	if err != nil {
-		return fmt.Errorf("could not retrieve associated objective with key %s- %s", in.ObjectiveKey, err.Error())
+		return errors.Internal("could not retrieve associated objective with key %s- %s", in.ObjectiveKey, err.Error())
 	}
 	if objective.Metrics == nil {
-		return fmt.Errorf("objective %s is missing metrics values", in.ObjectiveKey)
+		return errors.Internal("objective %s is missing metrics values", in.ObjectiveKey)
 	}
 	metrics := HashDress{
 		Hash:           objective.Metrics.Hash,

--- a/chaincode/output_aggregate.go
+++ b/chaincode/output_aggregate.go
@@ -14,7 +14,7 @@
 
 package main
 
-import "fmt"
+import "chaincode/errors"
 
 type outputAggregatetuple struct {
 	Key           string            `json:"key"`
@@ -51,7 +51,7 @@ func (outputAggregatetuple *outputAggregatetuple) Fill(db *LedgerDB, traintuple 
 	outputAggregatetuple.Tag = traintuple.Tag
 	algo, err := db.GetAggregateAlgo(traintuple.AlgoKey)
 	if err != nil {
-		err = fmt.Errorf("could not retrieve aggregate algo with key %s - %s", traintuple.AlgoKey, err.Error())
+		err = errors.Internal("could not retrieve aggregate algo with key %s - %s", traintuple.AlgoKey, err.Error())
 		return
 	}
 	outputAggregatetuple.Algo = &HashDressName{
@@ -66,7 +66,7 @@ func (outputAggregatetuple *outputAggregatetuple) Fill(db *LedgerDB, traintuple 
 		}
 		hashDress, _err := db.GetOutModelHashDress(inModelKey, TrunkType, []AssetType{TraintupleType, CompositeTraintupleType, AggregatetupleType})
 		if _err != nil {
-			err = fmt.Errorf("could not fill in-model with key \"%s\": %s", inModelKey, _err.Error())
+			err = errors.Internal("could not fill in-model with key \"%s\": %s", inModelKey, _err.Error())
 			return
 		}
 		inModel := &Model{

--- a/chaincode/output_composite.go
+++ b/chaincode/output_composite.go
@@ -14,9 +14,7 @@
 
 package main
 
-import (
-	"fmt"
-)
+import "chaincode/errors"
 
 type outputCompositeAlgo struct {
 	outputAlgo
@@ -62,7 +60,7 @@ func (outputCompositeTraintuple *outputCompositeTraintuple) Fill(db *LedgerDB, t
 	// fill algo
 	algo, err := db.GetCompositeAlgo(traintuple.AlgoKey)
 	if err != nil {
-		err = fmt.Errorf("could not retrieve composite algo with key %s - %s", traintuple.AlgoKey, err.Error())
+		err = errors.Internal("could not retrieve composite algo with key %s - %s", traintuple.AlgoKey, err.Error())
 		return
 	}
 	outputCompositeTraintuple.Algo = &HashDressName{
@@ -75,7 +73,7 @@ func (outputCompositeTraintuple *outputCompositeTraintuple) Fill(db *LedgerDB, t
 		// Head can only be a composite traintuple's head out model
 		hashDress, _err := db.GetOutModelHashDress(traintuple.InHeadModel, HeadType, []AssetType{CompositeTraintupleType})
 		if _err != nil {
-			err = fmt.Errorf("could not fill (head) in-model with key \"%s\": %s", traintuple.InHeadModel, _err.Error())
+			err = errors.Internal("could not fill (head) in-model with key \"%s\": %s", traintuple.InHeadModel, _err.Error())
 			return
 		}
 		outputCompositeTraintuple.InHeadModel = &Model{
@@ -95,7 +93,7 @@ func (outputCompositeTraintuple *outputCompositeTraintuple) Fill(db *LedgerDB, t
 		// - an aggregate tuple's out model
 		hashDress, _err := db.GetOutModelHashDress(traintuple.InTrunkModel, TrunkType, []AssetType{TraintupleType, CompositeTraintupleType, AggregatetupleType})
 		if _err != nil {
-			err = fmt.Errorf("could not fill (trunk) in-model with key \"%s\": %s", traintuple.InTrunkModel, _err.Error())
+			err = errors.Internal("could not fill (trunk) in-model with key \"%s\": %s", traintuple.InTrunkModel, _err.Error())
 			return
 		}
 		outputCompositeTraintuple.InTrunkModel = &Model{

--- a/chaincode/permissions.go
+++ b/chaincode/permissions.go
@@ -14,9 +14,7 @@
 
 package main
 
-import (
-	"fmt"
-)
+import "chaincode/errors"
 
 // Permission represents one permission based on an action type
 type Permission struct {
@@ -73,7 +71,7 @@ func NewPermissions(db *LedgerDB, in inputPermissions) (Permissions, error) {
 		}
 
 		if !stringInSlice(authorizedID, nodesIDs) {
-			return Permissions{}, fmt.Errorf("invalid permission input values")
+			return Permissions{}, errors.BadRequest("invalid permission input values")
 		}
 	}
 

--- a/chaincode/testtuple.go
+++ b/chaincode/testtuple.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"chaincode/errors"
-	"fmt"
 	"reflect"
 	"sort"
 	"strconv"
@@ -434,7 +433,7 @@ func (testtuple *Testtuple) validateNewStatus(db *LedgerDB, status string) error
 // commitStatusUpdate update the testtuple status in the ledger
 func (testtuple *Testtuple) commitStatusUpdate(db *LedgerDB, testtupleKey string, newStatus string) error {
 	if err := testtuple.validateNewStatus(db, newStatus); err != nil {
-		return fmt.Errorf("update testtuple %s failed: %s", testtupleKey, err.Error())
+		return errors.Internal("update testtuple %s failed: %s", testtupleKey, err.Error())
 	}
 
 	// do not update if previous status is already Done, Failed, Todo, Doing
@@ -446,7 +445,7 @@ func (testtuple *Testtuple) commitStatusUpdate(db *LedgerDB, testtupleKey string
 	testtuple.Status = newStatus
 
 	if err := db.Put(testtupleKey, testtuple); err != nil {
-		return fmt.Errorf("failed to update testtuple status to %s with key %s", newStatus, testtupleKey)
+		return errors.Internal("failed to update testtuple status to %s with key %s", newStatus, testtupleKey)
 	}
 
 	// update associated composite key

--- a/chaincode/testtuple.go
+++ b/chaincode/testtuple.go
@@ -190,7 +190,7 @@ func (testtuple *Testtuple) AddToComputePlan(db *LedgerDB, testtupleKey string) 
 	if err != nil {
 		return err
 	}
-	computePlan.AddTuple(testtuple.AssetType, testtupleKey, testtuple.Status)
+	computePlan.AddTuple(TesttupleType, testtupleKey, testtuple.Status)
 	err = computePlan.Save(db, testtuple.ComputePlanID)
 	if err != nil {
 		return err

--- a/chaincode/testtuple_test.go
+++ b/chaincode/testtuple_test.go
@@ -169,7 +169,7 @@ func TestQueryTesttuple(t *testing.T) {
 			resp = mockStub.MockInvoke("42", args)
 			respTesttuple := resp.Payload
 			testtuple := outputTesttuple{}
-			bytesToStruct(respTesttuple, &testtuple)
+			json.Unmarshal(respTesttuple, &testtuple)
 
 			// assert
 			assert.Equal(t, worker, testtuple.Creator)
@@ -210,7 +210,7 @@ func TestTesttupleOnCompositeTraintuple(t *testing.T) {
 			resp := mockStub.MockInvoke("42", args)
 			assert.EqualValues(t, http.StatusOK, resp.Status, resp.Message)
 			values := map[string]string{}
-			bytesToStruct(resp.Payload, &values)
+			json.Unmarshal(resp.Payload, &values)
 			testTupleKey := values["key"]
 
 			// Start training
@@ -254,7 +254,7 @@ func TestTesttupleOnCompositeTraintuple(t *testing.T) {
 			case StatusDone:
 				assert.EqualValues(t, http.StatusOK, resp.Status, resp.Message)
 				values = map[string]string{}
-				bytesToStruct(resp.Payload, &values)
+				json.Unmarshal(resp.Payload, &values)
 				testTupleKey = values["key"]
 				testTuple, err := queryTesttuple(db, assetToArgs(inputHash{Key: testTupleKey}))
 				assert.NoError(t, err)

--- a/chaincode/traintuple.go
+++ b/chaincode/traintuple.go
@@ -136,7 +136,8 @@ func (traintuple *Traintuple) AddToComputePlan(db *LedgerDB, inp inputTraintuple
 			err = errors.BadRequest("invalid inputs, a new ComputePlan should have a rank 0")
 			return err
 		}
-		computePlan := ComputePlan{Status: traintuple.Status, TraintupleKeys: []string{traintupleKey}}
+		computePlan := ComputePlan{}
+		computePlan.AddTuple(traintuple.AssetType, traintupleKey, traintuple.Status)
 		traintuple.ComputePlanID, err = computePlan.Create(db)
 		if err != nil {
 			return err
@@ -148,9 +149,7 @@ func (traintuple *Traintuple) AddToComputePlan(db *LedgerDB, inp inputTraintuple
 	if err != nil {
 		return err
 	}
-	computePlan.TraintupleKeys = append(computePlan.TraintupleKeys, traintupleKey)
-	computePlan.TupleCount++
-	computePlan.CheckNewTupleStatus(traintuple.Status)
+	computePlan.AddTuple(traintuple.AssetType, traintupleKey, traintuple.Status)
 	err = computePlan.Save(db, traintuple.ComputePlanID)
 	if err != nil {
 		return err
@@ -285,10 +284,6 @@ func logStartTrain(db *LedgerDB, args []string) (o outputTraintuple, err error) 
 		return
 	}
 	err = o.Fill(db, traintuple, inp.Key)
-	if err != nil {
-		return
-	}
-	err = UpdateComputePlan(db, traintuple.ComputePlanID, traintuple.Status)
 	return
 }
 
@@ -333,15 +328,6 @@ func logSuccessTrain(db *LedgerDB, args []string) (o outputTraintuple, err error
 	}
 
 	err = o.Fill(db, traintuple, inp.Key)
-	if err != nil {
-		return
-	}
-
-	err = UpdateComputePlan(db, traintuple.ComputePlanID, traintuple.Status)
-	if err != nil {
-		return
-	}
-
 	return
 }
 
@@ -373,10 +359,6 @@ func logFailTrain(db *LedgerDB, args []string) (o outputTraintuple, err error) {
 		return
 	}
 
-	err = UpdateComputePlan(db, traintuple.ComputePlanID, traintuple.Status)
-	if err != nil {
-		return
-	}
 	// Do not propagate failure if we are in a compute plan
 	if traintuple.ComputePlanID != "" {
 		return
@@ -631,6 +613,9 @@ func (traintuple *Traintuple) commitStatusUpdate(db *LedgerDB, traintupleKey str
 	oldAttributes := []string{"traintuple", traintuple.Dataset.Worker, oldStatus, traintupleKey}
 	newAttributes := []string{"traintuple", traintuple.Dataset.Worker, traintuple.Status, traintupleKey}
 	if err := db.UpdateIndex(indexName, oldAttributes, newAttributes); err != nil {
+		return err
+	}
+	if err := UpdateComputePlan(db, traintuple.ComputePlanID, newStatus, traintupleKey); err != nil {
 		return err
 	}
 	logger.Infof("traintuple %s status updated: %s (from=%s)", traintupleKey, newStatus, oldStatus)

--- a/chaincode/traintuple.go
+++ b/chaincode/traintuple.go
@@ -136,7 +136,7 @@ func (traintuple *Traintuple) AddToComputePlan(db *LedgerDB, inp inputTraintuple
 			return err
 		}
 		computePlan := ComputePlan{}
-		computePlan.AddTuple(traintuple.AssetType, traintupleKey, traintuple.Status)
+		computePlan.AddTuple(TraintupleType, traintupleKey, traintuple.Status)
 		traintuple.ComputePlanID, err = computePlan.Create(db)
 		if err != nil {
 			return err
@@ -148,7 +148,7 @@ func (traintuple *Traintuple) AddToComputePlan(db *LedgerDB, inp inputTraintuple
 	if err != nil {
 		return err
 	}
-	computePlan.AddTuple(traintuple.AssetType, traintupleKey, traintuple.Status)
+	computePlan.AddTuple(TraintupleType, traintupleKey, traintuple.Status)
 	err = computePlan.Save(db, traintuple.ComputePlanID)
 	if err != nil {
 		return err

--- a/chaincode/traintuple.go
+++ b/chaincode/traintuple.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"chaincode/errors"
-	"fmt"
 	"strconv"
 )
 
@@ -93,7 +92,7 @@ func (traintuple *Traintuple) SetFromParents(db *LedgerDB, inModels []string) er
 			return errors.BadRequest(err, "could not retrieve parent traintuple with key %s", parentTraintupleKey)
 		}
 		if !typeInSlice(tuple.AssetType, []AssetType{TraintupleType, CompositeTraintupleType, AggregatetupleType}) {
-			return fmt.Errorf("aggregate.SetFromParents: Unsupported parent type %s", tuple.AssetType)
+			return errors.Internal("aggregate.SetFromParents: Unsupported parent type %s", tuple.AssetType)
 		}
 		parentStatuses = append(parentStatuses, tuple.Status)
 		inModelKeys = append(inModelKeys, parentTraintupleKey)
@@ -453,15 +452,15 @@ func UpdateTraintupleChildren(db *LedgerDB, traintupleKey string, traintupleStat
 	// get traintuples having as inModels the input traintuple
 	childTraintupleKeys, err := db.GetIndexKeys("traintuple~inModel~key", []string{"traintuple", traintupleKey})
 	if err != nil {
-		return fmt.Errorf("error while getting associated tuples to update their inModel, traintupleKey=%s traintupleStatus=%s %s", traintupleKey, traintupleStatus, err)
+		return errors.Internal("error while getting associated tuples to update their inModel, traintupleKey=%s traintupleStatus=%s %s", traintupleKey, traintupleStatus, err)
 	}
 	childCompositeTraintupleKeys, err := db.GetIndexKeys("compositeTraintuple~inModel~key", []string{"compositeTraintuple", traintupleKey})
 	if err != nil {
-		return fmt.Errorf("error while getting associated composite traintuples to update their inModel")
+		return errors.Internal("error while getting associated composite traintuples to update their inModel")
 	}
 	childAggregatetupleKeys, err := db.GetIndexKeys("aggregatetuple~inModel~key", []string{"aggregatetuple", traintupleKey})
 	if err != nil {
-		return fmt.Errorf("error while getting associated aggregate tuples to update their inModel")
+		return errors.Internal("error while getting associated aggregate tuples to update their inModel")
 	}
 
 	allChildKeys := append(append(childTraintupleKeys, childCompositeTraintupleKeys...), childAggregatetupleKeys...)
@@ -481,7 +480,7 @@ func UpdateTraintupleChildren(db *LedgerDB, traintupleKey string, traintupleStat
 		}
 
 		if child.Status != StatusWaiting {
-			return fmt.Errorf("traintuple %s has invalid status : '%s' instead of waiting", childTraintupleKey, child.Status)
+			return errors.Internal("traintuple %s has invalid status : '%s' instead of waiting", childTraintupleKey, child.Status)
 		}
 
 		childTraintupleStatus := child.Status
@@ -504,7 +503,7 @@ func UpdateTraintupleChildren(db *LedgerDB, traintupleKey string, traintupleStat
 				return err
 			}
 		default:
-			return fmt.Errorf("Unknown child traintuple type: %s", child.AssetType)
+			return errors.Internal("Unknown child traintuple type: %s", child.AssetType)
 		}
 
 		alreadyUpdatedKeys = append(alreadyUpdatedKeys, childTraintupleKey)
@@ -599,13 +598,13 @@ func (traintuple *Traintuple) commitStatusUpdate(db *LedgerDB, traintupleKey str
 	}
 
 	if err := traintuple.validateNewStatus(db, newStatus); err != nil {
-		return fmt.Errorf("update traintuple %s failed: %s", traintupleKey, err.Error())
+		return errors.Internal("update traintuple %s failed: %s", traintupleKey, err.Error())
 	}
 
 	oldStatus := traintuple.Status
 	traintuple.Status = newStatus
 	if err := db.Put(traintupleKey, traintuple); err != nil {
-		return fmt.Errorf("failed to update traintuple %s - %s", traintupleKey, err.Error())
+		return errors.Internal("failed to update traintuple %s - %s", traintupleKey, err.Error())
 	}
 
 	// update associated composite keys

--- a/chaincode/traintuple_composite.go
+++ b/chaincode/traintuple_composite.go
@@ -169,7 +169,7 @@ func (traintuple *CompositeTraintuple) AddToComputePlan(db *LedgerDB, inp inputC
 			return err
 		}
 		computePlan := ComputePlan{}
-		computePlan.AddTuple(traintuple.AssetType, traintupleKey, traintuple.Status)
+		computePlan.AddTuple(CompositeTraintupleType, traintupleKey, traintuple.Status)
 		traintuple.ComputePlanID, err = computePlan.Create(db)
 		if err != nil {
 			return err
@@ -181,7 +181,7 @@ func (traintuple *CompositeTraintuple) AddToComputePlan(db *LedgerDB, inp inputC
 	if err != nil {
 		return err
 	}
-	computePlan.AddTuple(traintuple.AssetType, traintupleKey, traintuple.Status)
+	computePlan.AddTuple(CompositeTraintupleType, traintupleKey, traintuple.Status)
 	err = computePlan.Save(db, traintuple.ComputePlanID)
 	if err != nil {
 		return err

--- a/chaincode/traintuple_composite.go
+++ b/chaincode/traintuple_composite.go
@@ -169,7 +169,8 @@ func (traintuple *CompositeTraintuple) AddToComputePlan(db *LedgerDB, inp inputC
 			err = errors.BadRequest("invalid inputs, a new ComputePlan should have a rank 0")
 			return err
 		}
-		computePlan := ComputePlan{Status: traintuple.Status, CompositeTraintupleKeys: []string{traintupleKey}}
+		computePlan := ComputePlan{}
+		computePlan.AddTuple(traintuple.AssetType, traintupleKey, traintuple.Status)
 		traintuple.ComputePlanID, err = computePlan.Create(db)
 		if err != nil {
 			return err
@@ -181,9 +182,7 @@ func (traintuple *CompositeTraintuple) AddToComputePlan(db *LedgerDB, inp inputC
 	if err != nil {
 		return err
 	}
-	computePlan.CompositeTraintupleKeys = append(computePlan.CompositeTraintupleKeys, traintupleKey)
-	computePlan.TupleCount++
-	computePlan.CheckNewTupleStatus(traintuple.Status)
+	computePlan.AddTuple(traintuple.AssetType, traintupleKey, traintuple.Status)
 	err = computePlan.Save(db, traintuple.ComputePlanID)
 	if err != nil {
 		return err
@@ -321,10 +320,6 @@ func logStartCompositeTrain(db *LedgerDB, args []string) (o outputCompositeTrain
 		return
 	}
 	err = o.Fill(db, compositeTraintuple, inp.Key)
-	if err != nil {
-		return
-	}
-	err = UpdateComputePlan(db, compositeTraintuple.ComputePlanID, compositeTraintuple.Status)
 	return
 }
 
@@ -371,11 +366,6 @@ func logSuccessCompositeTrain(db *LedgerDB, args []string) (o outputCompositeTra
 	}
 
 	err = o.Fill(db, compositeTraintuple, inp.Key)
-	if err != nil {
-		return
-	}
-
-	err = UpdateComputePlan(db, compositeTraintuple.ComputePlanID, compositeTraintuple.Status)
 	return
 }
 
@@ -404,10 +394,6 @@ func logFailCompositeTrain(db *LedgerDB, args []string) (o outputCompositeTraint
 	}
 
 	err = o.Fill(db, compositeTraintuple, inp.Key)
-	if err != nil {
-		return
-	}
-	err = UpdateComputePlan(db, compositeTraintuple.ComputePlanID, compositeTraintuple.Status)
 	if err != nil {
 		return
 	}
@@ -574,6 +560,9 @@ func (traintuple *CompositeTraintuple) commitStatusUpdate(db *LedgerDB, traintup
 	oldAttributes := []string{"compositeTraintuple", traintuple.Dataset.Worker, oldStatus, traintupleKey}
 	newAttributes := []string{"compositeTraintuple", traintuple.Dataset.Worker, traintuple.Status, traintupleKey}
 	if err := db.UpdateIndex(indexName, oldAttributes, newAttributes); err != nil {
+		return err
+	}
+	if err := UpdateComputePlan(db, traintuple.ComputePlanID, newStatus, traintupleKey); err != nil {
 		return err
 	}
 	logger.Infof("traintuple %s status updated: %s (from=%s)", traintupleKey, newStatus, oldStatus)

--- a/chaincode/traintuple_composite.go
+++ b/chaincode/traintuple_composite.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"chaincode/errors"
-	"fmt"
 	"strconv"
 )
 
@@ -546,13 +545,13 @@ func (traintuple *CompositeTraintuple) commitStatusUpdate(db *LedgerDB, traintup
 	}
 
 	if err := traintuple.validateNewStatus(db, newStatus); err != nil {
-		return fmt.Errorf("update traintuple %s failed: %s", traintupleKey, err.Error())
+		return errors.Internal("update traintuple %s failed: %s", traintupleKey, err.Error())
 	}
 
 	oldStatus := traintuple.Status
 	traintuple.Status = newStatus
 	if err := db.Put(traintupleKey, traintuple); err != nil {
-		return fmt.Errorf("failed to update traintuple %s - %s", traintupleKey, err.Error())
+		return errors.Internal("failed to update traintuple %s - %s", traintupleKey, err.Error())
 	}
 
 	// update associated composite keys

--- a/chaincode/tuple.go
+++ b/chaincode/tuple.go
@@ -18,7 +18,6 @@ import (
 	"chaincode/errors"
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"sort"
 )
 
@@ -174,7 +173,7 @@ func validateTupleOwner(db *LedgerDB, worker string) error {
 		return err
 	}
 	if txCreator != worker {
-		return fmt.Errorf("%s is not allowed to update tuple (%s)", txCreator, worker)
+		return errors.Forbidden("%s is not allowed to update tuple (%s)", txCreator, worker)
 	}
 	return nil
 }

--- a/chaincode/tuple_aggregate.go
+++ b/chaincode/tuple_aggregate.go
@@ -139,7 +139,7 @@ func (tuple *Aggregatetuple) AddToComputePlan(db *LedgerDB, inp inputAggregatetu
 			return err
 		}
 		computePlan := ComputePlan{}
-		computePlan.AddTuple(tuple.AssetType, traintupleKey, tuple.Status)
+		computePlan.AddTuple(AggregatetupleType, traintupleKey, tuple.Status)
 		tuple.ComputePlanID, err = computePlan.Create(db)
 		if err != nil {
 			return err
@@ -152,7 +152,7 @@ func (tuple *Aggregatetuple) AddToComputePlan(db *LedgerDB, inp inputAggregatetu
 	if err != nil {
 		return err
 	}
-	computePlan.AddTuple(tuple.AssetType, traintupleKey, tuple.Status)
+	computePlan.AddTuple(AggregatetupleType, traintupleKey, tuple.Status)
 	err = computePlan.Save(db, tuple.ComputePlanID)
 	if err != nil {
 		return err

--- a/chaincode/tuple_aggregate.go
+++ b/chaincode/tuple_aggregate.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"chaincode/errors"
-	"fmt"
 	"strconv"
 )
 
@@ -65,7 +64,7 @@ func (tuple *Aggregatetuple) SetFromParents(db *LedgerDB, inModels []string) err
 	for _, parentTraintupleKey := range inModels {
 		parentType, err := db.GetAssetType(parentTraintupleKey)
 		if err != nil {
-			return fmt.Errorf("could not retrieve traintuple type with key %s - %s", parentTraintupleKey, err.Error())
+			return errors.Internal("could not retrieve traintuple type with key %s - %s", parentTraintupleKey, err.Error())
 		}
 
 		parentPermissions := Permissions{}
@@ -92,11 +91,11 @@ func (tuple *Aggregatetuple) SetFromParents(db *LedgerDB, inModels []string) err
 				parentStatuses = append(parentStatuses, tuple.Status)
 			}
 		default:
-			return fmt.Errorf("aggregate.SetFromParents: Unsupported parent type %s", parentType)
+			return errors.Internal("aggregate.SetFromParents: Unsupported parent type %s", parentType)
 		}
 
 		if err != nil {
-			return fmt.Errorf("could not retrieve traintuple type with key %s - %s", parentTraintupleKey, err.Error())
+			return errors.Internal("could not retrieve traintuple type with key %s - %s", parentTraintupleKey, err.Error())
 		}
 
 		inModelKeys = append(inModelKeys, parentTraintupleKey)
@@ -499,13 +498,13 @@ func (tuple *Aggregatetuple) commitStatusUpdate(db *LedgerDB, aggregatetupleKey 
 	}
 
 	if err := tuple.validateNewStatus(db, newStatus); err != nil {
-		return fmt.Errorf("update aggregatetuple %s failed: %s", aggregatetupleKey, err.Error())
+		return errors.Internal("update aggregatetuple %s failed: %s", aggregatetupleKey, err.Error())
 	}
 
 	oldStatus := tuple.Status
 	tuple.Status = newStatus
 	if err := db.Put(aggregatetupleKey, tuple); err != nil {
-		return fmt.Errorf("failed to update aggregatetuple %s - %s", aggregatetupleKey, err.Error())
+		return errors.Internal("failed to update aggregatetuple %s - %s", aggregatetupleKey, err.Error())
 	}
 
 	// update associated composite keys

--- a/chaincode/utils.go
+++ b/chaincode/utils.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"reflect"
 	"unicode"
 	"unicode/utf8"
 
@@ -47,40 +46,6 @@ func typeInSlice(a AssetType, list []AssetType) bool {
 		}
 	}
 	return false
-}
-
-// inputStructToBytes converts fields of a struct (with string fields only, such as input struct defined in ledger.go) to a [][]byte
-func inputStructToBytes(v interface{}) (sb [][]byte, err error) {
-
-	e := reflect.Indirect(reflect.ValueOf(v))
-	for i := 0; i < e.NumField(); i++ {
-		v := e.Field(i)
-		if v.Type().Name() != "string" {
-			err = fmt.Errorf("struct should contain only string values")
-			return
-		}
-		varValue := v.String()
-		sb = append(sb, []byte(varValue))
-	}
-	return
-
-}
-
-// bytesToStruct converts bytes to one a the struct corresponding to elements stored in the ledger
-func bytesToStruct(elementBytes []byte, element interface{}) error {
-	return json.Unmarshal(elementBytes, &element)
-}
-
-// checkHashes checks if all elements in a slice are all hashes, returns error if not the case
-func checkHashes(hashes []string) (err error) {
-	for _, hash := range hashes {
-		// check validity of dataSampleHashes
-		if len(hash) != 64 {
-			err = fmt.Errorf("invalid hash %s", hash)
-			return
-		}
-	}
-	return
 }
 
 // AssetFromJSON unmarshal a stringify json into the passed interface


### PR DESCRIPTION
Optimize and fix the way we add a tuple to a compute plan. It's the first step for #76 but can be merged at anytime.