### PR TITLE
Check done intermediary models only when tuple is Done

### DIFF
--- a/chaincode/compute_plan.go
+++ b/chaincode/compute_plan.go
@@ -414,7 +414,11 @@ func UpdateComputePlanState(db *LedgerDB, ComputePlanID, tupleStatus, tupleKey s
 		return err
 	}
 	statusUpdated := cp.UpdateStatus(tupleStatus)
-	doneModels, err := cp.CheckDoneIntermediaryModel(db)
+	doneModels := []string{}
+	if tupleStatus == StatusDone {
+		doneModels, err = cp.CheckDoneIntermediaryModel(db)
+	}
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

This will perform a check of done intermediary models only when a tuple is Done, to avoid MVCC.

This PR is targeting master, the commit is already present is melloddy branch and the tag 0.0.9-melloddy.1