### PR TITLE
Limit the size of compute plan output

### DIFF
--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -306,9 +306,12 @@ type outputComputePlan struct {
 
 func (out *outputComputePlan) Fill(key string, in ComputePlan) {
 	out.ComputePlanID = key
-	out.TraintupleKeys = in.TraintupleKeys
-	out.AggregatetupleKeys = in.AggregatetupleKeys
-	out.CompositeTraintupleKeys = in.CompositeTraintupleKeys
+	nb := getLimitedNbSliceElements(in.TraintupleKeys)
+	out.TraintupleKeys = in.TraintupleKeys[:nb]
+	nb = getLimitedNbSliceElements(in.AggregatetupleKeys)
+	out.AggregatetupleKeys = in.AggregatetupleKeys[:nb]
+	nb = getLimitedNbSliceElements(in.CompositeTraintupleKeys)
+	out.CompositeTraintupleKeys = in.CompositeTraintupleKeys[:nb]
 	out.TesttupleKeys = in.TesttupleKeys
 	out.Status = in.Status
 	out.Tag = in.Tag


### PR DESCRIPTION
Since there was an issue with too big computeplan for GRPC around 8000 tuples, we limit the number of train like tuples' keys. We don't limit the number of test tuples since there are crucial for the current project nor the list matching IDs to keys.
But this is mostly arbitrary and open to discussion.