### PR TITLE
Return only new ID to Key

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1499,8 +1499,6 @@ peer chaincode invoke -n mycc -c '{"Args":["updateComputePlan","{\"computePlanID
 ```json
 {
  "IDToKey": {
-  "firstTraintupleID": "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
-  "secondTraintupleID": "d23f8cf290b902417ae698d68e2c6835483521d54fcbece31208517759b7c299",
   "thirdTraintupleID": "c163663889566a4c51fad3765107774891f8ed456dcc859a9a1a7fcd17b11386"
  },
  "aggregatetupleKeys": null,
@@ -1598,11 +1596,7 @@ peer chaincode invoke -n mycc -c '{"Args":["queryComputePlan","{\"key\":\"7dd808
 ##### Command output:
 ```json
 {
- "IDToKey": {
-  "firstTraintupleID": "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
-  "secondTraintupleID": "d23f8cf290b902417ae698d68e2c6835483521d54fcbece31208517759b7c299",
-  "thirdTraintupleID": "c163663889566a4c51fad3765107774891f8ed456dcc859a9a1a7fcd17b11386"
- },
+ "IDToKey": {},
  "aggregatetupleKeys": null,
  "compositeTraintupleKeys": null,
  "computePlanID": "7dd808239c1e062399449bd11b634d9bd1fd0a2b795ad345b62f95b4933bfa17",
@@ -1629,11 +1623,7 @@ peer chaincode invoke -n mycc -c '{"Args":["queryComputePlans"]}' -C myc
 ```json
 [
  {
-  "IDToKey": {
-   "firstTraintupleID": "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
-   "secondTraintupleID": "d23f8cf290b902417ae698d68e2c6835483521d54fcbece31208517759b7c299",
-   "thirdTraintupleID": "c163663889566a4c51fad3765107774891f8ed456dcc859a9a1a7fcd17b11386"
-  },
+  "IDToKey": {},
   "aggregatetupleKeys": null,
   "compositeTraintupleKeys": null,
   "computePlanID": "7dd808239c1e062399449bd11b634d9bd1fd0a2b795ad345b62f95b4933bfa17",
@@ -1669,11 +1659,7 @@ peer chaincode invoke -n mycc -c '{"Args":["cancelComputePlan","{\"key\":\"7dd80
 ##### Command output:
 ```json
 {
- "IDToKey": {
-  "firstTraintupleID": "432fcffdf68892f5e4adeeed8bb618beaeaecf709f840671eca724a3e3109369",
-  "secondTraintupleID": "d23f8cf290b902417ae698d68e2c6835483521d54fcbece31208517759b7c299",
-  "thirdTraintupleID": "c163663889566a4c51fad3765107774891f8ed456dcc859a9a1a7fcd17b11386"
- },
+ "IDToKey": {},
  "aggregatetupleKeys": null,
  "compositeTraintupleKeys": null,
  "computePlanID": "7dd808239c1e062399449bd11b634d9bd1fd0a2b795ad345b62f95b4933bfa17",

--- a/chaincode/compute_plan.go
+++ b/chaincode/compute_plan.go
@@ -138,7 +138,7 @@ func createComputePlanInternal(db *LedgerDB, inp inputComputePlan, tag string) (
 		len(inp.CompositeTraintuples) +
 		len(inp.Testtuples)
 	if count == 0 {
-		resp.Fill(ID, computePlan)
+		resp.Fill(ID, computePlan, []string{})
 		return resp, nil
 	}
 	return updateComputePlanInternal(db, ID, inp)
@@ -154,6 +154,7 @@ func updateComputePlanInternal(db *LedgerDB, computePlanID string, inp inputComp
 	for ID, trainTask := range computePlan.IDToTrainTask {
 		IDToTrainTask[ID] = trainTask
 	}
+	NewIDs := []string{}
 	DAG, err := createComputeDAG(inp, computePlan.IDToTrainTask)
 	if err != nil {
 		return resp, errors.BadRequest(err)
@@ -211,6 +212,7 @@ func updateComputePlanInternal(db *LedgerDB, computePlanID string, inp inputComp
 			}
 		}
 		IDToTrainTask[task.ID] = TrainTask{Depth: task.Depth, Key: tupleKey}
+		NewIDs = append(NewIDs, task.ID)
 	}
 
 	for index, computeTesttuple := range inp.Testtuples {
@@ -236,7 +238,7 @@ func updateComputePlanInternal(db *LedgerDB, computePlanID string, inp inputComp
 	if err != nil {
 		return resp, err
 	}
-	resp.Fill(computePlanID, computePlan)
+	resp.Fill(computePlanID, computePlan, NewIDs)
 	return resp, err
 }
 
@@ -275,7 +277,7 @@ func getOutComputePlan(db *LedgerDB, key string) (resp outputComputePlan, err er
 		return resp, err
 	}
 
-	resp.Fill(key, computePlan)
+	resp.Fill(key, computePlan, []string{})
 	return resp, err
 }
 
@@ -297,7 +299,7 @@ func cancelComputePlan(db *LedgerDB, args []string) (resp outputComputePlan, err
 	}
 
 	db.AddComputePlanEvent(inp.Key, computeplan.State.Status)
-	resp.Fill(inp.Key, computeplan)
+	resp.Fill(inp.Key, computeplan, []string{})
 	return resp, nil
 }
 

--- a/chaincode/compute_plan_test.go
+++ b/chaincode/compute_plan_test.go
@@ -681,7 +681,7 @@ func TestUpdateComputePlan(t *testing.T) {
 	assert.Len(
 		t,
 		out.IDToKey,
-		3,
-		"IDToKey should match the 3 train like tuples keys to their respective ID")
+		1,
+		"IDToKey should match the newly created tuple keys to its ID")
 	assert.Equal(t, 4, out.TupleCount)
 }

--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -311,7 +311,7 @@ type outputComputePlan struct {
 	IDToKey                 map[string]string `json:"IDToKey"`
 }
 
-func (out *outputComputePlan) Fill(key string, in ComputePlan, IDs []string) {
+func (out *outputComputePlan) Fill(key string, in ComputePlan, newIDs []string) {
 	out.ComputePlanID = key
 	nb := getLimitedNbSliceElements(in.TraintupleKeys)
 	out.TraintupleKeys = in.TraintupleKeys[:nb]
@@ -325,7 +325,7 @@ func (out *outputComputePlan) Fill(key string, in ComputePlan, IDs []string) {
 	out.TupleCount = in.State.TupleCount
 	out.DoneCount = in.State.DoneCount
 	IDToKey := map[string]string{}
-	for _, ID := range IDs {
+	for _, ID := range newIDs {
 		IDToKey[ID] = in.IDToTrainTask[ID].Key
 	}
 	out.IDToKey = IDToKey

--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -311,7 +311,7 @@ type outputComputePlan struct {
 	IDToKey                 map[string]string `json:"IDToKey"`
 }
 
-func (out *outputComputePlan) Fill(key string, in ComputePlan) {
+func (out *outputComputePlan) Fill(key string, in ComputePlan, IDs []string) {
 	out.ComputePlanID = key
 	nb := getLimitedNbSliceElements(in.TraintupleKeys)
 	out.TraintupleKeys = in.TraintupleKeys[:nb]
@@ -325,8 +325,8 @@ func (out *outputComputePlan) Fill(key string, in ComputePlan) {
 	out.TupleCount = in.State.TupleCount
 	out.DoneCount = in.State.DoneCount
 	IDToKey := map[string]string{}
-	for ID, trainTask := range in.IDToTrainTask {
-		IDToKey[ID] = trainTask.Key
+	for _, ID := range IDs {
+		IDToKey[ID] = in.IDToTrainTask[ID].Key
 	}
 	out.IDToKey = IDToKey
 }


### PR DESCRIPTION
We reached a new limit while testing and decided to limit even more the potential size of the compute plan's output. So for now we only return the newly added IDs in the `IDtoKey` field.