### PR TITLE
Add union operator for permissions

### DIFF
--- a/chaincode/permissions_test.go
+++ b/chaincode/permissions_test.go
@@ -103,17 +103,17 @@ func TestMergingMechanism(t *testing.T) {
 				Public:        test.toMergeINR,
 				AuthorizedIDs: test.toMergeRU,
 			}
-			mergedPriv := mergePermissions(defaultPermission, toMerge)
+			mergedPriv := mergePermissions(defaultPermission, toMerge, "intersection")
 			assert.Equal(t, test.expectedINR, mergedPriv.Public)
 			assert.ElementsMatch(t, test.expectedRU, mergedPriv.AuthorizedIDs)
-			privMerged := mergePermissions(toMerge, defaultPermission)
+			privMerged := mergePermissions(toMerge, defaultPermission, "intersection")
 			assert.Equal(t, mergedPriv.Public, privMerged.Public, "merging should be transitif")
 			assert.ElementsMatch(t, mergedPriv.AuthorizedIDs, privMerged.AuthorizedIDs, "merging should be transitif")
 
-			theSamePriv := mergePermissions(Permission{Public: true}, toMerge)
+			theSamePriv := mergePermissions(Permission{Public: true}, toMerge, "intersection")
 			assert.Equal(t, toMerge.Public, theSamePriv.Public, "a non restrictive permission should be neutral")
 			assert.ElementsMatch(t, toMerge.AuthorizedIDs, theSamePriv.AuthorizedIDs, "a non restrictive permission should be neutral")
-			theSamePriv = mergePermissions(toMerge, Permission{Public: true})
+			theSamePriv = mergePermissions(toMerge, Permission{Public: true}, "intersection")
 			assert.Equal(t, toMerge.Public, theSamePriv.Public, "neutral element should be transitive")
 			assert.ElementsMatch(t, toMerge.AuthorizedIDs, theSamePriv.AuthorizedIDs, "neutral element should be transitive")
 		})

--- a/chaincode/traintuple.go
+++ b/chaincode/traintuple.go
@@ -69,7 +69,7 @@ func (traintuple *Traintuple) SetFromInput(db *LedgerDB, inp inputTraintuple) er
 		return errors.Forbidden("not authorized to process dataManager %s", inp.DataManagerKey)
 	}
 
-	traintuple.Permissions = MergePermissions(dataManager.Permissions, algo.Permissions)
+	traintuple.Permissions = MergePermissions(dataManager.Permissions, algo.Permissions, "intersection")
 
 	// fill traintuple.Dataset from dataManager and dataSample
 	traintuple.Dataset = &Dataset{

--- a/chaincode/tuple_aggregate.go
+++ b/chaincode/tuple_aggregate.go
@@ -100,7 +100,7 @@ func (tuple *Aggregatetuple) SetFromParents(db *LedgerDB, inModels []string) err
 		}
 
 		inModelKeys = append(inModelKeys, parentTraintupleKey)
-		permissions = MergePermissions(permissions, parentPermissions)
+		permissions = MergePermissions(permissions, parentPermissions, "union")
 	}
 	tuple.Status = determineStatusFromInModels(parentStatuses)
 	tuple.InModelKeys = inModelKeys

--- a/chaincode/tuple_aggregate_test.go
+++ b/chaincode/tuple_aggregate_test.go
@@ -482,8 +482,8 @@ func TestAggregatetuplePermissions(t *testing.T) {
 	// verify permissions
 	assert.EqualValues(t, false, aggr.Permissions.Process.Public,
 		"the aggregate tuple should not be public")
-	assert.EqualValues(t, []string{worker, "nodeC"}, aggr.Permissions.Process.AuthorizedIDs,
-		"the aggregate tuple permissions should be the intersect of the in-model permissions")
+	assert.EqualValues(t, []string{worker, "nodeA", "nodeC", "nodeB", "nodeD"}, aggr.Permissions.Process.AuthorizedIDs,
+		"the aggregate tuple permissions should be the union of the in-model permissions")
 }
 
 func TestAggregatetupleLogSuccessFail(t *testing.T) {


### PR DESCRIPTION
Implement union operator for aggregate tuple permissions to test if fix model protection in the backend is compatible.

It should fix issues in substra-tests.
