### PR TITLE
Add channel name in chaincode log in case of multi-channels

### DIFF
--- a/chaincode/algo_aggregate_test.go
+++ b/chaincode/algo_aggregate_test.go
@@ -32,7 +32,7 @@ func TestAggregateAlgo(t *testing.T) {
 		},
 	}
 	args := inpAlgo.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding algo with invalid checksum, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add algo
@@ -46,7 +46,7 @@ func TestAggregateAlgo(t *testing.T) {
 
 	// Query algo from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryAggregateAlgo"), keyToJSON(algoKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying an aggregate algo with status %d and message %s", resp.Status, resp.Message)
 	algo := outputAggregateAlgo{}
 	err = json.Unmarshal(resp.Payload, &algo)
@@ -74,7 +74,7 @@ func TestAggregateAlgo(t *testing.T) {
 
 	// Query all algo and check consistency
 	args = [][]byte{[]byte("queryAggregateAlgos")}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying aggregate algos - status %d and message %s", resp.Status, resp.Message)
 	var algos []outputAggregateAlgo
 	err = json.Unmarshal(resp.Payload, &algos)

--- a/chaincode/algo_aggregate_test.go
+++ b/chaincode/algo_aggregate_test.go
@@ -32,7 +32,7 @@ func TestAggregateAlgo(t *testing.T) {
 		},
 	}
 	args := inpAlgo.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding algo with invalid checksum, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add algo
@@ -46,7 +46,7 @@ func TestAggregateAlgo(t *testing.T) {
 
 	// Query algo from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryAggregateAlgo"), keyToJSON(algoKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying an aggregate algo with status %d and message %s", resp.Status, resp.Message)
 	algo := outputAggregateAlgo{}
 	err = json.Unmarshal(resp.Payload, &algo)
@@ -74,7 +74,7 @@ func TestAggregateAlgo(t *testing.T) {
 
 	// Query all algo and check consistency
 	args = [][]byte{[]byte("queryAggregateAlgos")}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying aggregate algos - status %d and message %s", resp.Status, resp.Message)
 	var algos []outputAggregateAlgo
 	err = json.Unmarshal(resp.Payload, &algos)

--- a/chaincode/algo_aggregate_test.go
+++ b/chaincode/algo_aggregate_test.go
@@ -24,6 +24,7 @@ import (
 func TestAggregateAlgo(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add algo with invalid field
 	inpAlgo := inputAggregateAlgo{
@@ -32,7 +33,7 @@ func TestAggregateAlgo(t *testing.T) {
 		},
 	}
 	args := inpAlgo.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding algo with invalid checksum, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add algo
@@ -46,7 +47,7 @@ func TestAggregateAlgo(t *testing.T) {
 
 	// Query algo from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryAggregateAlgo"), keyToJSON(algoKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying an aggregate algo with status %d and message %s", resp.Status, resp.Message)
 	algo := outputAggregateAlgo{}
 	err = json.Unmarshal(resp.Payload, &algo)
@@ -74,7 +75,7 @@ func TestAggregateAlgo(t *testing.T) {
 
 	// Query all algo and check consistency
 	args = [][]byte{[]byte("queryAggregateAlgos")}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying aggregate algos - status %d and message %s", resp.Status, resp.Message)
 	var algos []outputAggregateAlgo
 	err = json.Unmarshal(resp.Payload, &algos)

--- a/chaincode/algo_aggregate_test.go
+++ b/chaincode/algo_aggregate_test.go
@@ -24,7 +24,6 @@ import (
 func TestAggregateAlgo(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add algo with invalid field
 	inpAlgo := inputAggregateAlgo{

--- a/chaincode/algo_composite_test.go
+++ b/chaincode/algo_composite_test.go
@@ -24,7 +24,6 @@ import (
 func TestCompositeAlgo(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add algo with invalid field
 	inpAlgo := inputCompositeAlgo{

--- a/chaincode/algo_composite_test.go
+++ b/chaincode/algo_composite_test.go
@@ -24,6 +24,7 @@ import (
 func TestCompositeAlgo(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add algo with invalid field
 	inpAlgo := inputCompositeAlgo{
@@ -32,7 +33,7 @@ func TestCompositeAlgo(t *testing.T) {
 		},
 	}
 	args := inpAlgo.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding algo with invalid checksum, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add algo
@@ -46,7 +47,7 @@ func TestCompositeAlgo(t *testing.T) {
 
 	// Query algo from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryCompositeAlgo"), keyToJSON(algoKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying a composite algo with status %d and message %s", resp.Status, resp.Message)
 	algo := outputCompositeAlgo{}
 	err = json.Unmarshal(resp.Payload, &algo)
@@ -74,7 +75,7 @@ func TestCompositeAlgo(t *testing.T) {
 
 	// Query all algo and check consistency
 	args = [][]byte{[]byte("queryCompositeAlgos")}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying composite algos - status %d and message %s", resp.Status, resp.Message)
 	var algos []outputCompositeAlgo
 	err = json.Unmarshal(resp.Payload, &algos)

--- a/chaincode/algo_composite_test.go
+++ b/chaincode/algo_composite_test.go
@@ -32,7 +32,7 @@ func TestCompositeAlgo(t *testing.T) {
 		},
 	}
 	args := inpAlgo.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding algo with invalid checksum, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add algo
@@ -46,7 +46,7 @@ func TestCompositeAlgo(t *testing.T) {
 
 	// Query algo from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryCompositeAlgo"), keyToJSON(algoKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying a composite algo with status %d and message %s", resp.Status, resp.Message)
 	algo := outputCompositeAlgo{}
 	err = json.Unmarshal(resp.Payload, &algo)
@@ -74,7 +74,7 @@ func TestCompositeAlgo(t *testing.T) {
 
 	// Query all algo and check consistency
 	args = [][]byte{[]byte("queryCompositeAlgos")}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying composite algos - status %d and message %s", resp.Status, resp.Message)
 	var algos []outputCompositeAlgo
 	err = json.Unmarshal(resp.Payload, &algos)

--- a/chaincode/algo_composite_test.go
+++ b/chaincode/algo_composite_test.go
@@ -32,7 +32,7 @@ func TestCompositeAlgo(t *testing.T) {
 		},
 	}
 	args := inpAlgo.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding algo with invalid checksum, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add algo
@@ -46,7 +46,7 @@ func TestCompositeAlgo(t *testing.T) {
 
 	// Query algo from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryCompositeAlgo"), keyToJSON(algoKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying a composite algo with status %d and message %s", resp.Status, resp.Message)
 	algo := outputCompositeAlgo{}
 	err = json.Unmarshal(resp.Payload, &algo)
@@ -74,7 +74,7 @@ func TestCompositeAlgo(t *testing.T) {
 
 	// Query all algo and check consistency
 	args = [][]byte{[]byte("queryCompositeAlgos")}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying composite algos - status %d and message %s", resp.Status, resp.Message)
 	var algos []outputCompositeAlgo
 	err = json.Unmarshal(resp.Payload, &algos)

--- a/chaincode/algo_test.go
+++ b/chaincode/algo_test.go
@@ -24,7 +24,6 @@ import (
 func TestAlgo(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add algo with invalid field
 	inpAlgo := inputAlgo{

--- a/chaincode/algo_test.go
+++ b/chaincode/algo_test.go
@@ -24,13 +24,14 @@ import (
 func TestAlgo(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add algo with invalid field
 	inpAlgo := inputAlgo{
 		DescriptionChecksum: "aaa",
 	}
 	args := inpAlgo.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding algo with invalid checksum, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add algo
@@ -43,7 +44,7 @@ func TestAlgo(t *testing.T) {
 
 	// Query algo from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryAlgo"), keyToJSON(algoKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying an algo with status %d and message %s", resp.Status, resp.Message)
 	algo := outputAlgo{}
 	err = json.Unmarshal(resp.Payload, &algo)
@@ -69,7 +70,7 @@ func TestAlgo(t *testing.T) {
 
 	// Query all algo and check consistency
 	args = [][]byte{[]byte("queryAlgos")}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying algos - status %d and message %s", resp.Status, resp.Message)
 	var algos []outputAlgo
 	err = json.Unmarshal(resp.Payload, &algos)

--- a/chaincode/algo_test.go
+++ b/chaincode/algo_test.go
@@ -30,7 +30,7 @@ func TestAlgo(t *testing.T) {
 		DescriptionChecksum: "aaa",
 	}
 	args := inpAlgo.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding algo with invalid checksum, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add algo
@@ -43,7 +43,7 @@ func TestAlgo(t *testing.T) {
 
 	// Query algo from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryAlgo"), keyToJSON(algoKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying an algo with status %d and message %s", resp.Status, resp.Message)
 	algo := outputAlgo{}
 	err = json.Unmarshal(resp.Payload, &algo)
@@ -69,7 +69,7 @@ func TestAlgo(t *testing.T) {
 
 	// Query all algo and check consistency
 	args = [][]byte{[]byte("queryAlgos")}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying algos - status %d and message %s", resp.Status, resp.Message)
 	var algos []outputAlgo
 	err = json.Unmarshal(resp.Payload, &algos)

--- a/chaincode/algo_test.go
+++ b/chaincode/algo_test.go
@@ -30,7 +30,7 @@ func TestAlgo(t *testing.T) {
 		DescriptionChecksum: "aaa",
 	}
 	args := inpAlgo.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding algo with invalid checksum, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add algo
@@ -43,7 +43,7 @@ func TestAlgo(t *testing.T) {
 
 	// Query algo from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryAlgo"), keyToJSON(algoKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying an algo with status %d and message %s", resp.Status, resp.Message)
 	algo := outputAlgo{}
 	err = json.Unmarshal(resp.Payload, &algo)
@@ -69,7 +69,7 @@ func TestAlgo(t *testing.T) {
 
 	// Query all algo and check consistency
 	args = [][]byte{[]byte("queryAlgos")}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying algos - status %d and message %s", resp.Status, resp.Message)
 	var algos []outputAlgo
 	err = json.Unmarshal(resp.Payload, &algos)

--- a/chaincode/data_test.go
+++ b/chaincode/data_test.go
@@ -24,7 +24,6 @@ import (
 func TestJsonInputsDataManager(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	inpDataManager := inputDataManager{}
 	inpDataManager.createDefault()
@@ -37,7 +36,6 @@ func TestJsonInputsDataManager(t *testing.T) {
 func TestDataManager(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add dataManager with invalid field
 	inpDataManager := inputDataManager{
@@ -111,7 +109,6 @@ func TestDataManager(t *testing.T) {
 func TestGetTestDatasetKeys(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Input DataManager
 	inpDataManager := inputDataManager{}
@@ -143,7 +140,6 @@ func TestGetTestDatasetKeys(t *testing.T) {
 func TestDataset(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add dataSample with invalid field
 	inpDataSample := inputDataSample{

--- a/chaincode/data_test.go
+++ b/chaincode/data_test.go
@@ -30,7 +30,7 @@ func TestJsonInputsDataManager(t *testing.T) {
 	payload, err := json.Marshal(inpDataManager)
 	assert.NoError(t, err)
 	args := [][]byte{[]byte("registerDataManager"), payload}
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status)
 }
 func TestDataManager(t *testing.T) {
@@ -42,7 +42,7 @@ func TestDataManager(t *testing.T) {
 		OpenerChecksum: "aaa",
 	}
 	args := inpDataManager.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding dataManager with invalid opener checksum, status %d and message %s", resp.Status, resp.Message)
 	// Properly add dataManager
 	resp, tt := registerItem(t, *mockStub, "dataManager")
@@ -56,11 +56,11 @@ func TestDataManager(t *testing.T) {
 	// Add dataManager which already exist
 	inpDataManager = inputDataManager{}
 	args = inpDataManager.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 409, resp.Status, "when adding dataManager which already exists, status %d and message %s", resp.Status, resp.Message)
 	// Query dataManager and check fields match expectations
 	args = [][]byte{[]byte("queryDataManager"), keyToJSON(dataManagerKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the dataManager, status %d and message %s", resp.Status, resp.Message)
 	dataManager := outputDataManager{}
 	err = json.Unmarshal(resp.Payload, &dataManager)
@@ -88,7 +88,7 @@ func TestDataManager(t *testing.T) {
 
 	// Query all dataManagers and check fields match expectations
 	args = [][]byte{[]byte("queryDataManagers")}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying dataManagers - status %d and message %s", resp.Status, resp.Message)
 	var dataManagers []outputDataManager
 	err = json.Unmarshal(resp.Payload, &dataManagers)
@@ -97,7 +97,7 @@ func TestDataManager(t *testing.T) {
 	assert.Exactly(t, expectedDataManager, dataManagers[0], "return objective different from registered one")
 
 	args = [][]byte{[]byte("queryDataset"), keyToJSON(inpDataManager.Key)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying Dataset, status %d and message %s", resp.Status, resp.Message)
 	out := outputDataset{}
 	err = json.Unmarshal(resp.Payload, &out)
@@ -113,20 +113,20 @@ func TestGetTestDatasetKeys(t *testing.T) {
 	// Input DataManager
 	inpDataManager := inputDataManager{}
 	args := inpDataManager.createDefault()
-	mockStub.MockInvoke(mockTxID, args)
+	mockStub.MockInvoke(args)
 
 	// Add both train and test dataSample
 	inpDataSample := inputDataSample{Keys: []string{testDataSampleKey1}}
 	args = inpDataSample.createDefault()
-	mockStub.MockInvoke(mockTxID, args)
+	mockStub.MockInvoke(args)
 	inpDataSample.Keys = []string{testDataSampleKey2}
 	inpDataSample.TestOnly = "true"
 	args = inpDataSample.createDefault()
-	mockStub.MockInvoke(mockTxID, args)
+	mockStub.MockInvoke(args)
 
 	// Query the DataManager
 	args = [][]byte{[]byte("queryDataset"), keyToJSON(inpDataManager.Key)}
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "querying the dataManager should return an ok status")
 	payload := map[string]interface{}{}
 	err := json.Unmarshal(resp.Payload, &payload)
@@ -146,13 +146,13 @@ func TestDataset(t *testing.T) {
 		Keys: []string{"aaa"},
 	}
 	args := inpDataSample.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding dataSample with invalid key, status %d and message %s", resp.Status, resp.Message)
 
 	// Add dataSample with unexiting dataManager
 	inpDataSample = inputDataSample{}
 	args = inpDataSample.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding dataSample with unexisting dataManager, status %d and message %s", resp.Status, resp.Message)
 	// TODO Would be nice to check failure when adding dataSample to a dataManager owned by a different people
 
@@ -160,11 +160,11 @@ func TestDataset(t *testing.T) {
 	// 1. add associated dataManager
 	inpDataManager := inputDataManager{}
 	args = inpDataManager.createDefault()
-	mockStub.MockInvoke(mockTxID, args)
+	mockStub.MockInvoke(args)
 	// 2. add dataSample
 	inpDataSample = inputDataSample{}
 	args = inpDataSample.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when adding dataSample, status %d and message %s", resp.Status, resp.Message)
 	// check payload correspond to input dataSample keys
 	res := map[string]interface{}{}
@@ -176,12 +176,12 @@ func TestDataset(t *testing.T) {
 	assert.ElementsMatch(t, expectedResp, dataSampleKeys, "when adding dataSample: dataSample keys does not correspond to dataSample keys")
 
 	// Add dataSample which already exist
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 409, resp.Status, "when adding dataSample which already exist, status %d and message %s", resp.Status, resp.Message)
 
 	// Query dataSample and check it corresponds to what was input
 	args = [][]byte{[]byte("queryDataset"), keyToJSON(inpDataManager.Key)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying dataManager dataSample with status %d and message %s", resp.Status, resp.Message)
 	out := outputDataset{}
 	err = json.Unmarshal(resp.Payload, &out)

--- a/chaincode/data_test.go
+++ b/chaincode/data_test.go
@@ -24,25 +24,27 @@ import (
 func TestJsonInputsDataManager(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	inpDataManager := inputDataManager{}
 	inpDataManager.createDefault()
 	payload, err := json.Marshal(inpDataManager)
 	assert.NoError(t, err)
 	args := [][]byte{[]byte("registerDataManager"), payload}
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status)
 }
 func TestDataManager(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add dataManager with invalid field
 	inpDataManager := inputDataManager{
 		OpenerChecksum: "aaa",
 	}
 	args := inpDataManager.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding dataManager with invalid opener checksum, status %d and message %s", resp.Status, resp.Message)
 	// Properly add dataManager
 	resp, tt := registerItem(t, *mockStub, "dataManager")
@@ -56,11 +58,11 @@ func TestDataManager(t *testing.T) {
 	// Add dataManager which already exist
 	inpDataManager = inputDataManager{}
 	args = inpDataManager.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 409, resp.Status, "when adding dataManager which already exists, status %d and message %s", resp.Status, resp.Message)
 	// Query dataManager and check fields match expectations
 	args = [][]byte{[]byte("queryDataManager"), keyToJSON(dataManagerKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the dataManager, status %d and message %s", resp.Status, resp.Message)
 	dataManager := outputDataManager{}
 	err = json.Unmarshal(resp.Payload, &dataManager)
@@ -88,7 +90,7 @@ func TestDataManager(t *testing.T) {
 
 	// Query all dataManagers and check fields match expectations
 	args = [][]byte{[]byte("queryDataManagers")}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying dataManagers - status %d and message %s", resp.Status, resp.Message)
 	var dataManagers []outputDataManager
 	err = json.Unmarshal(resp.Payload, &dataManagers)
@@ -97,7 +99,7 @@ func TestDataManager(t *testing.T) {
 	assert.Exactly(t, expectedDataManager, dataManagers[0], "return objective different from registered one")
 
 	args = [][]byte{[]byte("queryDataset"), keyToJSON(inpDataManager.Key)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying Dataset, status %d and message %s", resp.Status, resp.Message)
 	out := outputDataset{}
 	err = json.Unmarshal(resp.Payload, &out)
@@ -109,24 +111,25 @@ func TestDataManager(t *testing.T) {
 func TestGetTestDatasetKeys(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Input DataManager
 	inpDataManager := inputDataManager{}
 	args := inpDataManager.createDefault()
-	mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	mockStub.MockInvoke(mockTxID, args)
 
 	// Add both train and test dataSample
 	inpDataSample := inputDataSample{Keys: []string{testDataSampleKey1}}
 	args = inpDataSample.createDefault()
-	mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	mockStub.MockInvoke(mockTxID, args)
 	inpDataSample.Keys = []string{testDataSampleKey2}
 	inpDataSample.TestOnly = "true"
 	args = inpDataSample.createDefault()
-	mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	mockStub.MockInvoke(mockTxID, args)
 
 	// Query the DataManager
 	args = [][]byte{[]byte("queryDataset"), keyToJSON(inpDataManager.Key)}
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "querying the dataManager should return an ok status")
 	payload := map[string]interface{}{}
 	err := json.Unmarshal(resp.Payload, &payload)
@@ -140,19 +143,20 @@ func TestGetTestDatasetKeys(t *testing.T) {
 func TestDataset(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add dataSample with invalid field
 	inpDataSample := inputDataSample{
 		Keys: []string{"aaa"},
 	}
 	args := inpDataSample.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding dataSample with invalid key, status %d and message %s", resp.Status, resp.Message)
 
 	// Add dataSample with unexiting dataManager
 	inpDataSample = inputDataSample{}
 	args = inpDataSample.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding dataSample with unexisting dataManager, status %d and message %s", resp.Status, resp.Message)
 	// TODO Would be nice to check failure when adding dataSample to a dataManager owned by a different people
 
@@ -160,11 +164,11 @@ func TestDataset(t *testing.T) {
 	// 1. add associated dataManager
 	inpDataManager := inputDataManager{}
 	args = inpDataManager.createDefault()
-	mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	mockStub.MockInvoke(mockTxID, args)
 	// 2. add dataSample
 	inpDataSample = inputDataSample{}
 	args = inpDataSample.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when adding dataSample, status %d and message %s", resp.Status, resp.Message)
 	// check payload correspond to input dataSample keys
 	res := map[string]interface{}{}
@@ -176,12 +180,12 @@ func TestDataset(t *testing.T) {
 	assert.ElementsMatch(t, expectedResp, dataSampleKeys, "when adding dataSample: dataSample keys does not correspond to dataSample keys")
 
 	// Add dataSample which already exist
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 409, resp.Status, "when adding dataSample which already exist, status %d and message %s", resp.Status, resp.Message)
 
 	// Query dataSample and check it corresponds to what was input
 	args = [][]byte{[]byte("queryDataset"), keyToJSON(inpDataManager.Key)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying dataManager dataSample with status %d and message %s", resp.Status, resp.Message)
 	out := outputDataset{}
 	err = json.Unmarshal(resp.Payload, &out)

--- a/chaincode/data_test.go
+++ b/chaincode/data_test.go
@@ -30,7 +30,7 @@ func TestJsonInputsDataManager(t *testing.T) {
 	payload, err := json.Marshal(inpDataManager)
 	assert.NoError(t, err)
 	args := [][]byte{[]byte("registerDataManager"), payload}
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status)
 }
 func TestDataManager(t *testing.T) {
@@ -42,7 +42,7 @@ func TestDataManager(t *testing.T) {
 		OpenerChecksum: "aaa",
 	}
 	args := inpDataManager.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding dataManager with invalid opener checksum, status %d and message %s", resp.Status, resp.Message)
 	// Properly add dataManager
 	resp, tt := registerItem(t, *mockStub, "dataManager")
@@ -56,11 +56,11 @@ func TestDataManager(t *testing.T) {
 	// Add dataManager which already exist
 	inpDataManager = inputDataManager{}
 	args = inpDataManager.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 409, resp.Status, "when adding dataManager which already exists, status %d and message %s", resp.Status, resp.Message)
 	// Query dataManager and check fields match expectations
 	args = [][]byte{[]byte("queryDataManager"), keyToJSON(dataManagerKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the dataManager, status %d and message %s", resp.Status, resp.Message)
 	dataManager := outputDataManager{}
 	err = json.Unmarshal(resp.Payload, &dataManager)
@@ -88,7 +88,7 @@ func TestDataManager(t *testing.T) {
 
 	// Query all dataManagers and check fields match expectations
 	args = [][]byte{[]byte("queryDataManagers")}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying dataManagers - status %d and message %s", resp.Status, resp.Message)
 	var dataManagers []outputDataManager
 	err = json.Unmarshal(resp.Payload, &dataManagers)
@@ -97,7 +97,7 @@ func TestDataManager(t *testing.T) {
 	assert.Exactly(t, expectedDataManager, dataManagers[0], "return objective different from registered one")
 
 	args = [][]byte{[]byte("queryDataset"), keyToJSON(inpDataManager.Key)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying Dataset, status %d and message %s", resp.Status, resp.Message)
 	out := outputDataset{}
 	err = json.Unmarshal(resp.Payload, &out)
@@ -113,20 +113,20 @@ func TestGetTestDatasetKeys(t *testing.T) {
 	// Input DataManager
 	inpDataManager := inputDataManager{}
 	args := inpDataManager.createDefault()
-	mockStub.MockInvoke("42", args)
+	mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 
 	// Add both train and test dataSample
 	inpDataSample := inputDataSample{Keys: []string{testDataSampleKey1}}
 	args = inpDataSample.createDefault()
-	mockStub.MockInvoke("42", args)
+	mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	inpDataSample.Keys = []string{testDataSampleKey2}
 	inpDataSample.TestOnly = "true"
 	args = inpDataSample.createDefault()
-	mockStub.MockInvoke("42", args)
+	mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 
 	// Query the DataManager
 	args = [][]byte{[]byte("queryDataset"), keyToJSON(inpDataManager.Key)}
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "querying the dataManager should return an ok status")
 	payload := map[string]interface{}{}
 	err := json.Unmarshal(resp.Payload, &payload)
@@ -146,13 +146,13 @@ func TestDataset(t *testing.T) {
 		Keys: []string{"aaa"},
 	}
 	args := inpDataSample.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding dataSample with invalid key, status %d and message %s", resp.Status, resp.Message)
 
 	// Add dataSample with unexiting dataManager
 	inpDataSample = inputDataSample{}
 	args = inpDataSample.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding dataSample with unexisting dataManager, status %d and message %s", resp.Status, resp.Message)
 	// TODO Would be nice to check failure when adding dataSample to a dataManager owned by a different people
 
@@ -160,11 +160,11 @@ func TestDataset(t *testing.T) {
 	// 1. add associated dataManager
 	inpDataManager := inputDataManager{}
 	args = inpDataManager.createDefault()
-	mockStub.MockInvoke("42", args)
+	mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	// 2. add dataSample
 	inpDataSample = inputDataSample{}
 	args = inpDataSample.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when adding dataSample, status %d and message %s", resp.Status, resp.Message)
 	// check payload correspond to input dataSample keys
 	res := map[string]interface{}{}
@@ -176,12 +176,12 @@ func TestDataset(t *testing.T) {
 	assert.ElementsMatch(t, expectedResp, dataSampleKeys, "when adding dataSample: dataSample keys does not correspond to dataSample keys")
 
 	// Add dataSample which already exist
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 409, resp.Status, "when adding dataSample which already exist, status %d and message %s", resp.Status, resp.Message)
 
 	// Query dataSample and check it corresponds to what was input
 	args = [][]byte{[]byte("queryDataset"), keyToJSON(inpDataManager.Key)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying dataManager dataSample with status %d and message %s", resp.Status, resp.Message)
 	out := outputDataset{}
 	err = json.Unmarshal(resp.Payload, &out)

--- a/chaincode/generate_examples_test.go
+++ b/chaincode/generate_examples_test.go
@@ -51,7 +51,7 @@ func TestPipeline(t *testing.T) {
 			args = methodToByte(smartContract)
 		}
 		printArgs(&out, args, peerCmd)
-		resp := mockStub.MockInvoke(mockTxID, args)
+		resp := mockStub.MockInvoke(args)
 		require.EqualValuesf(t, 200, resp.Status, "problem when calling %s, return status %d and message %s", smartContract, resp.Status, resp.Message)
 		printResp(&out, resp.Payload)
 		return resp
@@ -115,11 +115,11 @@ func TestPipeline(t *testing.T) {
 	assert.NoError(t, err, "should unmarshal without problem")
 	traintupleKey := res.Key
 	// check not possible to create same traintuple
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 409, resp.Status, "when adding same traintuple with status %d and message %s", resp.Status, resp.Message)
 	// Get owner of the traintuple
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when adding traintuple with status %d and message %s", resp.Status, resp.Message)
 	traintuple := outputTraintuple{}
 	respTraintuple := resp.Payload
@@ -176,11 +176,11 @@ func TestPipeline(t *testing.T) {
 	assert.NoError(t, err, "should unmarshal without problem")
 	testtupleKey := res.Key
 	// check not possible to create same testtuple
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 409, resp.Status, "when adding same testtuple with status %d and message %s", resp.Status, resp.Message)
 	// Get owner of the testtuple
 	args = [][]byte{[]byte("queryTesttuple"), keyToJSON(testtupleKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	respTesttuple := resp.Payload
 	testtuple := outputTesttuple{}
 	if err := json.Unmarshal(respTesttuple, &testtuple); err != nil {
@@ -236,7 +236,7 @@ func TestPipeline(t *testing.T) {
 	newDataManagerKey := "38a320b2-a67c-8003-cc74-8d6666534f2b"
 	inpDataManager = inputDataManager{Key: newDataManagerKey}
 	args = inpDataManager.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when adding dataManager with status %d and message %s", resp.Status, resp.Message)
 	// associate a data sample with the old data manager with the updateDataSample
 	updateData := inputUpdateDataSample{

--- a/chaincode/generate_examples_test.go
+++ b/chaincode/generate_examples_test.go
@@ -50,7 +50,7 @@ func TestPipeline(t *testing.T) {
 			args = methodToByte(smartContract)
 		}
 		printArgs(&out, args, peerCmd)
-		resp := mockStub.MockInvoke("42", args)
+		resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 		require.EqualValuesf(t, 200, resp.Status, "problem when calling %s, return status %d and message %s", smartContract, resp.Status, resp.Message)
 		printResp(&out, resp.Payload)
 		return resp
@@ -114,11 +114,11 @@ func TestPipeline(t *testing.T) {
 	assert.NoError(t, err, "should unmarshal without problem")
 	traintupleKey := res.Key
 	// check not possible to create same traintuple
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 409, resp.Status, "when adding same traintuple with status %d and message %s", resp.Status, resp.Message)
 	// Get owner of the traintuple
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when adding traintuple with status %d and message %s", resp.Status, resp.Message)
 	traintuple := outputTraintuple{}
 	respTraintuple := resp.Payload
@@ -175,11 +175,11 @@ func TestPipeline(t *testing.T) {
 	assert.NoError(t, err, "should unmarshal without problem")
 	testtupleKey := res.Key
 	// check not possible to create same testtuple
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 409, resp.Status, "when adding same testtuple with status %d and message %s", resp.Status, resp.Message)
 	// Get owner of the testtuple
 	args = [][]byte{[]byte("queryTesttuple"), keyToJSON(testtupleKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	respTesttuple := resp.Payload
 	testtuple := outputTesttuple{}
 	if err := json.Unmarshal(respTesttuple, &testtuple); err != nil {
@@ -235,7 +235,7 @@ func TestPipeline(t *testing.T) {
 	newDataManagerKey := "38a320b2-a67c-8003-cc74-8d6666534f2b"
 	inpDataManager = inputDataManager{Key: newDataManagerKey}
 	args = inpDataManager.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when adding dataManager with status %d and message %s", resp.Status, resp.Message)
 	// associate a data sample with the old data manager with the updateDataSample
 	updateData := inputUpdateDataSample{

--- a/chaincode/generate_examples_test.go
+++ b/chaincode/generate_examples_test.go
@@ -40,7 +40,6 @@ var (
 func TestPipeline(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStub("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	var out strings.Builder
 	callAssertAndPrint := func(peerCmd, smartContract string, inputAsset interface{}) peer.Response {

--- a/chaincode/generate_examples_test.go
+++ b/chaincode/generate_examples_test.go
@@ -40,6 +40,8 @@ var (
 func TestPipeline(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStub("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
+
 	var out strings.Builder
 	callAssertAndPrint := func(peerCmd, smartContract string, inputAsset interface{}) peer.Response {
 		var args [][]byte
@@ -50,7 +52,7 @@ func TestPipeline(t *testing.T) {
 			args = methodToByte(smartContract)
 		}
 		printArgs(&out, args, peerCmd)
-		resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+		resp := mockStub.MockInvoke(mockTxID, args)
 		require.EqualValuesf(t, 200, resp.Status, "problem when calling %s, return status %d and message %s", smartContract, resp.Status, resp.Message)
 		printResp(&out, resp.Payload)
 		return resp
@@ -114,11 +116,11 @@ func TestPipeline(t *testing.T) {
 	assert.NoError(t, err, "should unmarshal without problem")
 	traintupleKey := res.Key
 	// check not possible to create same traintuple
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 409, resp.Status, "when adding same traintuple with status %d and message %s", resp.Status, resp.Message)
 	// Get owner of the traintuple
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when adding traintuple with status %d and message %s", resp.Status, resp.Message)
 	traintuple := outputTraintuple{}
 	respTraintuple := resp.Payload
@@ -175,11 +177,11 @@ func TestPipeline(t *testing.T) {
 	assert.NoError(t, err, "should unmarshal without problem")
 	testtupleKey := res.Key
 	// check not possible to create same testtuple
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 409, resp.Status, "when adding same testtuple with status %d and message %s", resp.Status, resp.Message)
 	// Get owner of the testtuple
 	args = [][]byte{[]byte("queryTesttuple"), keyToJSON(testtupleKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	respTesttuple := resp.Payload
 	testtuple := outputTesttuple{}
 	if err := json.Unmarshal(respTesttuple, &testtuple); err != nil {
@@ -235,7 +237,7 @@ func TestPipeline(t *testing.T) {
 	newDataManagerKey := "38a320b2-a67c-8003-cc74-8d6666534f2b"
 	inpDataManager = inputDataManager{Key: newDataManagerKey}
 	args = inpDataManager.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when adding dataManager with status %d and message %s", resp.Status, resp.Message)
 	// associate a data sample with the old data manager with the updateDataSample
 	updateData := inputUpdateDataSample{

--- a/chaincode/main.go
+++ b/chaincode/main.go
@@ -49,9 +49,10 @@ func (t *SubstraChaincode) Init(stub shim.ChaincodeStubInterface) peer.Response 
 
 // Invoke is called per transaction on the chaincode.
 func (t *SubstraChaincode) Invoke(stub shim.ChaincodeStubInterface) peer.Response {
+
 	start := time.Now()
 	// Log all input for potential debug later on.
-	logger.Infof("Args received by the chaincode: %#v", stub.GetStringArgs())
+	logger.Infof("Args received by the chaincode on channel '%s': %#v", stub.GetChannelID(), stub.GetStringArgs())
 
 	// Seed with a timestamp from the channel header so the chaincode's output
 	// stay determinist for each transaction. It's necessary because endorsers
@@ -187,7 +188,7 @@ func (t *SubstraChaincode) Invoke(stub shim.ChaincodeStubInterface) peer.Respons
 	}
 	// Invoke duration
 	duration := int(time.Since(start).Nanoseconds()) / 1e6
-	logger.Infof("Response from chaincode (in %dms): %#v, error: %s", duration, result, err)
+	logger.Infof("Response from chaincode on channel '%s' (in %dms): %#v, error: %s", stub.GetChannelID(), duration, result, err)
 	// Return the result as success payload
 	if err != nil {
 		return formatErrorResponse(err)

--- a/chaincode/main_test.go
+++ b/chaincode/main_test.go
@@ -128,7 +128,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 1. add dataManager
 	inpDataManager := inputDataManager{}
 	args := inpDataManager.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding dataManager with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "dataManager" {
 		return resp, inpDataManager
@@ -140,7 +140,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 		TestOnly:        "true",
 	}
 	args = inpDataSample.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding test dataSample with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "testDataset" {
 		return resp, inpDataSample
@@ -148,7 +148,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 3. add objective
 	inpObjective := inputObjective{}
 	args = inpObjective.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding objective with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "objective" {
 		return resp, inpObjective
@@ -156,7 +156,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 4. Add train dataSample
 	inpDataSample = inputDataSample{}
 	args = inpDataSample.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding train dataSample with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "trainDataset" {
 		return resp, inpDataSample
@@ -164,7 +164,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 5. Add algo
 	inpAlgo := inputAlgo{}
 	args = inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding algo with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "algo" {
 		return resp, inpAlgo
@@ -172,7 +172,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 6. Add composite algo
 	inpCompositeAlgo := inputCompositeAlgo{}
 	args = inpCompositeAlgo.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding composite algo with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "compositeAlgo" {
 		return resp, inpCompositeAlgo
@@ -180,7 +180,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 7. Add aggregate algo
 	inpAggregateAlgo := inputAggregateAlgo{}
 	args = inpAggregateAlgo.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding aggregate algo with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "aggregateAlgo" {
 		return resp, inpAggregateAlgo
@@ -188,7 +188,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 8. Add traintuple
 	inpTraintuple := inputTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding traintuple with status %d and message %s", resp.Status, resp.Message)
 
 	if itemType == "traintuple" {
@@ -197,7 +197,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 9. Add composite traintuple
 	inpCompositeTraintuple := inputCompositeTraintuple{}
 	args = inpCompositeTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding composite traintuple with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "compositeTraintuple" {
 		return resp, inpCompositeTraintuple
@@ -205,7 +205,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 10. Add aggregate tuple
 	inpAggregatetuple := inputAggregatetuple{}
 	args = inpAggregatetuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding aggregate tuple with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "aggregatetuple" {
 		return resp, inpAggregatetuple
@@ -218,7 +218,7 @@ func registerRandomCompositeAlgo(t *testing.T, mockStub *MockStub) (key string, 
 	key = RandomUUID()
 	inpAlgo := inputCompositeAlgo{inputAlgo{Key: key}}
 	args := inpAlgo.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	if resp.Status != 200 {
 		err = fmt.Errorf("failed to register random algo: %s", resp.Message)
 		return
@@ -243,7 +243,7 @@ func registerTraintuple(t *testing.T, mockStub *MockStub, assetType AssetType) (
 		inpTraintuple := inputCompositeTraintuple{Key: randomTraintupleKey, AlgoKey: randomAlgoKey}
 		inpTraintuple.fillDefaults()
 		args := inpTraintuple.getArgs()
-		resp := mockStub.MockInvoke("42", args)
+		resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 		if resp.Status != 200 {
 			err = fmt.Errorf("failed to register traintuple: %s", resp.Message)
 			return
@@ -254,14 +254,14 @@ func registerTraintuple(t *testing.T, mockStub *MockStub, assetType AssetType) (
 	case TraintupleType:
 		inpAlgo := inputAlgo{Key: randomAlgoKey}
 		args := inpAlgo.createDefault()
-		resp := mockStub.MockInvoke("42", args)
+		resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 		if resp.Status != 200 {
 			err = fmt.Errorf("failed to register random algo: %s", resp.Message)
 			return
 		}
 		inpTraintuple := inputTraintuple{Key: randomTraintupleKey, AlgoKey: randomAlgoKey}
 		args = inpTraintuple.createDefault()
-		resp = mockStub.MockInvoke("42", args)
+		resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 		if resp.Status != 200 {
 			err = fmt.Errorf("failed to register traintuple: %s", resp.Message)
 			return
@@ -272,14 +272,14 @@ func registerTraintuple(t *testing.T, mockStub *MockStub, assetType AssetType) (
 	case AggregatetupleType:
 		inpAlgo := inputAggregateAlgo{inputAlgo{Key: randomAlgoKey}}
 		args := inpAlgo.createDefault()
-		resp := mockStub.MockInvoke("42", args)
+		resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 		if resp.Status != 200 {
 			err = fmt.Errorf("failed to register random algo: %s", resp.Message)
 			return
 		}
 		inpTraintuple := inputAggregatetuple{Key: randomTraintupleKey, AlgoKey: randomAlgoKey}
 		args = inpTraintuple.createDefault()
-		resp = mockStub.MockInvoke("42", args)
+		resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 		if resp.Status != 200 {
 			err = fmt.Errorf("failed to register traintuple: %s", resp.Message)
 			return
@@ -338,7 +338,7 @@ func TestQueryEmptyResponse(t *testing.T) {
 	for _, contractName := range smartContracts {
 		t.Run(contractName, func(t *testing.T) {
 			args := [][]byte{[]byte(contractName)}
-			resp := mockStub.MockInvoke("42", args)
+			resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 
 			expectedPayload, _ := json.Marshal(make([]string, 0))
 			assert.Equal(t, expectedPayload, resp.Payload, "payload is not an empty list")

--- a/chaincode/main_test.go
+++ b/chaincode/main_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const mockTxID = "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 const objectiveKey = "5c1d9cd1-c2c1-082d-de09-21b56d11030c"
 const objectiveDescriptionChecksum = "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379"
 const objectiveMetricsChecksum = "4a1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379"
@@ -126,8 +127,6 @@ func keyToJSON(key string) []byte {
 
 func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Response, interface{}) {
 
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
-
 	// 1. add dataManager
 	inpDataManager := inputDataManager{}
 	args := inpDataManager.createDefault()
@@ -218,7 +217,6 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 }
 
 func registerRandomCompositeAlgo(t *testing.T, mockStub *MockStub) (key string, err error) {
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	key = RandomUUID()
 	inpAlgo := inputCompositeAlgo{inputAlgo{Key: key}}
 	args := inpAlgo.createDefault()
@@ -237,7 +235,6 @@ func registerTraintuple(t *testing.T, mockStub *MockStub, assetType AssetType) (
 
 	randomAlgoKey := RandomUUID()
 	randomTraintupleKey := RandomUUID()
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	switch assetType {
 	case CompositeTraintupleType:
@@ -321,7 +318,6 @@ func TestMain(m *testing.M) {
 }
 
 func initializeMockStateDB(t *testing.T, stub *MockStub) {
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	stub.MockTransactionStart(mockTxID)
 	stub.PutState("key", []byte("value"))
 }
@@ -329,9 +325,7 @@ func initializeMockStateDB(t *testing.T, stub *MockStub) {
 func TestQueryEmptyResponse(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	initializeMockStateDB(t, mockStub)
-
 
 	smartContracts := []string{
 		"queryAlgos",

--- a/chaincode/main_test.go
+++ b/chaincode/main_test.go
@@ -125,10 +125,13 @@ func keyToJSON(key string) []byte {
 }
 
 func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Response, interface{}) {
+
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
+
 	// 1. add dataManager
 	inpDataManager := inputDataManager{}
 	args := inpDataManager.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding dataManager with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "dataManager" {
 		return resp, inpDataManager
@@ -140,7 +143,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 		TestOnly:        "true",
 	}
 	args = inpDataSample.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding test dataSample with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "testDataset" {
 		return resp, inpDataSample
@@ -148,7 +151,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 3. add objective
 	inpObjective := inputObjective{}
 	args = inpObjective.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding objective with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "objective" {
 		return resp, inpObjective
@@ -156,7 +159,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 4. Add train dataSample
 	inpDataSample = inputDataSample{}
 	args = inpDataSample.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding train dataSample with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "trainDataset" {
 		return resp, inpDataSample
@@ -164,7 +167,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 5. Add algo
 	inpAlgo := inputAlgo{}
 	args = inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding algo with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "algo" {
 		return resp, inpAlgo
@@ -172,7 +175,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 6. Add composite algo
 	inpCompositeAlgo := inputCompositeAlgo{}
 	args = inpCompositeAlgo.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding composite algo with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "compositeAlgo" {
 		return resp, inpCompositeAlgo
@@ -180,7 +183,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 7. Add aggregate algo
 	inpAggregateAlgo := inputAggregateAlgo{}
 	args = inpAggregateAlgo.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding aggregate algo with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "aggregateAlgo" {
 		return resp, inpAggregateAlgo
@@ -188,7 +191,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 8. Add traintuple
 	inpTraintuple := inputTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding traintuple with status %d and message %s", resp.Status, resp.Message)
 
 	if itemType == "traintuple" {
@@ -197,7 +200,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 9. Add composite traintuple
 	inpCompositeTraintuple := inputCompositeTraintuple{}
 	args = inpCompositeTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding composite traintuple with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "compositeTraintuple" {
 		return resp, inpCompositeTraintuple
@@ -205,7 +208,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 10. Add aggregate tuple
 	inpAggregatetuple := inputAggregatetuple{}
 	args = inpAggregatetuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding aggregate tuple with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "aggregatetuple" {
 		return resp, inpAggregatetuple
@@ -215,10 +218,11 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 }
 
 func registerRandomCompositeAlgo(t *testing.T, mockStub *MockStub) (key string, err error) {
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	key = RandomUUID()
 	inpAlgo := inputCompositeAlgo{inputAlgo{Key: key}}
 	args := inpAlgo.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	if resp.Status != 200 {
 		err = fmt.Errorf("failed to register random algo: %s", resp.Message)
 		return
@@ -233,6 +237,7 @@ func registerTraintuple(t *testing.T, mockStub *MockStub, assetType AssetType) (
 
 	randomAlgoKey := RandomUUID()
 	randomTraintupleKey := RandomUUID()
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	switch assetType {
 	case CompositeTraintupleType:
@@ -243,7 +248,7 @@ func registerTraintuple(t *testing.T, mockStub *MockStub, assetType AssetType) (
 		inpTraintuple := inputCompositeTraintuple{Key: randomTraintupleKey, AlgoKey: randomAlgoKey}
 		inpTraintuple.fillDefaults()
 		args := inpTraintuple.getArgs()
-		resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+		resp := mockStub.MockInvoke(mockTxID, args)
 		if resp.Status != 200 {
 			err = fmt.Errorf("failed to register traintuple: %s", resp.Message)
 			return
@@ -254,14 +259,14 @@ func registerTraintuple(t *testing.T, mockStub *MockStub, assetType AssetType) (
 	case TraintupleType:
 		inpAlgo := inputAlgo{Key: randomAlgoKey}
 		args := inpAlgo.createDefault()
-		resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+		resp := mockStub.MockInvoke(mockTxID, args)
 		if resp.Status != 200 {
 			err = fmt.Errorf("failed to register random algo: %s", resp.Message)
 			return
 		}
 		inpTraintuple := inputTraintuple{Key: randomTraintupleKey, AlgoKey: randomAlgoKey}
 		args = inpTraintuple.createDefault()
-		resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+		resp = mockStub.MockInvoke(mockTxID, args)
 		if resp.Status != 200 {
 			err = fmt.Errorf("failed to register traintuple: %s", resp.Message)
 			return
@@ -272,14 +277,14 @@ func registerTraintuple(t *testing.T, mockStub *MockStub, assetType AssetType) (
 	case AggregatetupleType:
 		inpAlgo := inputAggregateAlgo{inputAlgo{Key: randomAlgoKey}}
 		args := inpAlgo.createDefault()
-		resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+		resp := mockStub.MockInvoke(mockTxID, args)
 		if resp.Status != 200 {
 			err = fmt.Errorf("failed to register random algo: %s", resp.Message)
 			return
 		}
 		inpTraintuple := inputAggregatetuple{Key: randomTraintupleKey, AlgoKey: randomAlgoKey}
 		args = inpTraintuple.createDefault()
-		resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+		resp = mockStub.MockInvoke(mockTxID, args)
 		if resp.Status != 200 {
 			err = fmt.Errorf("failed to register traintuple: %s", resp.Message)
 			return
@@ -316,14 +321,17 @@ func TestMain(m *testing.M) {
 }
 
 func initializeMockStateDB(t *testing.T, stub *MockStub) {
-	stub.MockTransactionStart("42")
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
+	stub.MockTransactionStart(mockTxID)
 	stub.PutState("key", []byte("value"))
 }
 
 func TestQueryEmptyResponse(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	initializeMockStateDB(t, mockStub)
+
 
 	smartContracts := []string{
 		"queryAlgos",
@@ -338,7 +346,7 @@ func TestQueryEmptyResponse(t *testing.T) {
 	for _, contractName := range smartContracts {
 		t.Run(contractName, func(t *testing.T) {
 			args := [][]byte{[]byte(contractName)}
-			resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+			resp := mockStub.MockInvoke(mockTxID, args)
 
 			expectedPayload, _ := json.Marshal(make([]string, 0))
 			assert.Equal(t, expectedPayload, resp.Payload, "payload is not an empty list")

--- a/chaincode/main_test.go
+++ b/chaincode/main_test.go
@@ -130,7 +130,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 1. add dataManager
 	inpDataManager := inputDataManager{}
 	args := inpDataManager.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding dataManager with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "dataManager" {
 		return resp, inpDataManager
@@ -142,7 +142,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 		TestOnly:        "true",
 	}
 	args = inpDataSample.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding test dataSample with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "testDataset" {
 		return resp, inpDataSample
@@ -150,7 +150,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 3. add objective
 	inpObjective := inputObjective{}
 	args = inpObjective.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding objective with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "objective" {
 		return resp, inpObjective
@@ -158,7 +158,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 4. Add train dataSample
 	inpDataSample = inputDataSample{}
 	args = inpDataSample.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding train dataSample with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "trainDataset" {
 		return resp, inpDataSample
@@ -166,7 +166,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 5. Add algo
 	inpAlgo := inputAlgo{}
 	args = inpAlgo.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding algo with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "algo" {
 		return resp, inpAlgo
@@ -174,7 +174,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 6. Add composite algo
 	inpCompositeAlgo := inputCompositeAlgo{}
 	args = inpCompositeAlgo.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding composite algo with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "compositeAlgo" {
 		return resp, inpCompositeAlgo
@@ -182,7 +182,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 7. Add aggregate algo
 	inpAggregateAlgo := inputAggregateAlgo{}
 	args = inpAggregateAlgo.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding aggregate algo with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "aggregateAlgo" {
 		return resp, inpAggregateAlgo
@@ -190,7 +190,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 8. Add traintuple
 	inpTraintuple := inputTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding traintuple with status %d and message %s", resp.Status, resp.Message)
 
 	if itemType == "traintuple" {
@@ -199,7 +199,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 9. Add composite traintuple
 	inpCompositeTraintuple := inputCompositeTraintuple{}
 	args = inpCompositeTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding composite traintuple with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "compositeTraintuple" {
 		return resp, inpCompositeTraintuple
@@ -207,7 +207,7 @@ func registerItem(t *testing.T, mockStub MockStub, itemType string) (peer.Respon
 	// 10. Add aggregate tuple
 	inpAggregatetuple := inputAggregatetuple{}
 	args = inpAggregatetuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding aggregate tuple with status %d and message %s", resp.Status, resp.Message)
 	if itemType == "aggregatetuple" {
 		return resp, inpAggregatetuple
@@ -220,7 +220,7 @@ func registerRandomCompositeAlgo(t *testing.T, mockStub *MockStub) (key string, 
 	key = RandomUUID()
 	inpAlgo := inputCompositeAlgo{inputAlgo{Key: key}}
 	args := inpAlgo.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	if resp.Status != 200 {
 		err = fmt.Errorf("failed to register random algo: %s", resp.Message)
 		return
@@ -245,7 +245,7 @@ func registerTraintuple(t *testing.T, mockStub *MockStub, assetType AssetType) (
 		inpTraintuple := inputCompositeTraintuple{Key: randomTraintupleKey, AlgoKey: randomAlgoKey}
 		inpTraintuple.fillDefaults()
 		args := inpTraintuple.getArgs()
-		resp := mockStub.MockInvoke(mockTxID, args)
+		resp := mockStub.MockInvoke(args)
 		if resp.Status != 200 {
 			err = fmt.Errorf("failed to register traintuple: %s", resp.Message)
 			return
@@ -256,14 +256,14 @@ func registerTraintuple(t *testing.T, mockStub *MockStub, assetType AssetType) (
 	case TraintupleType:
 		inpAlgo := inputAlgo{Key: randomAlgoKey}
 		args := inpAlgo.createDefault()
-		resp := mockStub.MockInvoke(mockTxID, args)
+		resp := mockStub.MockInvoke(args)
 		if resp.Status != 200 {
 			err = fmt.Errorf("failed to register random algo: %s", resp.Message)
 			return
 		}
 		inpTraintuple := inputTraintuple{Key: randomTraintupleKey, AlgoKey: randomAlgoKey}
 		args = inpTraintuple.createDefault()
-		resp = mockStub.MockInvoke(mockTxID, args)
+		resp = mockStub.MockInvoke(args)
 		if resp.Status != 200 {
 			err = fmt.Errorf("failed to register traintuple: %s", resp.Message)
 			return
@@ -274,14 +274,14 @@ func registerTraintuple(t *testing.T, mockStub *MockStub, assetType AssetType) (
 	case AggregatetupleType:
 		inpAlgo := inputAggregateAlgo{inputAlgo{Key: randomAlgoKey}}
 		args := inpAlgo.createDefault()
-		resp := mockStub.MockInvoke(mockTxID, args)
+		resp := mockStub.MockInvoke(args)
 		if resp.Status != 200 {
 			err = fmt.Errorf("failed to register random algo: %s", resp.Message)
 			return
 		}
 		inpTraintuple := inputAggregatetuple{Key: randomTraintupleKey, AlgoKey: randomAlgoKey}
 		args = inpTraintuple.createDefault()
-		resp = mockStub.MockInvoke(mockTxID, args)
+		resp = mockStub.MockInvoke(args)
 		if resp.Status != 200 {
 			err = fmt.Errorf("failed to register traintuple: %s", resp.Message)
 			return
@@ -340,7 +340,7 @@ func TestQueryEmptyResponse(t *testing.T) {
 	for _, contractName := range smartContracts {
 		t.Run(contractName, func(t *testing.T) {
 			args := [][]byte{[]byte(contractName)}
-			resp := mockStub.MockInvoke(mockTxID, args)
+			resp := mockStub.MockInvoke(args)
 
 			expectedPayload, _ := json.Marshal(make([]string, 0))
 			assert.Equal(t, expectedPayload, resp.Payload, "payload is not an empty list")

--- a/chaincode/mockstub_test.go
+++ b/chaincode/mockstub_test.go
@@ -149,12 +149,17 @@ func (stub *MockStub) MockInit(uuid string, args [][]byte) pb.Response {
 	return res
 }
 
-// Invoke this chaincode, also starts and ends a transaction.
-func (stub *MockStub) MockInvoke(uuid string, args [][]byte) pb.Response {
+// Invoke this chaincode using the default transction ID. Also starts and ends a transaction.
+func (stub *MockStub) MockInvoke(args [][]byte) pb.Response {
+	return stub.MockInvokeTxID(mockTxID, args)
+}
+
+// Invoke this chaincode using the specified transction ID. Also starts and ends a transaction.
+func (stub *MockStub) MockInvokeTxID(txid string, args [][]byte) pb.Response {
 	stub.args = args
-	stub.MockTransactionStart(uuid)
+	stub.MockTransactionStart(txid)
 	res := stub.cc.Invoke(stub)
-	stub.MockTransactionEnd(uuid)
+	stub.MockTransactionEnd(txid)
 	return res
 }
 
@@ -352,7 +357,7 @@ func (stub *MockStub) InvokeChaincode(chaincodeName string, args [][]byte, chann
 	// TODO "args" here should possibly be a serialized pb.ChaincodeInput
 	otherStub := stub.Invokables[chaincodeName]
 	//	function, strings := getFuncArgs(args)
-	res := otherStub.MockInvoke(stub.TxID, args)
+	res := otherStub.MockInvokeTxID(stub.TxID, args)
 	return res
 }
 
@@ -490,7 +495,7 @@ func NewMockStub(name string, cc shim.Chaincode) *MockStub {
 
 func NewMockStubWithRegisterNode(name string, cc shim.Chaincode) *MockStub {
 	s := NewMockStub(name, cc)
-	s.MockInvoke(mockTxID, [][]byte{[]byte("registerNode")})
+	s.MockInvoke([][]byte{[]byte("registerNode")})
 
 	return s
 }

--- a/chaincode/mockstub_test.go
+++ b/chaincode/mockstub_test.go
@@ -490,7 +490,7 @@ func NewMockStub(name string, cc shim.Chaincode) *MockStub {
 
 func NewMockStubWithRegisterNode(name string, cc shim.Chaincode) *MockStub {
 	s := NewMockStub(name, cc)
-	s.MockInvoke("42", [][]byte{[]byte("registerNode")})
+	s.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", [][]byte{[]byte("registerNode")})
 
 	return s
 }

--- a/chaincode/mockstub_test.go
+++ b/chaincode/mockstub_test.go
@@ -490,7 +490,8 @@ func NewMockStub(name string, cc shim.Chaincode) *MockStub {
 
 func NewMockStubWithRegisterNode(name string, cc shim.Chaincode) *MockStub {
 	s := NewMockStub(name, cc)
-	s.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", [][]byte{[]byte("registerNode")})
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
+	s.MockInvoke(mockTxID, [][]byte{[]byte("registerNode")})
 
 	return s
 }

--- a/chaincode/mockstub_test.go
+++ b/chaincode/mockstub_test.go
@@ -21,11 +21,11 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/timestamp"
-	"github.com/hyperledger/fabric/common/util"
 	"github.com/hyperledger/fabric-chaincode-go/shim"
 	"github.com/hyperledger/fabric-protos-go/ledger/queryresult"
 	"github.com/hyperledger/fabric-protos-go/msp"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric/common/util"
 	"github.com/pkg/errors"
 )
 
@@ -490,7 +490,6 @@ func NewMockStub(name string, cc shim.Chaincode) *MockStub {
 
 func NewMockStubWithRegisterNode(name string, cc shim.Chaincode) *MockStub {
 	s := NewMockStub(name, cc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	s.MockInvoke(mockTxID, [][]byte{[]byte("registerNode")})
 
 	return s

--- a/chaincode/node_test.go
+++ b/chaincode/node_test.go
@@ -26,11 +26,11 @@ func TestNode(t *testing.T) {
 
 	args := append([][]byte{[]byte("registerNode")}, []byte{})
 
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "Node created")
 	assert.Contains(t, string(resp.Payload), "\"id\":\"SampleOrg\"", "Node created")
 
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "Node registered twice")
 	assert.Contains(t, string(resp.Payload), "\"id\":\"SampleOrg\"", "Node registered twice")
 }
@@ -39,7 +39,7 @@ func TestQueryNodes(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
 
-	response := mockStub.MockInvoke(mockTxID, [][]byte{[]byte("queryNodes")})
+	response := mockStub.MockInvoke([][]byte{[]byte("queryNodes")})
 
 	assert.EqualValuesf(t, 200, response.Status, "Node Created")
 	assert.Contains(t, string(response.Payload), "\"id\":\"SampleOrg\"", "Query nodes")

--- a/chaincode/node_test.go
+++ b/chaincode/node_test.go
@@ -26,11 +26,11 @@ func TestNode(t *testing.T) {
 
 	args := append([][]byte{[]byte("registerNode")}, []byte{})
 
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "Node created")
 	assert.Contains(t, string(resp.Payload), "\"id\":\"SampleOrg\"", "Node created")
 
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "Node registered twice")
 	assert.Contains(t, string(resp.Payload), "\"id\":\"SampleOrg\"", "Node registered twice")
 }
@@ -38,7 +38,7 @@ func TestNode(t *testing.T) {
 func TestQueryNodes(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	response := mockStub.MockInvoke("43", [][]byte{[]byte("queryNodes")})
+	response := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720e", [][]byte{[]byte("queryNodes")})
 
 	assert.EqualValuesf(t, 200, response.Status, "Node Created")
 	assert.Contains(t, string(response.Payload), "\"id\":\"SampleOrg\"", "Query nodes")

--- a/chaincode/node_test.go
+++ b/chaincode/node_test.go
@@ -23,7 +23,6 @@ import (
 func TestNode(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStub("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	args := append([][]byte{[]byte("registerNode")}, []byte{})
 
@@ -39,7 +38,6 @@ func TestNode(t *testing.T) {
 func TestQueryNodes(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	response := mockStub.MockInvoke(mockTxID, [][]byte{[]byte("queryNodes")})
 

--- a/chaincode/node_test.go
+++ b/chaincode/node_test.go
@@ -23,14 +23,15 @@ import (
 func TestNode(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStub("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	args := append([][]byte{[]byte("registerNode")}, []byte{})
 
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "Node created")
 	assert.Contains(t, string(resp.Payload), "\"id\":\"SampleOrg\"", "Node created")
 
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "Node registered twice")
 	assert.Contains(t, string(resp.Payload), "\"id\":\"SampleOrg\"", "Node registered twice")
 }
@@ -38,7 +39,9 @@ func TestNode(t *testing.T) {
 func TestQueryNodes(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	response := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720e", [][]byte{[]byte("queryNodes")})
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
+
+	response := mockStub.MockInvoke(mockTxID, [][]byte{[]byte("queryNodes")})
 
 	assert.EqualValuesf(t, 200, response.Status, "Node Created")
 	assert.Contains(t, string(response.Payload), "\"id\":\"SampleOrg\"", "Query nodes")

--- a/chaincode/objective_test.go
+++ b/chaincode/objective_test.go
@@ -73,32 +73,32 @@ func TestRegisterObjectiveWhitoutDataset(t *testing.T) {
 	inpObjective := inputObjective{}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke(methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 }
 func TestRegisterObjectiveWithDataSampleKeyNotDataManagerKey(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockStub.MockInvoke(mockTxID, [][]byte{[]byte("registerNode")})
+	mockStub.MockInvoke([][]byte{[]byte("registerNode")})
 
 	// Add a dataManager and some dataSample successfuly
 	inpDataManager := inputDataManager{}
 	args := inpDataManager.createDefault()
-	mockStub.MockInvoke(mockTxID, args)
+	mockStub.MockInvoke(args)
 	inpDataSample := inputDataSample{
 		Keys:            []string{testDataSampleKey1},
 		DataManagerKeys: []string{dataManagerKey},
 		TestOnly:        "true",
 	}
 	args = inpDataSample.createDefault()
-	mockStub.MockInvoke(mockTxID, args)
+	mockStub.MockInvoke(args)
 	inpDataSample = inputDataSample{
 		Keys:            []string{testDataSampleKey2},
 		DataManagerKeys: []string{dataManagerKey},
 		TestOnly:        "true",
 	}
 	args = inpDataSample.createDefault()
-	r := mockStub.MockInvoke(mockTxID, args)
+	r := mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, r.Status)
 
 	// Fail to insert the objective
@@ -107,7 +107,7 @@ func TestRegisterObjectiveWithDataSampleKeyNotDataManagerKey(t *testing.T) {
 			DataManagerKey: testDataSampleKey1,
 			DataSampleKeys: []string{testDataSampleKey2}}}
 	args = inpObjective.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	assert.EqualValues(t, 400, resp.Status, "status should indicate an error since the dataManager key is a dataSample key")
 }
 func TestObjective(t *testing.T) {
@@ -119,13 +119,13 @@ func TestObjective(t *testing.T) {
 		DescriptionChecksum: "aaa",
 	}
 	args := inpObjective.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding objective with invalid checksum, status %d and message %s", resp.Status, resp.Message)
 
 	// Add objective with unexisting test dataSample
 	inpObjective = inputObjective{}
 	args = inpObjective.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding objective with unexisting test dataSample, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add objective
@@ -146,7 +146,7 @@ func TestObjective(t *testing.T) {
 
 	// Query objective from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryObjective"), keyToJSON(objectiveKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying a dataManager with status %d and message %s", resp.Status, resp.Message)
 	objective := outputObjective{}
 	err = json.Unmarshal(resp.Payload, &objective)
@@ -178,7 +178,7 @@ func TestObjective(t *testing.T) {
 
 	// Query all objectives and check consistency
 	args = [][]byte{[]byte("queryObjectives")}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying objectives - status %d and message %s", resp.Status, resp.Message)
 	var objectives []outputObjective
 	err = json.Unmarshal(resp.Payload, &objectives)

--- a/chaincode/objective_test.go
+++ b/chaincode/objective_test.go
@@ -69,7 +69,6 @@ func TestLeaderBoard(t *testing.T) {
 func TestRegisterObjectiveWhitoutDataset(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	inpObjective := inputObjective{}
 	inpObjective.createDefault()
@@ -80,7 +79,6 @@ func TestRegisterObjectiveWhitoutDataset(t *testing.T) {
 func TestRegisterObjectiveWithDataSampleKeyNotDataManagerKey(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	mockStub.MockInvoke(mockTxID, [][]byte{[]byte("registerNode")})
 
 	// Add a dataManager and some dataSample successfuly
@@ -115,7 +113,6 @@ func TestRegisterObjectiveWithDataSampleKeyNotDataManagerKey(t *testing.T) {
 func TestObjective(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add objective with invalid field
 	inpObjective := inputObjective{

--- a/chaincode/objective_test.go
+++ b/chaincode/objective_test.go
@@ -73,32 +73,32 @@ func TestRegisterObjectiveWhitoutDataset(t *testing.T) {
 	inpObjective := inputObjective{}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke("42", methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 }
 func TestRegisterObjectiveWithDataSampleKeyNotDataManagerKey(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockStub.MockInvoke("42", [][]byte{[]byte("registerNode")})
+	mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", [][]byte{[]byte("registerNode")})
 
 	// Add a dataManager and some dataSample successfuly
 	inpDataManager := inputDataManager{}
 	args := inpDataManager.createDefault()
-	mockStub.MockInvoke("42", args)
+	mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	inpDataSample := inputDataSample{
 		Keys:            []string{testDataSampleKey1},
 		DataManagerKeys: []string{dataManagerKey},
 		TestOnly:        "true",
 	}
 	args = inpDataSample.createDefault()
-	mockStub.MockInvoke("42", args)
+	mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	inpDataSample = inputDataSample{
 		Keys:            []string{testDataSampleKey2},
 		DataManagerKeys: []string{dataManagerKey},
 		TestOnly:        "true",
 	}
 	args = inpDataSample.createDefault()
-	r := mockStub.MockInvoke("42", args)
+	r := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, r.Status)
 
 	// Fail to insert the objective
@@ -107,7 +107,7 @@ func TestRegisterObjectiveWithDataSampleKeyNotDataManagerKey(t *testing.T) {
 			DataManagerKey: testDataSampleKey1,
 			DataSampleKeys: []string{testDataSampleKey2}}}
 	args = inpObjective.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 400, resp.Status, "status should indicate an error since the dataManager key is a dataSample key")
 }
 func TestObjective(t *testing.T) {
@@ -119,13 +119,13 @@ func TestObjective(t *testing.T) {
 		DescriptionChecksum: "aaa",
 	}
 	args := inpObjective.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding objective with invalid checksum, status %d and message %s", resp.Status, resp.Message)
 
 	// Add objective with unexisting test dataSample
 	inpObjective = inputObjective{}
 	args = inpObjective.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding objective with unexisting test dataSample, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add objective
@@ -146,7 +146,7 @@ func TestObjective(t *testing.T) {
 
 	// Query objective from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryObjective"), keyToJSON(objectiveKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying a dataManager with status %d and message %s", resp.Status, resp.Message)
 	objective := outputObjective{}
 	err = json.Unmarshal(resp.Payload, &objective)
@@ -178,7 +178,7 @@ func TestObjective(t *testing.T) {
 
 	// Query all objectives and check consistency
 	args = [][]byte{[]byte("queryObjectives")}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying objectives - status %d and message %s", resp.Status, resp.Message)
 	var objectives []outputObjective
 	err = json.Unmarshal(resp.Payload, &objectives)

--- a/chaincode/objective_test.go
+++ b/chaincode/objective_test.go
@@ -69,36 +69,38 @@ func TestLeaderBoard(t *testing.T) {
 func TestRegisterObjectiveWhitoutDataset(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	inpObjective := inputObjective{}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 }
 func TestRegisterObjectiveWithDataSampleKeyNotDataManagerKey(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", [][]byte{[]byte("registerNode")})
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
+	mockStub.MockInvoke(mockTxID, [][]byte{[]byte("registerNode")})
 
 	// Add a dataManager and some dataSample successfuly
 	inpDataManager := inputDataManager{}
 	args := inpDataManager.createDefault()
-	mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	mockStub.MockInvoke(mockTxID, args)
 	inpDataSample := inputDataSample{
 		Keys:            []string{testDataSampleKey1},
 		DataManagerKeys: []string{dataManagerKey},
 		TestOnly:        "true",
 	}
 	args = inpDataSample.createDefault()
-	mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	mockStub.MockInvoke(mockTxID, args)
 	inpDataSample = inputDataSample{
 		Keys:            []string{testDataSampleKey2},
 		DataManagerKeys: []string{dataManagerKey},
 		TestOnly:        "true",
 	}
 	args = inpDataSample.createDefault()
-	r := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	r := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, r.Status)
 
 	// Fail to insert the objective
@@ -107,25 +109,26 @@ func TestRegisterObjectiveWithDataSampleKeyNotDataManagerKey(t *testing.T) {
 			DataManagerKey: testDataSampleKey1,
 			DataSampleKeys: []string{testDataSampleKey2}}}
 	args = inpObjective.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 400, resp.Status, "status should indicate an error since the dataManager key is a dataSample key")
 }
 func TestObjective(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add objective with invalid field
 	inpObjective := inputObjective{
 		DescriptionChecksum: "aaa",
 	}
 	args := inpObjective.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding objective with invalid checksum, status %d and message %s", resp.Status, resp.Message)
 
 	// Add objective with unexisting test dataSample
 	inpObjective = inputObjective{}
 	args = inpObjective.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding objective with unexisting test dataSample, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add objective
@@ -146,7 +149,7 @@ func TestObjective(t *testing.T) {
 
 	// Query objective from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryObjective"), keyToJSON(objectiveKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying a dataManager with status %d and message %s", resp.Status, resp.Message)
 	objective := outputObjective{}
 	err = json.Unmarshal(resp.Payload, &objective)
@@ -178,7 +181,7 @@ func TestObjective(t *testing.T) {
 
 	// Query all objectives and check consistency
 	args = [][]byte{[]byte("queryObjectives")}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying objectives - status %d and message %s", resp.Status, resp.Message)
 	var objectives []outputObjective
 	err = json.Unmarshal(resp.Payload, &objectives)

--- a/chaincode/testtuple_test.go
+++ b/chaincode/testtuple_test.go
@@ -26,6 +26,7 @@ import (
 func TestTesttupleOnFailedTraintuple(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add a some dataManager, dataSample and traintuple
 	resp, _ := registerItem(t, *mockStub, "traintuple")
@@ -39,13 +40,13 @@ func TestTesttupleOnFailedTraintuple(t *testing.T) {
 	fail := inputLogFailTrain{}
 	fail.Key = traintupleKey
 	args := fail.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "should be able to log traintuple as failed")
 
 	// Fail to add a testtuple to this failed traintuple
 	inpTesttuple := inputTesttuple{}
 	args = inpTesttuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 400, resp.Status, "status should show an error since the traintuple is failed")
 	assert.Contains(t, resp.Message, "could not register this testtuple")
 }
@@ -53,6 +54,7 @@ func TestTesttupleOnFailedTraintuple(t *testing.T) {
 func TestCertifiedExplicitTesttuple(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add a some dataManager, dataSample and traintuple
 	registerItem(t, *mockStub, "traintuple")
@@ -63,11 +65,11 @@ func TestCertifiedExplicitTesttuple(t *testing.T) {
 		DataSampleKeys: []string{testDataSampleKey2, testDataSampleKey1},
 		DataManagerKey: dataManagerKey}
 	args := inpTesttuple.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status)
 
 	args = [][]byte{[]byte("queryTesttuples")}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	testtuples := [](map[string]interface{}){}
 	err := json.Unmarshal(resp.Payload, &testtuples)
 	assert.NoError(t, err, "should be unmarshaled")
@@ -79,6 +81,7 @@ func TestCertifiedExplicitTesttuple(t *testing.T) {
 func TestConflictCertifiedNonCertifiedTesttuple(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add a some dataManager, dataSample and traintuple
 	registerItem(t, *mockStub, "traintuple")
@@ -86,13 +89,13 @@ func TestConflictCertifiedNonCertifiedTesttuple(t *testing.T) {
 	// Add a certified testtuple
 	inpTesttuple1 := inputTesttuple{}
 	args := inpTesttuple1.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status)
 
 	// Fail to add an incomplete uncertified testtuple
 	inpTesttuple2 := inputTesttuple{DataSampleKeys: []string{trainDataSampleKey1}}
 	args = inpTesttuple2.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 400, resp.Status)
 	assert.Contains(t, resp.Message, "invalid input: dataManagerKey and dataSampleKey should be provided together")
 
@@ -102,13 +105,13 @@ func TestConflictCertifiedNonCertifiedTesttuple(t *testing.T) {
 		DataSampleKeys: []string{trainDataSampleKey1, trainDataSampleKey2},
 		DataManagerKey: dataManagerKey}
 	args = inpTesttuple3.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status)
 
 	// Fail to add the same testtuple with the same key
 	inpTesttuple4 := inputTesttuple{}
 	args = inpTesttuple4.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 409, resp.Status)
 	assert.Contains(t, resp.Message, "already exists")
 }
@@ -147,6 +150,7 @@ func TestQueryTesttuple(t *testing.T) {
 		t.Run("TestQueryTesttuple"+tt.expectedTypeString, func(t *testing.T) {
 			scc := new(SubstraChaincode)
 			mockStub := NewMockStubWithRegisterNode("substra", scc)
+			mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 			registerItem(t, *mockStub, "aggregatetuple")
 
 			// create testtuple
@@ -157,14 +161,14 @@ func TestQueryTesttuple(t *testing.T) {
 				DataSampleKeys: dataSampleKeys,
 			}
 			inpTesttuple.fillDefaults()
-			resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inpTesttuple.getArgs())
+			resp := mockStub.MockInvoke(mockTxID, inpTesttuple.getArgs())
 			res := map[string]string{}
 			json.Unmarshal(resp.Payload, &res)
 			testtupleKey := res["key"]
 
 			// query testtuple
 			args := [][]byte{[]byte("queryTesttuple"), keyToJSON(testtupleKey)}
-			resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+			resp = mockStub.MockInvoke(mockTxID, args)
 			respTesttuple := resp.Payload
 			testtuple := outputTesttuple{}
 			json.Unmarshal(respTesttuple, &testtuple)
@@ -199,6 +203,7 @@ func TestTesttupleOnCompositeTraintuple(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			scc := new(SubstraChaincode)
 			mockStub := NewMockStubWithRegisterNode("substra", scc)
+			mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 			registerItem(t, *mockStub, "compositeTraintuple")
 
@@ -208,7 +213,7 @@ func TestTesttupleOnCompositeTraintuple(t *testing.T) {
 			}
 			// Create a testtuple before training
 			args := inp.createDefault()
-			resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+			resp := mockStub.MockInvoke(mockTxID, args)
 			assert.EqualValues(t, http.StatusOK, resp.Status, resp.Message)
 			values := map[string]string{}
 			json.Unmarshal(resp.Payload, &values)
@@ -250,7 +255,7 @@ func TestTesttupleOnCompositeTraintuple(t *testing.T) {
 			inp.DataManagerKey = dataManagerKey
 			inp.DataSampleKeys = []string{trainDataSampleKey1}
 			args = inp.createDefault()
-			resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+			resp = mockStub.MockInvoke(mockTxID, args)
 
 			switch status {
 			case StatusDone:

--- a/chaincode/testtuple_test.go
+++ b/chaincode/testtuple_test.go
@@ -26,7 +26,6 @@ import (
 func TestTesttupleOnFailedTraintuple(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add a some dataManager, dataSample and traintuple
 	resp, _ := registerItem(t, *mockStub, "traintuple")
@@ -54,7 +53,6 @@ func TestTesttupleOnFailedTraintuple(t *testing.T) {
 func TestCertifiedExplicitTesttuple(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add a some dataManager, dataSample and traintuple
 	registerItem(t, *mockStub, "traintuple")
@@ -81,7 +79,6 @@ func TestCertifiedExplicitTesttuple(t *testing.T) {
 func TestConflictCertifiedNonCertifiedTesttuple(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add a some dataManager, dataSample and traintuple
 	registerItem(t, *mockStub, "traintuple")
@@ -150,7 +147,6 @@ func TestQueryTesttuple(t *testing.T) {
 		t.Run("TestQueryTesttuple"+tt.expectedTypeString, func(t *testing.T) {
 			scc := new(SubstraChaincode)
 			mockStub := NewMockStubWithRegisterNode("substra", scc)
-			mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 			registerItem(t, *mockStub, "aggregatetuple")
 
 			// create testtuple
@@ -203,7 +199,6 @@ func TestTesttupleOnCompositeTraintuple(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			scc := new(SubstraChaincode)
 			mockStub := NewMockStubWithRegisterNode("substra", scc)
-			mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 			registerItem(t, *mockStub, "compositeTraintuple")
 

--- a/chaincode/testtuple_test.go
+++ b/chaincode/testtuple_test.go
@@ -39,13 +39,13 @@ func TestTesttupleOnFailedTraintuple(t *testing.T) {
 	fail := inputLogFailTrain{}
 	fail.Key = traintupleKey
 	args := fail.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "should be able to log traintuple as failed")
 
 	// Fail to add a testtuple to this failed traintuple
 	inpTesttuple := inputTesttuple{}
 	args = inpTesttuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 400, resp.Status, "status should show an error since the traintuple is failed")
 	assert.Contains(t, resp.Message, "could not register this testtuple")
 }
@@ -63,11 +63,11 @@ func TestCertifiedExplicitTesttuple(t *testing.T) {
 		DataSampleKeys: []string{testDataSampleKey2, testDataSampleKey1},
 		DataManagerKey: dataManagerKey}
 	args := inpTesttuple.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status)
 
 	args = [][]byte{[]byte("queryTesttuples")}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	testtuples := [](map[string]interface{}){}
 	err := json.Unmarshal(resp.Payload, &testtuples)
 	assert.NoError(t, err, "should be unmarshaled")
@@ -86,13 +86,13 @@ func TestConflictCertifiedNonCertifiedTesttuple(t *testing.T) {
 	// Add a certified testtuple
 	inpTesttuple1 := inputTesttuple{}
 	args := inpTesttuple1.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status)
 
 	// Fail to add an incomplete uncertified testtuple
 	inpTesttuple2 := inputTesttuple{DataSampleKeys: []string{trainDataSampleKey1}}
 	args = inpTesttuple2.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 400, resp.Status)
 	assert.Contains(t, resp.Message, "invalid input: dataManagerKey and dataSampleKey should be provided together")
 
@@ -102,13 +102,13 @@ func TestConflictCertifiedNonCertifiedTesttuple(t *testing.T) {
 		DataSampleKeys: []string{trainDataSampleKey1, trainDataSampleKey2},
 		DataManagerKey: dataManagerKey}
 	args = inpTesttuple3.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status)
 
 	// Fail to add the same testtuple with the same key
 	inpTesttuple4 := inputTesttuple{}
 	args = inpTesttuple4.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 409, resp.Status)
 	assert.Contains(t, resp.Message, "already exists")
 }
@@ -157,14 +157,14 @@ func TestQueryTesttuple(t *testing.T) {
 				DataSampleKeys: dataSampleKeys,
 			}
 			inpTesttuple.fillDefaults()
-			resp := mockStub.MockInvoke("42", inpTesttuple.getArgs())
+			resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inpTesttuple.getArgs())
 			res := map[string]string{}
 			json.Unmarshal(resp.Payload, &res)
 			testtupleKey := res["key"]
 
 			// query testtuple
 			args := [][]byte{[]byte("queryTesttuple"), keyToJSON(testtupleKey)}
-			resp = mockStub.MockInvoke("42", args)
+			resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 			respTesttuple := resp.Payload
 			testtuple := outputTesttuple{}
 			json.Unmarshal(respTesttuple, &testtuple)
@@ -208,7 +208,7 @@ func TestTesttupleOnCompositeTraintuple(t *testing.T) {
 			}
 			// Create a testtuple before training
 			args := inp.createDefault()
-			resp := mockStub.MockInvoke("42", args)
+			resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 			assert.EqualValues(t, http.StatusOK, resp.Status, resp.Message)
 			values := map[string]string{}
 			json.Unmarshal(resp.Payload, &values)
@@ -250,7 +250,7 @@ func TestTesttupleOnCompositeTraintuple(t *testing.T) {
 			inp.DataManagerKey = dataManagerKey
 			inp.DataSampleKeys = []string{trainDataSampleKey1}
 			args = inp.createDefault()
-			resp = mockStub.MockInvoke("42", args)
+			resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 
 			switch status {
 			case StatusDone:

--- a/chaincode/testtuple_test.go
+++ b/chaincode/testtuple_test.go
@@ -39,13 +39,13 @@ func TestTesttupleOnFailedTraintuple(t *testing.T) {
 	fail := inputLogFailTrain{}
 	fail.Key = traintupleKey
 	args := fail.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "should be able to log traintuple as failed")
 
 	// Fail to add a testtuple to this failed traintuple
 	inpTesttuple := inputTesttuple{}
 	args = inpTesttuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 400, resp.Status, "status should show an error since the traintuple is failed")
 	assert.Contains(t, resp.Message, "could not register this testtuple")
 }
@@ -63,11 +63,11 @@ func TestCertifiedExplicitTesttuple(t *testing.T) {
 		DataSampleKeys: []string{testDataSampleKey2, testDataSampleKey1},
 		DataManagerKey: dataManagerKey}
 	args := inpTesttuple.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status)
 
 	args = [][]byte{[]byte("queryTesttuples")}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	testtuples := [](map[string]interface{}){}
 	err := json.Unmarshal(resp.Payload, &testtuples)
 	assert.NoError(t, err, "should be unmarshaled")
@@ -86,13 +86,13 @@ func TestConflictCertifiedNonCertifiedTesttuple(t *testing.T) {
 	// Add a certified testtuple
 	inpTesttuple1 := inputTesttuple{}
 	args := inpTesttuple1.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status)
 
 	// Fail to add an incomplete uncertified testtuple
 	inpTesttuple2 := inputTesttuple{DataSampleKeys: []string{trainDataSampleKey1}}
 	args = inpTesttuple2.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 400, resp.Status)
 	assert.Contains(t, resp.Message, "invalid input: dataManagerKey and dataSampleKey should be provided together")
 
@@ -102,13 +102,13 @@ func TestConflictCertifiedNonCertifiedTesttuple(t *testing.T) {
 		DataSampleKeys: []string{trainDataSampleKey1, trainDataSampleKey2},
 		DataManagerKey: dataManagerKey}
 	args = inpTesttuple3.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status)
 
 	// Fail to add the same testtuple with the same key
 	inpTesttuple4 := inputTesttuple{}
 	args = inpTesttuple4.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 409, resp.Status)
 	assert.Contains(t, resp.Message, "already exists")
 }
@@ -157,14 +157,14 @@ func TestQueryTesttuple(t *testing.T) {
 				DataSampleKeys: dataSampleKeys,
 			}
 			inpTesttuple.fillDefaults()
-			resp := mockStub.MockInvoke(mockTxID, inpTesttuple.getArgs())
+			resp := mockStub.MockInvoke(inpTesttuple.getArgs())
 			res := map[string]string{}
 			json.Unmarshal(resp.Payload, &res)
 			testtupleKey := res["key"]
 
 			// query testtuple
 			args := [][]byte{[]byte("queryTesttuple"), keyToJSON(testtupleKey)}
-			resp = mockStub.MockInvoke(mockTxID, args)
+			resp = mockStub.MockInvoke(args)
 			respTesttuple := resp.Payload
 			testtuple := outputTesttuple{}
 			json.Unmarshal(respTesttuple, &testtuple)
@@ -208,7 +208,7 @@ func TestTesttupleOnCompositeTraintuple(t *testing.T) {
 			}
 			// Create a testtuple before training
 			args := inp.createDefault()
-			resp := mockStub.MockInvoke(mockTxID, args)
+			resp := mockStub.MockInvoke(args)
 			assert.EqualValues(t, http.StatusOK, resp.Status, resp.Message)
 			values := map[string]string{}
 			json.Unmarshal(resp.Payload, &values)
@@ -250,7 +250,7 @@ func TestTesttupleOnCompositeTraintuple(t *testing.T) {
 			inp.DataManagerKey = dataManagerKey
 			inp.DataSampleKeys = []string{trainDataSampleKey1}
 			args = inp.createDefault()
-			resp = mockStub.MockInvoke(mockTxID, args)
+			resp = mockStub.MockInvoke(args)
 
 			switch status {
 			case StatusDone:

--- a/chaincode/traintuple_composite_test.go
+++ b/chaincode/traintuple_composite_test.go
@@ -36,48 +36,50 @@ import (
 func TestTraintupleWithNoTestDatasetComposite(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	key := strings.Replace(objectiveKey, "1", "2", 1)
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputCompositeAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	inpTraintuple := inputCompositeTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 
 	assert.EqualValues(t, 200, resp.Status, "when adding traintuple without test dataset it should work: ", resp.Message)
 
 	traintuple := outputCompositeTraintuple{}
 	json.Unmarshal(resp.Payload, &traintuple)
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(traintuple.Key)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error ", resp.Message)
 }
 
 func TestTraintupleWithSingleDatasampleComposite(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	key := strings.Replace(objectiveKey, "1", "2", 1)
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputCompositeAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	inpTraintuple := inputCompositeTraintuple{
@@ -85,39 +87,40 @@ func TestTraintupleWithSingleDatasampleComposite(t *testing.T) {
 		DataSampleKeys: []string{trainDataSampleKey1},
 	}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "when adding composite traintuple with a single data samples it should work: ", resp.Message)
 
 	traintuple := outputCompositeTraintuple{}
 	err := json.Unmarshal(resp.Payload, &traintuple)
 	assert.NoError(t, err, "should be unmarshaled")
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(traintuple.Key)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the composite traintuple without error ", resp.Message)
 }
 
 func TestTraintupleWithDuplicatedDatasamplesComposite(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	key := strings.Replace(objectiveKey, "1", "2", 1)
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputCompositeAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "when adding composite algo it should work: ", resp.Message)
 
 	inpTraintuple := inputCompositeTraintuple{
 		DataSampleKeys: []string{trainDataSampleKey1, trainDataSampleKey2, trainDataSampleKey1},
 	}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding traintuple with a duplicated data samples it should not work: %s", resp.Message)
 }
 
@@ -149,30 +152,31 @@ func TestNoPanicWhileQueryingIncompleteTraintupleComposite(t *testing.T) {
 func TestTraintupleComputePlanCreationComposite(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add dataManager, dataSample and algo
 	registerItem(t, *mockStub, "compositeAlgo")
 
 	inpTraintuple := inputCompositeTraintuple{ComputePlanKey: "someComputePlanKey"}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	require.EqualValues(t, 400, resp.Status, "should failed for missing rank")
 	require.Contains(t, resp.Message, "invalid inputs, a ComputePlan should have a rank", "invalid error message")
 
 	inpTraintuple = inputCompositeTraintuple{Rank: "1"}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	require.EqualValues(t, 400, resp.Status, "should failed for invalid rank")
 	require.Contains(t, resp.Message, "Field validation for 'ComputePlanKey' failed on the 'required_with' tag")
 
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inCP.getArgs())
+	resp = mockStub.MockInvoke(mockTxID, inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple = inputCompositeTraintuple{Rank: "0", ComputePlanKey: cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status)
 	res := outputKey{}
 	err := json.Unmarshal(resp.Payload, &res)
@@ -182,7 +186,7 @@ func TestTraintupleComputePlanCreationComposite(t *testing.T) {
 
 	inpTraintuple = inputCompositeTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	require.EqualValues(t, 409, resp.Status, "should failed for duplicate Key")
 	require.Contains(t, resp.Message, "already exists")
 
@@ -197,18 +201,19 @@ func TestTraintupleComputePlanCreationComposite(t *testing.T) {
 func TestTraintupleMultipleCommputePlanCreationsComposite(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add a some dataManager, dataSample and traintuple
 	registerItem(t, *mockStub, "compositeAlgo")
 
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inCP.getArgs())
+	resp := mockStub.MockInvoke(mockTxID, inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple := inputCompositeTraintuple{Rank: "0", ComputePlanKey: cpKey}
 	args := inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status)
 	res := outputKey{}
 	err := json.Unmarshal(resp.Payload, &res)
@@ -225,7 +230,7 @@ func TestTraintupleMultipleCommputePlanCreationsComposite(t *testing.T) {
 		Rank:            "0",
 		ComputePlanKey:  cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 400, resp.Status, resp.Message, "should failed to add a traintuple of the same rank")
 
 	// Failed to add a traintuple to an unexisting CommputePlan
@@ -236,7 +241,7 @@ func TestTraintupleMultipleCommputePlanCreationsComposite(t *testing.T) {
 		Rank:            "1",
 		ComputePlanKey:  "notarealone"}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 404, resp.Status, resp.Message, "should failed to add a traintuple to an unexisting ComputePlanKey")
 
 	// Succesfully add a traintuple to the same ComputePlanKey
@@ -247,7 +252,7 @@ func TestTraintupleMultipleCommputePlanCreationsComposite(t *testing.T) {
 		Rank:            "1",
 		ComputePlanKey:  ct.ComputePlanKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message, "should be able do create a traintuple with the same ComputePlanKey")
 	err = json.Unmarshal(resp.Payload, &res)
 	assert.NoError(t, err, "should unmarshal without problem")
@@ -256,19 +261,20 @@ func TestTraintupleMultipleCommputePlanCreationsComposite(t *testing.T) {
 func TestTraintupleComposite(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add traintuple with invalid field
 	inpTraintuple := inputCompositeTraintuple{
 		AlgoKey: "aaa",
 	}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding objective with invalid key, status %d and message %s", resp.Status, resp.Message)
 
 	// Add traintuple with unexisting algo
 	inpTraintuple = inputCompositeTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding composite traintuple with unexisting algo, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add traintuple
@@ -281,7 +287,7 @@ func TestTraintupleComposite(t *testing.T) {
 	traintupleKey := res.Key
 	// Query traintuple from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the composite traintuple - status %d and message %s", resp.Status, resp.Message)
 	out := outputCompositeTraintuple{}
 	err = json.Unmarshal(resp.Payload, &out)
@@ -319,7 +325,7 @@ func TestTraintupleComposite(t *testing.T) {
 
 	// Query all traintuples and check consistency
 	args = [][]byte{[]byte("queryCompositeTraintuples")}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying composite traintuples - status %d and message %s", resp.Status, resp.Message)
 	// TODO add traintuple key to output struct
 	// For now we test it as cleanly as its added to the query response
@@ -336,7 +342,7 @@ func TestTraintupleComposite(t *testing.T) {
 		InHeadModelKey:  compositeTraintupleKey,
 		InTrunkModelKey: compositeTraintupleKey}
 	args = inpWaitingTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when adding composite traintuple with status %d and message %s", resp.Status, resp.Message)
 
 	// Query traintuple with status todo and worker as trainworker and check consistency
@@ -345,7 +351,7 @@ func TestTraintupleComposite(t *testing.T) {
 		Attributes: worker + ", todo",
 	}
 	args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying composite traintuple of worker with todo status - status %d and message %s", resp.Status, resp.Message)
 	err = json.Unmarshal(resp.Payload, &queryTraintuples)
 	assert.NoError(t, err, "composite traintuples should unmarshal without problem")
@@ -361,14 +367,14 @@ func TestTraintupleComposite(t *testing.T) {
 	}
 	traintupleStatus := []string{StatusDoing, StatusDone}
 	for i := range traintupleStatus {
-		resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", argsSlice[i])
+		resp = mockStub.MockInvoke(mockTxID, argsSlice[i])
 		require.EqualValuesf(t, 200, resp.Status, "when logging start %s with message %s", traintupleStatus[i], resp.Message)
 		filter := inputQueryFilter{
 			IndexName:  "compositeTraintuple~worker~status",
 			Attributes: worker + ", " + traintupleStatus[i],
 		}
 		args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-		resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+		resp = mockStub.MockInvoke(mockTxID, args)
 		assert.EqualValuesf(t, 200, resp.Status, "when querying traintuple of worker with %s status - message %s", traintupleStatus[i], resp.Message)
 		sPayload := make([]map[string]interface{}, 1)
 		assert.NoError(t, json.Unmarshal(resp.Payload, &sPayload), "when unmarshal queried traintuples")
@@ -378,7 +384,7 @@ func TestTraintupleComposite(t *testing.T) {
 
 	// Query CompositeTraintuple From key
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(compositeTraintupleKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying composite traintuple with status %d and message %s", resp.Status, resp.Message)
 	endTraintuple := outputCompositeTraintuple{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &endTraintuple))
@@ -395,7 +401,7 @@ func TestTraintupleComposite(t *testing.T) {
 
 	// query all traintuples related to a traintuple with the same algo
 	args = [][]byte{[]byte("queryModelDetails"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying model details with status %d and message %s", resp.Status, resp.Message)
 	payload := outputModelDetails{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &payload))
@@ -403,53 +409,55 @@ func TestTraintupleComposite(t *testing.T) {
 
 	// query all traintuples related to a traintuple with the same algo
 	args = [][]byte{[]byte("queryModels")}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying models with status %d and message %s", resp.Status, resp.Message)
 }
 
 func TestQueryTraintupleNotFoundComposite(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "compositeAlgo")
 
 	inpTraintuple := inputCompositeTraintuple{}
 	inpTraintuple.fillDefaults()
 	args := inpTraintuple.getArgs()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	var _key struct{ Key string }
 	json.Unmarshal(resp.Payload, &_key)
 
 	// queryCompositeTraintuple: normal queryCompositeTraintuple
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(_key.Key)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the composite traintuple - status %d and message %s", resp.Status, resp.Message)
 
 	// queryCompositeTraintuple: key does not exist
 	notFoundKey := "eedbb7c3-1f62-244c-0f34-461cc1688042"
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(notFoundKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 404, resp.Status, "when querying the composite traintuple - status %d and message %s", resp.Status, resp.Message)
 
 	// queryCompositeTraintuple: key does not exist and use existing other asset type key
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(algoKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 404, resp.Status, "when querying the composite traintuple - status %d and message %s", resp.Status, resp.Message)
 }
 
 func TestInsertTraintupleTwiceComposite(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	inpAlgo := inputCompositeAlgo{}
 	args := inpAlgo.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	// create a composite traintuple and start a ComplutePlan
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inCP.getArgs())
+	resp = mockStub.MockInvoke(mockTxID, inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple := inputCompositeTraintuple{
@@ -457,7 +465,7 @@ func TestInsertTraintupleTwiceComposite(t *testing.T) {
 		ComputePlanKey: cpKey,
 	}
 	inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("createCompositeTraintuple", inpTraintuple))
+	resp = mockStub.MockInvoke(mockTxID, methodAndAssetToByte("createCompositeTraintuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusOK, resp.Status)
 	var _key struct{ Key string }
 	json.Unmarshal(resp.Payload, &_key)
@@ -470,11 +478,11 @@ func TestInsertTraintupleTwiceComposite(t *testing.T) {
 	inpTraintuple.ComputePlanKey = tuple.ComputePlanKey
 	inpTraintuple.InHeadModelKey = _key.Key
 	inpTraintuple.InTrunkModelKey = _key.Key
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("createCompositeTraintuple", inpTraintuple))
+	resp = mockStub.MockInvoke(mockTxID, methodAndAssetToByte("createCompositeTraintuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusOK, resp.Status)
 
 	// re-insert the same composite traintuple and expect a conflict error
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("createCompositeTraintuple", inpTraintuple))
+	resp = mockStub.MockInvoke(mockTxID, methodAndAssetToByte("createCompositeTraintuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusConflict, resp.Status)
 }
 
@@ -525,18 +533,19 @@ func TestCreateCompositeTraintupleInModels(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			scc := new(SubstraChaincode)
 			mockStub := NewMockStubWithRegisterNode("substra", scc)
+			mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 			registerItem(t, *mockStub, "trainDataset")
 
 			key := strings.Replace(objectiveKey, "1", "2", 1)
 			inpObjective := inputObjective{Key: key}
 			inpObjective.createDefault()
 			inpObjective.TestDataset = inputDataset{}
-			resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
+			resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
 			assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 			inpAlgo := inputCompositeAlgo{}
 			args := inpAlgo.createDefault()
-			resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+			resp = mockStub.MockInvoke(mockTxID, args)
 			assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 			inpTraintuple := inputCompositeTraintuple{Key: RandomUUID()}
@@ -546,7 +555,7 @@ func TestCreateCompositeTraintupleInModels(t *testing.T) {
 				inpHeadTraintuple := inputCompositeTraintuple{}
 				inpHeadTraintuple.DataSampleKeys = []string{trainDataSampleKey1}
 				args = inpHeadTraintuple.createDefault()
-				resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+				resp = mockStub.MockInvoke(mockTxID, args)
 				headTraintuple := outputCompositeTraintuple{}
 				json.Unmarshal(resp.Payload, &headTraintuple)
 
@@ -559,7 +568,7 @@ func TestCreateCompositeTraintupleInModels(t *testing.T) {
 				inpTrunkTraintuple := inputCompositeTraintuple{}
 				inpTrunkTraintuple.DataSampleKeys = []string{trainDataSampleKey2}
 				args = inpTrunkTraintuple.createDefault()
-				resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+				resp = mockStub.MockInvoke(mockTxID, args)
 				trunkTraintuple := outputCompositeTraintuple{}
 				json.Unmarshal(resp.Payload, &trunkTraintuple)
 
@@ -568,14 +577,14 @@ func TestCreateCompositeTraintupleInModels(t *testing.T) {
 			}
 
 			args = inpTraintuple.createDefault()
-			resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+			resp = mockStub.MockInvoke(mockTxID, args)
 
 			if tt.shouldSucceed {
 				assert.EqualValues(t, 200, resp.Status, tt.message+": "+resp.Message)
 				traintuple := outputCompositeTraintuple{}
 				json.Unmarshal(resp.Payload, &traintuple)
 				args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(traintuple.Key)}
-				resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+				resp = mockStub.MockInvoke(mockTxID, args)
 				assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error ", resp.Message)
 				traintuple = outputCompositeTraintuple{}
 				json.Unmarshal(resp.Payload, &traintuple)
@@ -628,6 +637,7 @@ func TestCompositeTraintupleInModelTypes(t *testing.T) {
 func testCompositeTraintupleInModelTypes(t *testing.T, headType AssetType, trunkType AssetType, shouldSucceed bool) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "aggregateAlgo")
 
 	inpTraintuple := inputCompositeTraintuple{}
@@ -643,7 +653,7 @@ func testCompositeTraintupleInModelTypes(t *testing.T, headType AssetType, trunk
 	// create composite traintuple
 	inpTraintuple.fillDefaults()
 	args := inpTraintuple.getArgs()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 
 	if !shouldSucceed {
 		assert.EqualValues(t, http.StatusBadRequest, resp.Status, "It should NOT be possible to register a traintuple with a %s head and a %s trunk: %s", headType, trunkType, resp.Message)
@@ -656,7 +666,7 @@ func testCompositeTraintupleInModelTypes(t *testing.T, headType AssetType, trunk
 
 	// fetch it back
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(keyOnly.Key)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error: %s", resp.Message)
 	traintuple := outputCompositeTraintuple{}
 	json.Unmarshal(resp.Payload, &traintuple)
@@ -671,6 +681,7 @@ func testCompositeTraintupleInModelTypes(t *testing.T, headType AssetType, trunk
 func TestCompositeTraintuplePermissions(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "compositeAlgo")
 
 	inpTraintuple := inputCompositeTraintuple{}
@@ -678,12 +689,12 @@ func TestCompositeTraintuplePermissions(t *testing.T) {
 	// Grant trunk model permissions to no-one
 	inpTraintuple.OutTrunkModelPermissions = inputPermissions{Process: inputPermission{Public: false, AuthorizedIDs: []string{}}}
 	args := inpTraintuple.getArgs()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 
 	traintuple := outputCompositeTraintuple{}
 	json.Unmarshal(resp.Payload, &traintuple)
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(traintuple.Key)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	traintuple = outputCompositeTraintuple{}
 	json.Unmarshal(resp.Payload, &traintuple)
 
@@ -702,13 +713,14 @@ func TestCompositeTraintupleLogSuccessFail(t *testing.T) {
 		t.Run("TestCompositeTraintupleLog"+status, func(t *testing.T) {
 			scc := new(SubstraChaincode)
 			mockStub := NewMockStubWithRegisterNode("substra", scc)
+			mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 			resp, _ := registerItem(t, *mockStub, "compositeTraintuple")
 			var _key struct{ Key string }
 			json.Unmarshal(resp.Payload, &_key)
 			key := _key.Key
 
 			// start
-			resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", [][]byte{[]byte("logStartCompositeTrain"), keyToJSON(key)})
+			resp = mockStub.MockInvoke(mockTxID, [][]byte{[]byte("logStartCompositeTrain"), keyToJSON(key)})
 
 			var expectedStatus string
 
@@ -717,7 +729,7 @@ func TestCompositeTraintupleLogSuccessFail(t *testing.T) {
 				success := inputLogSuccessCompositeTrain{}
 				success.Key = key
 				args := success.createDefault()
-				resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+				resp = mockStub.MockInvoke(mockTxID, args)
 				require.EqualValuesf(t, 200, resp.Status, "traintuple should be successfully set to 'success': %s", resp.Message)
 				expectedStatus = "done"
 			case StatusFailed:
@@ -725,14 +737,14 @@ func TestCompositeTraintupleLogSuccessFail(t *testing.T) {
 				failed.Key = key
 				failed.fillDefaults()
 				args := failed.getArgsComposite()
-				resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+				resp = mockStub.MockInvoke(mockTxID, args)
 				require.EqualValuesf(t, 200, resp.Status, "traintuple should be successfully set to 'failed': %s", resp.Message)
 				expectedStatus = "failed"
 			}
 
 			// fetch back
 			args := [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(key)}
-			resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+			resp = mockStub.MockInvoke(mockTxID, args)
 			assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error: %s", resp.Message)
 			traintuple := outputCompositeTraintuple{}
 			json.Unmarshal(resp.Payload, &traintuple)
@@ -747,6 +759,7 @@ func TestCompositeTraintupleLogSuccessFail(t *testing.T) {
 func TestCorrectParent(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// register parent
 	resp, _ := registerItem(t, *mockStub, "compositeTraintuple")
@@ -758,7 +771,7 @@ func TestCorrectParent(t *testing.T) {
 	inp1 := inputAggregatetuple{}
 	inp1.fillDefaults()
 	inp1.InModels = []string{parentKey}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inp1.getArgs())
+	resp = mockStub.MockInvoke(mockTxID, inp1.getArgs())
 	json.Unmarshal(resp.Payload, &_key)
 	child1Key := _key.Key
 
@@ -767,17 +780,17 @@ func TestCorrectParent(t *testing.T) {
 	inp2.createDefault()
 	inp2.InHeadModelKey = parentKey
 	inp2.InTrunkModelKey = traintupleKey
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inp2.getArgs())
+	resp = mockStub.MockInvoke(mockTxID, inp2.getArgs())
 	json.Unmarshal(resp.Payload, &_key)
 	child2Key := _key.Key
 
 	// start
-	mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", [][]byte{[]byte("logStartCompositeTrain"), keyToJSON(parentKey)})
+	mockStub.MockInvoke(mockTxID, [][]byte{[]byte("logStartCompositeTrain"), keyToJSON(parentKey)})
 	// success
 	success := inputLogSuccessCompositeTrain{}
 	success.Key = parentKey
 	args := success.createDefault()
-	mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	mockStub.MockInvoke(mockTxID, args)
 
 	mockStub.MockTransactionStart("42")
 	db := NewLedgerDB(mockStub)
@@ -796,6 +809,7 @@ func TestCorrectParent(t *testing.T) {
 func TestCreateTesttuplePermissions(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	registerItem(t, *mockStub, "compositeTraintuple")
 
@@ -806,12 +820,12 @@ func TestCreateTesttuplePermissions(t *testing.T) {
 	// impersonate bad guy
 	initialCreator := mockStub.Creator
 	mockStub.Creator = "bad guy"
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inpTesttuple.getArgs())
+	resp := mockStub.MockInvoke(mockTxID, inpTesttuple.getArgs())
 	assert.EqualValues(t, 403, resp.Status, "When the creator is NOT an authorized worker, the testtuple creation should fail: %s", resp.Message)
 
 	// impersonate good guy
 	mockStub.Creator = initialCreator
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inpTesttuple.getArgs())
+	resp = mockStub.MockInvoke(mockTxID, inpTesttuple.getArgs())
 	assert.EqualValues(t, 200, resp.Status, "When the creator is an authorized worker, the testtuple should be created without error: %s", resp.Message)
 }
 

--- a/chaincode/traintuple_composite_test.go
+++ b/chaincode/traintuple_composite_test.go
@@ -42,24 +42,24 @@ func TestTraintupleWithNoTestDatasetComposite(t *testing.T) {
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke("42", methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputCompositeAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	inpTraintuple := inputCompositeTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 
 	assert.EqualValues(t, 200, resp.Status, "when adding traintuple without test dataset it should work: ", resp.Message)
 
 	traintuple := outputCompositeTraintuple{}
 	json.Unmarshal(resp.Payload, &traintuple)
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(traintuple.Key)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error ", resp.Message)
 }
 
@@ -72,12 +72,12 @@ func TestTraintupleWithSingleDatasampleComposite(t *testing.T) {
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke("42", methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputCompositeAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	inpTraintuple := inputCompositeTraintuple{
@@ -85,14 +85,14 @@ func TestTraintupleWithSingleDatasampleComposite(t *testing.T) {
 		DataSampleKeys: []string{trainDataSampleKey1},
 	}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "when adding composite traintuple with a single data samples it should work: ", resp.Message)
 
 	traintuple := outputCompositeTraintuple{}
 	err := json.Unmarshal(resp.Payload, &traintuple)
 	assert.NoError(t, err, "should be unmarshaled")
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(traintuple.Key)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the composite traintuple without error ", resp.Message)
 }
 
@@ -105,19 +105,19 @@ func TestTraintupleWithDuplicatedDatasamplesComposite(t *testing.T) {
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke("42", methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputCompositeAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "when adding composite algo it should work: ", resp.Message)
 
 	inpTraintuple := inputCompositeTraintuple{
 		DataSampleKeys: []string{trainDataSampleKey1, trainDataSampleKey2, trainDataSampleKey1},
 	}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding traintuple with a duplicated data samples it should not work: %s", resp.Message)
 }
 
@@ -155,24 +155,24 @@ func TestTraintupleComputePlanCreationComposite(t *testing.T) {
 
 	inpTraintuple := inputCompositeTraintuple{ComputePlanKey: "someComputePlanKey"}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValues(t, 400, resp.Status, "should failed for missing rank")
 	require.Contains(t, resp.Message, "invalid inputs, a ComputePlan should have a rank", "invalid error message")
 
 	inpTraintuple = inputCompositeTraintuple{Rank: "1"}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValues(t, 400, resp.Status, "should failed for invalid rank")
 	require.Contains(t, resp.Message, "Field validation for 'ComputePlanKey' failed on the 'required_with' tag")
 
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp = mockStub.MockInvoke("42", inCP.getArgs())
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple = inputCompositeTraintuple{Rank: "0", ComputePlanKey: cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status)
 	res := outputKey{}
 	err := json.Unmarshal(resp.Payload, &res)
@@ -182,7 +182,7 @@ func TestTraintupleComputePlanCreationComposite(t *testing.T) {
 
 	inpTraintuple = inputCompositeTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValues(t, 409, resp.Status, "should failed for duplicate Key")
 	require.Contains(t, resp.Message, "already exists")
 
@@ -203,12 +203,12 @@ func TestTraintupleMultipleCommputePlanCreationsComposite(t *testing.T) {
 
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp := mockStub.MockInvoke("42", inCP.getArgs())
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple := inputCompositeTraintuple{Rank: "0", ComputePlanKey: cpKey}
 	args := inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status)
 	res := outputKey{}
 	err := json.Unmarshal(resp.Payload, &res)
@@ -225,7 +225,7 @@ func TestTraintupleMultipleCommputePlanCreationsComposite(t *testing.T) {
 		Rank:            "0",
 		ComputePlanKey:  cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 400, resp.Status, resp.Message, "should failed to add a traintuple of the same rank")
 
 	// Failed to add a traintuple to an unexisting CommputePlan
@@ -236,7 +236,7 @@ func TestTraintupleMultipleCommputePlanCreationsComposite(t *testing.T) {
 		Rank:            "1",
 		ComputePlanKey:  "notarealone"}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 404, resp.Status, resp.Message, "should failed to add a traintuple to an unexisting ComputePlanKey")
 
 	// Succesfully add a traintuple to the same ComputePlanKey
@@ -247,7 +247,7 @@ func TestTraintupleMultipleCommputePlanCreationsComposite(t *testing.T) {
 		Rank:            "1",
 		ComputePlanKey:  ct.ComputePlanKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message, "should be able do create a traintuple with the same ComputePlanKey")
 	err = json.Unmarshal(resp.Payload, &res)
 	assert.NoError(t, err, "should unmarshal without problem")
@@ -262,13 +262,13 @@ func TestTraintupleComposite(t *testing.T) {
 		AlgoKey: "aaa",
 	}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding objective with invalid key, status %d and message %s", resp.Status, resp.Message)
 
 	// Add traintuple with unexisting algo
 	inpTraintuple = inputCompositeTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding composite traintuple with unexisting algo, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add traintuple
@@ -281,7 +281,7 @@ func TestTraintupleComposite(t *testing.T) {
 	traintupleKey := res.Key
 	// Query traintuple from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the composite traintuple - status %d and message %s", resp.Status, resp.Message)
 	out := outputCompositeTraintuple{}
 	err = json.Unmarshal(resp.Payload, &out)
@@ -319,7 +319,7 @@ func TestTraintupleComposite(t *testing.T) {
 
 	// Query all traintuples and check consistency
 	args = [][]byte{[]byte("queryCompositeTraintuples")}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying composite traintuples - status %d and message %s", resp.Status, resp.Message)
 	// TODO add traintuple key to output struct
 	// For now we test it as cleanly as its added to the query response
@@ -336,7 +336,7 @@ func TestTraintupleComposite(t *testing.T) {
 		InHeadModelKey:  compositeTraintupleKey,
 		InTrunkModelKey: compositeTraintupleKey}
 	args = inpWaitingTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when adding composite traintuple with status %d and message %s", resp.Status, resp.Message)
 
 	// Query traintuple with status todo and worker as trainworker and check consistency
@@ -345,7 +345,7 @@ func TestTraintupleComposite(t *testing.T) {
 		Attributes: worker + ", todo",
 	}
 	args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying composite traintuple of worker with todo status - status %d and message %s", resp.Status, resp.Message)
 	err = json.Unmarshal(resp.Payload, &queryTraintuples)
 	assert.NoError(t, err, "composite traintuples should unmarshal without problem")
@@ -361,14 +361,14 @@ func TestTraintupleComposite(t *testing.T) {
 	}
 	traintupleStatus := []string{StatusDoing, StatusDone}
 	for i := range traintupleStatus {
-		resp = mockStub.MockInvoke("42", argsSlice[i])
+		resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", argsSlice[i])
 		require.EqualValuesf(t, 200, resp.Status, "when logging start %s with message %s", traintupleStatus[i], resp.Message)
 		filter := inputQueryFilter{
 			IndexName:  "compositeTraintuple~worker~status",
 			Attributes: worker + ", " + traintupleStatus[i],
 		}
 		args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-		resp = mockStub.MockInvoke("42", args)
+		resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 		assert.EqualValuesf(t, 200, resp.Status, "when querying traintuple of worker with %s status - message %s", traintupleStatus[i], resp.Message)
 		sPayload := make([]map[string]interface{}, 1)
 		assert.NoError(t, json.Unmarshal(resp.Payload, &sPayload), "when unmarshal queried traintuples")
@@ -378,7 +378,7 @@ func TestTraintupleComposite(t *testing.T) {
 
 	// Query CompositeTraintuple From key
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(compositeTraintupleKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying composite traintuple with status %d and message %s", resp.Status, resp.Message)
 	endTraintuple := outputCompositeTraintuple{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &endTraintuple))
@@ -395,7 +395,7 @@ func TestTraintupleComposite(t *testing.T) {
 
 	// query all traintuples related to a traintuple with the same algo
 	args = [][]byte{[]byte("queryModelDetails"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying model details with status %d and message %s", resp.Status, resp.Message)
 	payload := outputModelDetails{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &payload))
@@ -403,7 +403,7 @@ func TestTraintupleComposite(t *testing.T) {
 
 	// query all traintuples related to a traintuple with the same algo
 	args = [][]byte{[]byte("queryModels")}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying models with status %d and message %s", resp.Status, resp.Message)
 }
 
@@ -415,24 +415,24 @@ func TestQueryTraintupleNotFoundComposite(t *testing.T) {
 	inpTraintuple := inputCompositeTraintuple{}
 	inpTraintuple.fillDefaults()
 	args := inpTraintuple.getArgs()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	var _key struct{ Key string }
 	json.Unmarshal(resp.Payload, &_key)
 
 	// queryCompositeTraintuple: normal queryCompositeTraintuple
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(_key.Key)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the composite traintuple - status %d and message %s", resp.Status, resp.Message)
 
 	// queryCompositeTraintuple: key does not exist
 	notFoundKey := "eedbb7c3-1f62-244c-0f34-461cc1688042"
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(notFoundKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 404, resp.Status, "when querying the composite traintuple - status %d and message %s", resp.Status, resp.Message)
 
 	// queryCompositeTraintuple: key does not exist and use existing other asset type key
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(algoKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 404, resp.Status, "when querying the composite traintuple - status %d and message %s", resp.Status, resp.Message)
 }
 
@@ -443,13 +443,13 @@ func TestInsertTraintupleTwiceComposite(t *testing.T) {
 
 	inpAlgo := inputCompositeAlgo{}
 	args := inpAlgo.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	// create a composite traintuple and start a ComplutePlan
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp = mockStub.MockInvoke("42", inCP.getArgs())
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple := inputCompositeTraintuple{
@@ -457,7 +457,7 @@ func TestInsertTraintupleTwiceComposite(t *testing.T) {
 		ComputePlanKey: cpKey,
 	}
 	inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", methodAndAssetToByte("createCompositeTraintuple", inpTraintuple))
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("createCompositeTraintuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusOK, resp.Status)
 	var _key struct{ Key string }
 	json.Unmarshal(resp.Payload, &_key)
@@ -470,11 +470,11 @@ func TestInsertTraintupleTwiceComposite(t *testing.T) {
 	inpTraintuple.ComputePlanKey = tuple.ComputePlanKey
 	inpTraintuple.InHeadModelKey = _key.Key
 	inpTraintuple.InTrunkModelKey = _key.Key
-	resp = mockStub.MockInvoke("42", methodAndAssetToByte("createCompositeTraintuple", inpTraintuple))
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("createCompositeTraintuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusOK, resp.Status)
 
 	// re-insert the same composite traintuple and expect a conflict error
-	resp = mockStub.MockInvoke("42", methodAndAssetToByte("createCompositeTraintuple", inpTraintuple))
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("createCompositeTraintuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusConflict, resp.Status)
 }
 
@@ -531,12 +531,12 @@ func TestCreateCompositeTraintupleInModels(t *testing.T) {
 			inpObjective := inputObjective{Key: key}
 			inpObjective.createDefault()
 			inpObjective.TestDataset = inputDataset{}
-			resp := mockStub.MockInvoke("42", methodAndAssetToByte("registerObjective", inpObjective))
+			resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
 			assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 			inpAlgo := inputCompositeAlgo{}
 			args := inpAlgo.createDefault()
-			resp = mockStub.MockInvoke("42", args)
+			resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 			assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 			inpTraintuple := inputCompositeTraintuple{Key: RandomUUID()}
@@ -546,7 +546,7 @@ func TestCreateCompositeTraintupleInModels(t *testing.T) {
 				inpHeadTraintuple := inputCompositeTraintuple{}
 				inpHeadTraintuple.DataSampleKeys = []string{trainDataSampleKey1}
 				args = inpHeadTraintuple.createDefault()
-				resp = mockStub.MockInvoke("42", args)
+				resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 				headTraintuple := outputCompositeTraintuple{}
 				json.Unmarshal(resp.Payload, &headTraintuple)
 
@@ -559,7 +559,7 @@ func TestCreateCompositeTraintupleInModels(t *testing.T) {
 				inpTrunkTraintuple := inputCompositeTraintuple{}
 				inpTrunkTraintuple.DataSampleKeys = []string{trainDataSampleKey2}
 				args = inpTrunkTraintuple.createDefault()
-				resp = mockStub.MockInvoke("42", args)
+				resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 				trunkTraintuple := outputCompositeTraintuple{}
 				json.Unmarshal(resp.Payload, &trunkTraintuple)
 
@@ -568,14 +568,14 @@ func TestCreateCompositeTraintupleInModels(t *testing.T) {
 			}
 
 			args = inpTraintuple.createDefault()
-			resp = mockStub.MockInvoke("42", args)
+			resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 
 			if tt.shouldSucceed {
 				assert.EqualValues(t, 200, resp.Status, tt.message+": "+resp.Message)
 				traintuple := outputCompositeTraintuple{}
 				json.Unmarshal(resp.Payload, &traintuple)
 				args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(traintuple.Key)}
-				resp = mockStub.MockInvoke("42", args)
+				resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 				assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error ", resp.Message)
 				traintuple = outputCompositeTraintuple{}
 				json.Unmarshal(resp.Payload, &traintuple)
@@ -643,7 +643,7 @@ func testCompositeTraintupleInModelTypes(t *testing.T, headType AssetType, trunk
 	// create composite traintuple
 	inpTraintuple.fillDefaults()
 	args := inpTraintuple.getArgs()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 
 	if !shouldSucceed {
 		assert.EqualValues(t, http.StatusBadRequest, resp.Status, "It should NOT be possible to register a traintuple with a %s head and a %s trunk: %s", headType, trunkType, resp.Message)
@@ -656,7 +656,7 @@ func testCompositeTraintupleInModelTypes(t *testing.T, headType AssetType, trunk
 
 	// fetch it back
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(keyOnly.Key)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error: %s", resp.Message)
 	traintuple := outputCompositeTraintuple{}
 	json.Unmarshal(resp.Payload, &traintuple)
@@ -678,12 +678,12 @@ func TestCompositeTraintuplePermissions(t *testing.T) {
 	// Grant trunk model permissions to no-one
 	inpTraintuple.OutTrunkModelPermissions = inputPermissions{Process: inputPermission{Public: false, AuthorizedIDs: []string{}}}
 	args := inpTraintuple.getArgs()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 
 	traintuple := outputCompositeTraintuple{}
 	json.Unmarshal(resp.Payload, &traintuple)
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(traintuple.Key)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	traintuple = outputCompositeTraintuple{}
 	json.Unmarshal(resp.Payload, &traintuple)
 
@@ -708,7 +708,7 @@ func TestCompositeTraintupleLogSuccessFail(t *testing.T) {
 			key := _key.Key
 
 			// start
-			resp = mockStub.MockInvoke("42", [][]byte{[]byte("logStartCompositeTrain"), keyToJSON(key)})
+			resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", [][]byte{[]byte("logStartCompositeTrain"), keyToJSON(key)})
 
 			var expectedStatus string
 
@@ -717,7 +717,7 @@ func TestCompositeTraintupleLogSuccessFail(t *testing.T) {
 				success := inputLogSuccessCompositeTrain{}
 				success.Key = key
 				args := success.createDefault()
-				resp = mockStub.MockInvoke("42", args)
+				resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 				require.EqualValuesf(t, 200, resp.Status, "traintuple should be successfully set to 'success': %s", resp.Message)
 				expectedStatus = "done"
 			case StatusFailed:
@@ -725,14 +725,14 @@ func TestCompositeTraintupleLogSuccessFail(t *testing.T) {
 				failed.Key = key
 				failed.fillDefaults()
 				args := failed.getArgsComposite()
-				resp = mockStub.MockInvoke("42", args)
+				resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 				require.EqualValuesf(t, 200, resp.Status, "traintuple should be successfully set to 'failed': %s", resp.Message)
 				expectedStatus = "failed"
 			}
 
 			// fetch back
 			args := [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(key)}
-			resp = mockStub.MockInvoke("42", args)
+			resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 			assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error: %s", resp.Message)
 			traintuple := outputCompositeTraintuple{}
 			json.Unmarshal(resp.Payload, &traintuple)
@@ -758,7 +758,7 @@ func TestCorrectParent(t *testing.T) {
 	inp1 := inputAggregatetuple{}
 	inp1.fillDefaults()
 	inp1.InModels = []string{parentKey}
-	resp = mockStub.MockInvoke("42", inp1.getArgs())
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inp1.getArgs())
 	json.Unmarshal(resp.Payload, &_key)
 	child1Key := _key.Key
 
@@ -767,17 +767,17 @@ func TestCorrectParent(t *testing.T) {
 	inp2.createDefault()
 	inp2.InHeadModelKey = parentKey
 	inp2.InTrunkModelKey = traintupleKey
-	resp = mockStub.MockInvoke("42", inp2.getArgs())
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inp2.getArgs())
 	json.Unmarshal(resp.Payload, &_key)
 	child2Key := _key.Key
 
 	// start
-	mockStub.MockInvoke("42", [][]byte{[]byte("logStartCompositeTrain"), keyToJSON(parentKey)})
+	mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", [][]byte{[]byte("logStartCompositeTrain"), keyToJSON(parentKey)})
 	// success
 	success := inputLogSuccessCompositeTrain{}
 	success.Key = parentKey
 	args := success.createDefault()
-	mockStub.MockInvoke("42", args)
+	mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 
 	mockStub.MockTransactionStart("42")
 	db := NewLedgerDB(mockStub)
@@ -806,12 +806,12 @@ func TestCreateTesttuplePermissions(t *testing.T) {
 	// impersonate bad guy
 	initialCreator := mockStub.Creator
 	mockStub.Creator = "bad guy"
-	resp := mockStub.MockInvoke("42", inpTesttuple.getArgs())
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inpTesttuple.getArgs())
 	assert.EqualValues(t, 403, resp.Status, "When the creator is NOT an authorized worker, the testtuple creation should fail: %s", resp.Message)
 
 	// impersonate good guy
 	mockStub.Creator = initialCreator
-	resp = mockStub.MockInvoke("42", inpTesttuple.getArgs())
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inpTesttuple.getArgs())
 	assert.EqualValues(t, 200, resp.Status, "When the creator is an authorized worker, the testtuple should be created without error: %s", resp.Message)
 }
 

--- a/chaincode/traintuple_composite_test.go
+++ b/chaincode/traintuple_composite_test.go
@@ -42,24 +42,24 @@ func TestTraintupleWithNoTestDatasetComposite(t *testing.T) {
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke(methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputCompositeAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	inpTraintuple := inputCompositeTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 
 	assert.EqualValues(t, 200, resp.Status, "when adding traintuple without test dataset it should work: ", resp.Message)
 
 	traintuple := outputCompositeTraintuple{}
 	json.Unmarshal(resp.Payload, &traintuple)
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(traintuple.Key)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error ", resp.Message)
 }
 
@@ -72,12 +72,12 @@ func TestTraintupleWithSingleDatasampleComposite(t *testing.T) {
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke(methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputCompositeAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	inpTraintuple := inputCompositeTraintuple{
@@ -85,14 +85,14 @@ func TestTraintupleWithSingleDatasampleComposite(t *testing.T) {
 		DataSampleKeys: []string{trainDataSampleKey1},
 	}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "when adding composite traintuple with a single data samples it should work: ", resp.Message)
 
 	traintuple := outputCompositeTraintuple{}
 	err := json.Unmarshal(resp.Payload, &traintuple)
 	assert.NoError(t, err, "should be unmarshaled")
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(traintuple.Key)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the composite traintuple without error ", resp.Message)
 }
 
@@ -105,19 +105,19 @@ func TestTraintupleWithDuplicatedDatasamplesComposite(t *testing.T) {
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke(methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputCompositeAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "when adding composite algo it should work: ", resp.Message)
 
 	inpTraintuple := inputCompositeTraintuple{
 		DataSampleKeys: []string{trainDataSampleKey1, trainDataSampleKey2, trainDataSampleKey1},
 	}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding traintuple with a duplicated data samples it should not work: %s", resp.Message)
 }
 
@@ -155,24 +155,24 @@ func TestTraintupleComputePlanCreationComposite(t *testing.T) {
 
 	inpTraintuple := inputCompositeTraintuple{ComputePlanKey: "someComputePlanKey"}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	require.EqualValues(t, 400, resp.Status, "should failed for missing rank")
 	require.Contains(t, resp.Message, "invalid inputs, a ComputePlan should have a rank", "invalid error message")
 
 	inpTraintuple = inputCompositeTraintuple{Rank: "1"}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	require.EqualValues(t, 400, resp.Status, "should failed for invalid rank")
 	require.Contains(t, resp.Message, "Field validation for 'ComputePlanKey' failed on the 'required_with' tag")
 
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp = mockStub.MockInvoke(mockTxID, inCP.getArgs())
+	resp = mockStub.MockInvoke(inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple = inputCompositeTraintuple{Rank: "0", ComputePlanKey: cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status)
 	res := outputKey{}
 	err := json.Unmarshal(resp.Payload, &res)
@@ -182,7 +182,7 @@ func TestTraintupleComputePlanCreationComposite(t *testing.T) {
 
 	inpTraintuple = inputCompositeTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	require.EqualValues(t, 409, resp.Status, "should failed for duplicate Key")
 	require.Contains(t, resp.Message, "already exists")
 
@@ -203,12 +203,12 @@ func TestTraintupleMultipleCommputePlanCreationsComposite(t *testing.T) {
 
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp := mockStub.MockInvoke(mockTxID, inCP.getArgs())
+	resp := mockStub.MockInvoke(inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple := inputCompositeTraintuple{Rank: "0", ComputePlanKey: cpKey}
 	args := inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status)
 	res := outputKey{}
 	err := json.Unmarshal(resp.Payload, &res)
@@ -225,7 +225,7 @@ func TestTraintupleMultipleCommputePlanCreationsComposite(t *testing.T) {
 		Rank:            "0",
 		ComputePlanKey:  cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 400, resp.Status, resp.Message, "should failed to add a traintuple of the same rank")
 
 	// Failed to add a traintuple to an unexisting CommputePlan
@@ -236,7 +236,7 @@ func TestTraintupleMultipleCommputePlanCreationsComposite(t *testing.T) {
 		Rank:            "1",
 		ComputePlanKey:  "notarealone"}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 404, resp.Status, resp.Message, "should failed to add a traintuple to an unexisting ComputePlanKey")
 
 	// Succesfully add a traintuple to the same ComputePlanKey
@@ -247,7 +247,7 @@ func TestTraintupleMultipleCommputePlanCreationsComposite(t *testing.T) {
 		Rank:            "1",
 		ComputePlanKey:  ct.ComputePlanKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message, "should be able do create a traintuple with the same ComputePlanKey")
 	err = json.Unmarshal(resp.Payload, &res)
 	assert.NoError(t, err, "should unmarshal without problem")
@@ -262,13 +262,13 @@ func TestTraintupleComposite(t *testing.T) {
 		AlgoKey: "aaa",
 	}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding objective with invalid key, status %d and message %s", resp.Status, resp.Message)
 
 	// Add traintuple with unexisting algo
 	inpTraintuple = inputCompositeTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding composite traintuple with unexisting algo, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add traintuple
@@ -281,7 +281,7 @@ func TestTraintupleComposite(t *testing.T) {
 	traintupleKey := res.Key
 	// Query traintuple from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the composite traintuple - status %d and message %s", resp.Status, resp.Message)
 	out := outputCompositeTraintuple{}
 	err = json.Unmarshal(resp.Payload, &out)
@@ -319,7 +319,7 @@ func TestTraintupleComposite(t *testing.T) {
 
 	// Query all traintuples and check consistency
 	args = [][]byte{[]byte("queryCompositeTraintuples")}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying composite traintuples - status %d and message %s", resp.Status, resp.Message)
 	// TODO add traintuple key to output struct
 	// For now we test it as cleanly as its added to the query response
@@ -336,7 +336,7 @@ func TestTraintupleComposite(t *testing.T) {
 		InHeadModelKey:  compositeTraintupleKey,
 		InTrunkModelKey: compositeTraintupleKey}
 	args = inpWaitingTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when adding composite traintuple with status %d and message %s", resp.Status, resp.Message)
 
 	// Query traintuple with status todo and worker as trainworker and check consistency
@@ -345,7 +345,7 @@ func TestTraintupleComposite(t *testing.T) {
 		Attributes: worker + ", todo",
 	}
 	args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying composite traintuple of worker with todo status - status %d and message %s", resp.Status, resp.Message)
 	err = json.Unmarshal(resp.Payload, &queryTraintuples)
 	assert.NoError(t, err, "composite traintuples should unmarshal without problem")
@@ -361,14 +361,14 @@ func TestTraintupleComposite(t *testing.T) {
 	}
 	traintupleStatus := []string{StatusDoing, StatusDone}
 	for i := range traintupleStatus {
-		resp = mockStub.MockInvoke(mockTxID, argsSlice[i])
+		resp = mockStub.MockInvoke(argsSlice[i])
 		require.EqualValuesf(t, 200, resp.Status, "when logging start %s with message %s", traintupleStatus[i], resp.Message)
 		filter := inputQueryFilter{
 			IndexName:  "compositeTraintuple~worker~status",
 			Attributes: worker + ", " + traintupleStatus[i],
 		}
 		args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-		resp = mockStub.MockInvoke(mockTxID, args)
+		resp = mockStub.MockInvoke(args)
 		assert.EqualValuesf(t, 200, resp.Status, "when querying traintuple of worker with %s status - message %s", traintupleStatus[i], resp.Message)
 		sPayload := make([]map[string]interface{}, 1)
 		assert.NoError(t, json.Unmarshal(resp.Payload, &sPayload), "when unmarshal queried traintuples")
@@ -378,7 +378,7 @@ func TestTraintupleComposite(t *testing.T) {
 
 	// Query CompositeTraintuple From key
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(compositeTraintupleKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying composite traintuple with status %d and message %s", resp.Status, resp.Message)
 	endTraintuple := outputCompositeTraintuple{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &endTraintuple))
@@ -395,7 +395,7 @@ func TestTraintupleComposite(t *testing.T) {
 
 	// query all traintuples related to a traintuple with the same algo
 	args = [][]byte{[]byte("queryModelDetails"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying model details with status %d and message %s", resp.Status, resp.Message)
 	payload := outputModelDetails{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &payload))
@@ -403,7 +403,7 @@ func TestTraintupleComposite(t *testing.T) {
 
 	// query all traintuples related to a traintuple with the same algo
 	args = [][]byte{[]byte("queryModels")}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying models with status %d and message %s", resp.Status, resp.Message)
 }
 
@@ -415,24 +415,24 @@ func TestQueryTraintupleNotFoundComposite(t *testing.T) {
 	inpTraintuple := inputCompositeTraintuple{}
 	inpTraintuple.fillDefaults()
 	args := inpTraintuple.getArgs()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	var _key struct{ Key string }
 	json.Unmarshal(resp.Payload, &_key)
 
 	// queryCompositeTraintuple: normal queryCompositeTraintuple
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(_key.Key)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the composite traintuple - status %d and message %s", resp.Status, resp.Message)
 
 	// queryCompositeTraintuple: key does not exist
 	notFoundKey := "eedbb7c3-1f62-244c-0f34-461cc1688042"
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(notFoundKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 404, resp.Status, "when querying the composite traintuple - status %d and message %s", resp.Status, resp.Message)
 
 	// queryCompositeTraintuple: key does not exist and use existing other asset type key
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(algoKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 404, resp.Status, "when querying the composite traintuple - status %d and message %s", resp.Status, resp.Message)
 }
 
@@ -443,13 +443,13 @@ func TestInsertTraintupleTwiceComposite(t *testing.T) {
 
 	inpAlgo := inputCompositeAlgo{}
 	args := inpAlgo.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	// create a composite traintuple and start a ComplutePlan
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp = mockStub.MockInvoke(mockTxID, inCP.getArgs())
+	resp = mockStub.MockInvoke(inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple := inputCompositeTraintuple{
@@ -457,7 +457,7 @@ func TestInsertTraintupleTwiceComposite(t *testing.T) {
 		ComputePlanKey: cpKey,
 	}
 	inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, methodAndAssetToByte("createCompositeTraintuple", inpTraintuple))
+	resp = mockStub.MockInvoke(methodAndAssetToByte("createCompositeTraintuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusOK, resp.Status)
 	var _key struct{ Key string }
 	json.Unmarshal(resp.Payload, &_key)
@@ -470,11 +470,11 @@ func TestInsertTraintupleTwiceComposite(t *testing.T) {
 	inpTraintuple.ComputePlanKey = tuple.ComputePlanKey
 	inpTraintuple.InHeadModelKey = _key.Key
 	inpTraintuple.InTrunkModelKey = _key.Key
-	resp = mockStub.MockInvoke(mockTxID, methodAndAssetToByte("createCompositeTraintuple", inpTraintuple))
+	resp = mockStub.MockInvoke(methodAndAssetToByte("createCompositeTraintuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusOK, resp.Status)
 
 	// re-insert the same composite traintuple and expect a conflict error
-	resp = mockStub.MockInvoke(mockTxID, methodAndAssetToByte("createCompositeTraintuple", inpTraintuple))
+	resp = mockStub.MockInvoke(methodAndAssetToByte("createCompositeTraintuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusConflict, resp.Status)
 }
 
@@ -531,12 +531,12 @@ func TestCreateCompositeTraintupleInModels(t *testing.T) {
 			inpObjective := inputObjective{Key: key}
 			inpObjective.createDefault()
 			inpObjective.TestDataset = inputDataset{}
-			resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
+			resp := mockStub.MockInvoke(methodAndAssetToByte("registerObjective", inpObjective))
 			assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 			inpAlgo := inputCompositeAlgo{}
 			args := inpAlgo.createDefault()
-			resp = mockStub.MockInvoke(mockTxID, args)
+			resp = mockStub.MockInvoke(args)
 			assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 			inpTraintuple := inputCompositeTraintuple{Key: RandomUUID()}
@@ -546,7 +546,7 @@ func TestCreateCompositeTraintupleInModels(t *testing.T) {
 				inpHeadTraintuple := inputCompositeTraintuple{}
 				inpHeadTraintuple.DataSampleKeys = []string{trainDataSampleKey1}
 				args = inpHeadTraintuple.createDefault()
-				resp = mockStub.MockInvoke(mockTxID, args)
+				resp = mockStub.MockInvoke(args)
 				headTraintuple := outputCompositeTraintuple{}
 				json.Unmarshal(resp.Payload, &headTraintuple)
 
@@ -559,7 +559,7 @@ func TestCreateCompositeTraintupleInModels(t *testing.T) {
 				inpTrunkTraintuple := inputCompositeTraintuple{}
 				inpTrunkTraintuple.DataSampleKeys = []string{trainDataSampleKey2}
 				args = inpTrunkTraintuple.createDefault()
-				resp = mockStub.MockInvoke(mockTxID, args)
+				resp = mockStub.MockInvoke(args)
 				trunkTraintuple := outputCompositeTraintuple{}
 				json.Unmarshal(resp.Payload, &trunkTraintuple)
 
@@ -568,14 +568,14 @@ func TestCreateCompositeTraintupleInModels(t *testing.T) {
 			}
 
 			args = inpTraintuple.createDefault()
-			resp = mockStub.MockInvoke(mockTxID, args)
+			resp = mockStub.MockInvoke(args)
 
 			if tt.shouldSucceed {
 				assert.EqualValues(t, 200, resp.Status, tt.message+": "+resp.Message)
 				traintuple := outputCompositeTraintuple{}
 				json.Unmarshal(resp.Payload, &traintuple)
 				args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(traintuple.Key)}
-				resp = mockStub.MockInvoke(mockTxID, args)
+				resp = mockStub.MockInvoke(args)
 				assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error ", resp.Message)
 				traintuple = outputCompositeTraintuple{}
 				json.Unmarshal(resp.Payload, &traintuple)
@@ -643,7 +643,7 @@ func testCompositeTraintupleInModelTypes(t *testing.T, headType AssetType, trunk
 	// create composite traintuple
 	inpTraintuple.fillDefaults()
 	args := inpTraintuple.getArgs()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 
 	if !shouldSucceed {
 		assert.EqualValues(t, http.StatusBadRequest, resp.Status, "It should NOT be possible to register a traintuple with a %s head and a %s trunk: %s", headType, trunkType, resp.Message)
@@ -656,7 +656,7 @@ func testCompositeTraintupleInModelTypes(t *testing.T, headType AssetType, trunk
 
 	// fetch it back
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(keyOnly.Key)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error: %s", resp.Message)
 	traintuple := outputCompositeTraintuple{}
 	json.Unmarshal(resp.Payload, &traintuple)
@@ -678,12 +678,12 @@ func TestCompositeTraintuplePermissions(t *testing.T) {
 	// Grant trunk model permissions to no-one
 	inpTraintuple.OutTrunkModelPermissions = inputPermissions{Process: inputPermission{Public: false, AuthorizedIDs: []string{}}}
 	args := inpTraintuple.getArgs()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 
 	traintuple := outputCompositeTraintuple{}
 	json.Unmarshal(resp.Payload, &traintuple)
 	args = [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(traintuple.Key)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	traintuple = outputCompositeTraintuple{}
 	json.Unmarshal(resp.Payload, &traintuple)
 
@@ -708,7 +708,7 @@ func TestCompositeTraintupleLogSuccessFail(t *testing.T) {
 			key := _key.Key
 
 			// start
-			resp = mockStub.MockInvoke(mockTxID, [][]byte{[]byte("logStartCompositeTrain"), keyToJSON(key)})
+			resp = mockStub.MockInvoke([][]byte{[]byte("logStartCompositeTrain"), keyToJSON(key)})
 
 			var expectedStatus string
 
@@ -717,7 +717,7 @@ func TestCompositeTraintupleLogSuccessFail(t *testing.T) {
 				success := inputLogSuccessCompositeTrain{}
 				success.Key = key
 				args := success.createDefault()
-				resp = mockStub.MockInvoke(mockTxID, args)
+				resp = mockStub.MockInvoke(args)
 				require.EqualValuesf(t, 200, resp.Status, "traintuple should be successfully set to 'success': %s", resp.Message)
 				expectedStatus = "done"
 			case StatusFailed:
@@ -725,14 +725,14 @@ func TestCompositeTraintupleLogSuccessFail(t *testing.T) {
 				failed.Key = key
 				failed.fillDefaults()
 				args := failed.getArgsComposite()
-				resp = mockStub.MockInvoke(mockTxID, args)
+				resp = mockStub.MockInvoke(args)
 				require.EqualValuesf(t, 200, resp.Status, "traintuple should be successfully set to 'failed': %s", resp.Message)
 				expectedStatus = "failed"
 			}
 
 			// fetch back
 			args := [][]byte{[]byte("queryCompositeTraintuple"), keyToJSON(key)}
-			resp = mockStub.MockInvoke(mockTxID, args)
+			resp = mockStub.MockInvoke(args)
 			assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error: %s", resp.Message)
 			traintuple := outputCompositeTraintuple{}
 			json.Unmarshal(resp.Payload, &traintuple)
@@ -758,7 +758,7 @@ func TestCorrectParent(t *testing.T) {
 	inp1 := inputAggregatetuple{}
 	inp1.fillDefaults()
 	inp1.InModels = []string{parentKey}
-	resp = mockStub.MockInvoke(mockTxID, inp1.getArgs())
+	resp = mockStub.MockInvoke(inp1.getArgs())
 	json.Unmarshal(resp.Payload, &_key)
 	child1Key := _key.Key
 
@@ -767,17 +767,17 @@ func TestCorrectParent(t *testing.T) {
 	inp2.createDefault()
 	inp2.InHeadModelKey = parentKey
 	inp2.InTrunkModelKey = traintupleKey
-	resp = mockStub.MockInvoke(mockTxID, inp2.getArgs())
+	resp = mockStub.MockInvoke(inp2.getArgs())
 	json.Unmarshal(resp.Payload, &_key)
 	child2Key := _key.Key
 
 	// start
-	mockStub.MockInvoke(mockTxID, [][]byte{[]byte("logStartCompositeTrain"), keyToJSON(parentKey)})
+	mockStub.MockInvoke([][]byte{[]byte("logStartCompositeTrain"), keyToJSON(parentKey)})
 	// success
 	success := inputLogSuccessCompositeTrain{}
 	success.Key = parentKey
 	args := success.createDefault()
-	mockStub.MockInvoke(mockTxID, args)
+	mockStub.MockInvoke(args)
 
 	mockStub.MockTransactionStart("42")
 	db := NewLedgerDB(mockStub)
@@ -806,12 +806,12 @@ func TestCreateTesttuplePermissions(t *testing.T) {
 	// impersonate bad guy
 	initialCreator := mockStub.Creator
 	mockStub.Creator = "bad guy"
-	resp := mockStub.MockInvoke(mockTxID, inpTesttuple.getArgs())
+	resp := mockStub.MockInvoke(inpTesttuple.getArgs())
 	assert.EqualValues(t, 403, resp.Status, "When the creator is NOT an authorized worker, the testtuple creation should fail: %s", resp.Message)
 
 	// impersonate good guy
 	mockStub.Creator = initialCreator
-	resp = mockStub.MockInvoke(mockTxID, inpTesttuple.getArgs())
+	resp = mockStub.MockInvoke(inpTesttuple.getArgs())
 	assert.EqualValues(t, 200, resp.Status, "When the creator is an authorized worker, the testtuple should be created without error: %s", resp.Message)
 }
 

--- a/chaincode/traintuple_composite_test.go
+++ b/chaincode/traintuple_composite_test.go
@@ -36,7 +36,6 @@ import (
 func TestTraintupleWithNoTestDatasetComposite(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	key := strings.Replace(objectiveKey, "1", "2", 1)
@@ -67,7 +66,6 @@ func TestTraintupleWithNoTestDatasetComposite(t *testing.T) {
 func TestTraintupleWithSingleDatasampleComposite(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	key := strings.Replace(objectiveKey, "1", "2", 1)
@@ -101,7 +99,6 @@ func TestTraintupleWithSingleDatasampleComposite(t *testing.T) {
 func TestTraintupleWithDuplicatedDatasamplesComposite(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	key := strings.Replace(objectiveKey, "1", "2", 1)
@@ -152,7 +149,6 @@ func TestNoPanicWhileQueryingIncompleteTraintupleComposite(t *testing.T) {
 func TestTraintupleComputePlanCreationComposite(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add dataManager, dataSample and algo
 	registerItem(t, *mockStub, "compositeAlgo")
@@ -201,7 +197,6 @@ func TestTraintupleComputePlanCreationComposite(t *testing.T) {
 func TestTraintupleMultipleCommputePlanCreationsComposite(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add a some dataManager, dataSample and traintuple
 	registerItem(t, *mockStub, "compositeAlgo")
@@ -261,7 +256,6 @@ func TestTraintupleMultipleCommputePlanCreationsComposite(t *testing.T) {
 func TestTraintupleComposite(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add traintuple with invalid field
 	inpTraintuple := inputCompositeTraintuple{
@@ -416,7 +410,6 @@ func TestTraintupleComposite(t *testing.T) {
 func TestQueryTraintupleNotFoundComposite(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "compositeAlgo")
 
 	inpTraintuple := inputCompositeTraintuple{}
@@ -446,7 +439,6 @@ func TestQueryTraintupleNotFoundComposite(t *testing.T) {
 func TestInsertTraintupleTwiceComposite(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	inpAlgo := inputCompositeAlgo{}
@@ -533,7 +525,6 @@ func TestCreateCompositeTraintupleInModels(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			scc := new(SubstraChaincode)
 			mockStub := NewMockStubWithRegisterNode("substra", scc)
-			mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 			registerItem(t, *mockStub, "trainDataset")
 
 			key := strings.Replace(objectiveKey, "1", "2", 1)
@@ -637,7 +628,6 @@ func TestCompositeTraintupleInModelTypes(t *testing.T) {
 func testCompositeTraintupleInModelTypes(t *testing.T, headType AssetType, trunkType AssetType, shouldSucceed bool) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "aggregateAlgo")
 
 	inpTraintuple := inputCompositeTraintuple{}
@@ -681,7 +671,6 @@ func testCompositeTraintupleInModelTypes(t *testing.T, headType AssetType, trunk
 func TestCompositeTraintuplePermissions(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "compositeAlgo")
 
 	inpTraintuple := inputCompositeTraintuple{}
@@ -713,7 +702,6 @@ func TestCompositeTraintupleLogSuccessFail(t *testing.T) {
 		t.Run("TestCompositeTraintupleLog"+status, func(t *testing.T) {
 			scc := new(SubstraChaincode)
 			mockStub := NewMockStubWithRegisterNode("substra", scc)
-			mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 			resp, _ := registerItem(t, *mockStub, "compositeTraintuple")
 			var _key struct{ Key string }
 			json.Unmarshal(resp.Payload, &_key)
@@ -759,7 +747,6 @@ func TestCompositeTraintupleLogSuccessFail(t *testing.T) {
 func TestCorrectParent(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// register parent
 	resp, _ := registerItem(t, *mockStub, "compositeTraintuple")
@@ -809,7 +796,6 @@ func TestCorrectParent(t *testing.T) {
 func TestCreateTesttuplePermissions(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	registerItem(t, *mockStub, "compositeTraintuple")
 

--- a/chaincode/traintuple_test.go
+++ b/chaincode/traintuple_test.go
@@ -33,21 +33,21 @@ func TestTraintupleWithNoTestDataset(t *testing.T) {
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke("42", methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	inpTraintuple := inputTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "when adding traintuple without test dataset it should work: ", resp.Message)
 
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error ", resp.Message)
 }
 
@@ -60,26 +60,26 @@ func TestTraintupleWithSingleDatasample(t *testing.T) {
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke("42", methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	inpTraintuple := inputTraintuple{
 		DataSampleKeys: []string{trainDataSampleKey1},
 	}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "when adding traintuple with a single data samples it should work: ", resp.Message)
 
 	traintuple := outputKey{}
 	err := json.Unmarshal(resp.Payload, &traintuple)
 	assert.NoError(t, err, "should be unmarshaled")
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(traintuple.Key)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error ", resp.Message)
 }
 
@@ -92,19 +92,19 @@ func TestTraintupleWithDuplicatedDatasamples(t *testing.T) {
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke("42", methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	inpTraintuple := inputTraintuple{
 		DataSampleKeys: []string{trainDataSampleKey1, trainDataSampleKey2, trainDataSampleKey1},
 	}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding traintuple with a duplicated data samples it should not work: %s", resp.Message)
 }
 
@@ -142,24 +142,24 @@ func TestTraintupleComputePlanCreation(t *testing.T) {
 
 	inpTraintuple := inputTraintuple{ComputePlanKey: "someComputePlanKey"}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValues(t, 400, resp.Status, "should failed for missing rank")
 	require.Contains(t, resp.Message, "invalid inputs, a ComputePlan should have a rank", "invalid error message")
 
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp = mockStub.MockInvoke("42", inCP.getArgs())
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple = inputTraintuple{Rank: "1"}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValues(t, 400, resp.Status, "should failed for invalid rank")
 	require.Contains(t, resp.Message, "Field validation for 'ComputePlanKey' failed on the 'required_with' tag")
 
 	inpTraintuple = inputTraintuple{Rank: "0", ComputePlanKey: cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status)
 	res := outputKey{}
 	err := json.Unmarshal(resp.Payload, &res)
@@ -169,7 +169,7 @@ func TestTraintupleComputePlanCreation(t *testing.T) {
 
 	inpTraintuple = inputTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValues(t, 409, resp.Status, "should failed for existing traintuple key")
 	require.Contains(t, resp.Message, "already exists")
 
@@ -190,12 +190,12 @@ func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp := mockStub.MockInvoke("42", inCP.getArgs())
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple := inputTraintuple{Rank: "0", ComputePlanKey: cpKey}
 	args := inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status)
 	res := outputKey{}
 	err := json.Unmarshal(resp.Payload, &res)
@@ -211,7 +211,7 @@ func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 		Rank:           "0",
 		ComputePlanKey: cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 400, resp.Status, resp.Message, "should failed to add a traintuple of the same rank")
 
 	// Failed to add a traintuple to an unexisting CommputePlan
@@ -221,7 +221,7 @@ func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 		Rank:           "1",
 		ComputePlanKey: "notarealone"}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 404, resp.Status, resp.Message, "should failed to add a traintuple to an unexisting ComputePlanKey")
 
 	// Succesfully add a traintuple to the same ComputePlanKey
@@ -231,7 +231,7 @@ func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 		Rank:           "1",
 		ComputePlanKey: tuple.ComputePlanKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message, "should be able do create a traintuple with the same ComputePlanKey")
 	err = json.Unmarshal(resp.Payload, &res)
 	assert.NoError(t, err, "should unmarshal without problem")
@@ -240,7 +240,7 @@ func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 	newAlgoKey := strings.Replace(algoKey, "a", "b", 1)
 	inpAlgo := inputAlgo{Key: newAlgoKey}
 	args = inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple = inputTraintuple{
@@ -250,7 +250,7 @@ func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 		Rank:           "2",
 		ComputePlanKey: tuple.ComputePlanKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message, "should be able to create a traintuple with the same ComputePlanKey and different algo keys")
 }
 
@@ -263,13 +263,13 @@ func TestTraintuple(t *testing.T) {
 		AlgoKey: "aaa",
 	}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding objective with invalid key, status %d and message %s", resp.Status, resp.Message)
 
 	// Add traintuple with unexisting algo
 	inpTraintuple = inputTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding traintuple with unexisting algo, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add traintuple
@@ -282,7 +282,7 @@ func TestTraintuple(t *testing.T) {
 	traintupleKey := res.Key
 	// Query traintuple from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the traintuple - status %d and message %s", resp.Status, resp.Message)
 	out := outputTraintuple{}
 	err = json.Unmarshal(resp.Payload, &out)
@@ -313,7 +313,7 @@ func TestTraintuple(t *testing.T) {
 
 	// Query all traintuples and check consistency
 	args = [][]byte{[]byte("queryTraintuples")}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying traintuples - status %d and message %s", resp.Status, resp.Message)
 	// TODO add traintuple key to output struct
 	// For now we test it as cleanly as its added to the query response
@@ -329,7 +329,7 @@ func TestTraintuple(t *testing.T) {
 		InModels: []string{string(traintupleKey)},
 	}
 	args = inpWaitingTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when adding traintuple with status %d and message %s", resp.Status, resp.Message)
 	//waitingTraintupleKey := string(resp.Payload)
 
@@ -339,7 +339,7 @@ func TestTraintuple(t *testing.T) {
 		Attributes: worker + ", todo",
 	}
 	args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying traintuple of worker with todo status - status %d and message %s", resp.Status, resp.Message)
 	err = json.Unmarshal(resp.Payload, &queryTraintuples)
 	assert.NoError(t, err, "traintuples should unmarshal without problem")
@@ -355,14 +355,14 @@ func TestTraintuple(t *testing.T) {
 	}
 	traintupleStatus := []string{StatusDoing, StatusDone}
 	for i := range traintupleStatus {
-		resp = mockStub.MockInvoke("42", argsSlice[i])
+		resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", argsSlice[i])
 		require.EqualValuesf(t, 200, resp.Status, "when logging start %s with message %s", traintupleStatus[i], resp.Message)
 		filter := inputQueryFilter{
 			IndexName:  "traintuple~worker~status",
 			Attributes: worker + ", " + traintupleStatus[i],
 		}
 		args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-		resp = mockStub.MockInvoke("42", args)
+		resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 		assert.EqualValuesf(t, 200, resp.Status, "when querying traintuple of worker with %s status - message %s", traintupleStatus[i], resp.Message)
 		sPayload := make([]map[string]interface{}, 1)
 		assert.NoError(t, json.Unmarshal(resp.Payload, &sPayload), "when unmarshal queried traintuples")
@@ -372,7 +372,7 @@ func TestTraintuple(t *testing.T) {
 
 	// Query Traintuple From key
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying traintuple with status %d and message %s", resp.Status, resp.Message)
 	endTraintuple := outputTraintuple{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &endTraintuple))
@@ -386,7 +386,7 @@ func TestTraintuple(t *testing.T) {
 
 	// query all traintuples related to a traintuple with the same algo
 	args = [][]byte{[]byte("queryModelDetails"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying model details with status %d and message %s", resp.Status, resp.Message)
 	payload := outputModelDetails{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &payload))
@@ -394,7 +394,7 @@ func TestTraintuple(t *testing.T) {
 
 	// query all traintuples related to a traintuple with the same algo
 	args = [][]byte{[]byte("queryModels")}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying models with status %d and message %s", resp.Status, resp.Message)
 }
 
@@ -405,18 +405,18 @@ func TestQueryTraintupleNotFound(t *testing.T) {
 
 	// queryTraintuple: normal case
 	args := [][]byte{[]byte("queryTraintuple"), keyToJSON(traintupleKey)}
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the traintuple - status %d and message %s", resp.Status, resp.Message)
 
 	// queryTraintuple: key does not exist
 	notFoundKey := "eedbb7c3-1f62-244c-0f34-461cc1688042"
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(notFoundKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 404, resp.Status, "when querying the traintuple - status %d and message %s", resp.Status, resp.Message)
 
 	// queryTraintuple: key does not exist and use existing other asset type key
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(algoKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 404, resp.Status, "when querying the traintuple - status %d and message %s", resp.Status, resp.Message)
 }
 
@@ -428,7 +428,7 @@ func TestInsertTraintupleTwice(t *testing.T) {
 	// create a traintuple and start a ComplutePlan
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp := mockStub.MockInvoke("42", inCP.getArgs())
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple := inputTraintuple{
@@ -436,7 +436,7 @@ func TestInsertTraintupleTwice(t *testing.T) {
 		ComputePlanKey: cpKey,
 	}
 	inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", methodAndAssetToByte("createTraintuple", inpTraintuple))
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("createTraintuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusOK, resp.Status)
 
 	db := NewLedgerDB(mockStub)
@@ -447,11 +447,11 @@ func TestInsertTraintupleTwice(t *testing.T) {
 	inpTraintuple.Rank = "1"
 	inpTraintuple.ComputePlanKey = tuple.ComputePlanKey
 	inpTraintuple.InModels = []string{traintupleKey}
-	resp = mockStub.MockInvoke("42", methodAndAssetToByte("createTraintuple", inpTraintuple))
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("createTraintuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusOK, resp.Status)
 
 	// re-insert the same traintuple and expect a conflict error
-	resp = mockStub.MockInvoke("42", methodAndAssetToByte("createTraintuple", inpTraintuple))
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("createTraintuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusConflict, resp.Status)
 
 }

--- a/chaincode/traintuple_test.go
+++ b/chaincode/traintuple_test.go
@@ -33,21 +33,21 @@ func TestTraintupleWithNoTestDataset(t *testing.T) {
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke(methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	inpTraintuple := inputTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "when adding traintuple without test dataset it should work: ", resp.Message)
 
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error ", resp.Message)
 }
 
@@ -60,26 +60,26 @@ func TestTraintupleWithSingleDatasample(t *testing.T) {
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke(methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	inpTraintuple := inputTraintuple{
 		DataSampleKeys: []string{trainDataSampleKey1},
 	}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "when adding traintuple with a single data samples it should work: ", resp.Message)
 
 	traintuple := outputKey{}
 	err := json.Unmarshal(resp.Payload, &traintuple)
 	assert.NoError(t, err, "should be unmarshaled")
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(traintuple.Key)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error ", resp.Message)
 }
 
@@ -92,19 +92,19 @@ func TestTraintupleWithDuplicatedDatasamples(t *testing.T) {
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke(methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	inpTraintuple := inputTraintuple{
 		DataSampleKeys: []string{trainDataSampleKey1, trainDataSampleKey2, trainDataSampleKey1},
 	}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding traintuple with a duplicated data samples it should not work: %s", resp.Message)
 }
 
@@ -142,24 +142,24 @@ func TestTraintupleComputePlanCreation(t *testing.T) {
 
 	inpTraintuple := inputTraintuple{ComputePlanKey: "someComputePlanKey"}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	require.EqualValues(t, 400, resp.Status, "should failed for missing rank")
 	require.Contains(t, resp.Message, "invalid inputs, a ComputePlan should have a rank", "invalid error message")
 
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp = mockStub.MockInvoke(mockTxID, inCP.getArgs())
+	resp = mockStub.MockInvoke(inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple = inputTraintuple{Rank: "1"}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	require.EqualValues(t, 400, resp.Status, "should failed for invalid rank")
 	require.Contains(t, resp.Message, "Field validation for 'ComputePlanKey' failed on the 'required_with' tag")
 
 	inpTraintuple = inputTraintuple{Rank: "0", ComputePlanKey: cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status)
 	res := outputKey{}
 	err := json.Unmarshal(resp.Payload, &res)
@@ -169,7 +169,7 @@ func TestTraintupleComputePlanCreation(t *testing.T) {
 
 	inpTraintuple = inputTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	require.EqualValues(t, 409, resp.Status, "should failed for existing traintuple key")
 	require.Contains(t, resp.Message, "already exists")
 
@@ -190,12 +190,12 @@ func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp := mockStub.MockInvoke(mockTxID, inCP.getArgs())
+	resp := mockStub.MockInvoke(inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple := inputTraintuple{Rank: "0", ComputePlanKey: cpKey}
 	args := inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status)
 	res := outputKey{}
 	err := json.Unmarshal(resp.Payload, &res)
@@ -211,7 +211,7 @@ func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 		Rank:           "0",
 		ComputePlanKey: cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 400, resp.Status, resp.Message, "should failed to add a traintuple of the same rank")
 
 	// Failed to add a traintuple to an unexisting CommputePlan
@@ -221,7 +221,7 @@ func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 		Rank:           "1",
 		ComputePlanKey: "notarealone"}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 404, resp.Status, resp.Message, "should failed to add a traintuple to an unexisting ComputePlanKey")
 
 	// Succesfully add a traintuple to the same ComputePlanKey
@@ -231,7 +231,7 @@ func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 		Rank:           "1",
 		ComputePlanKey: tuple.ComputePlanKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message, "should be able do create a traintuple with the same ComputePlanKey")
 	err = json.Unmarshal(resp.Payload, &res)
 	assert.NoError(t, err, "should unmarshal without problem")
@@ -240,7 +240,7 @@ func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 	newAlgoKey := strings.Replace(algoKey, "a", "b", 1)
 	inpAlgo := inputAlgo{Key: newAlgoKey}
 	args = inpAlgo.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple = inputTraintuple{
@@ -250,7 +250,7 @@ func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 		Rank:           "2",
 		ComputePlanKey: tuple.ComputePlanKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message, "should be able to create a traintuple with the same ComputePlanKey and different algo keys")
 }
 
@@ -263,13 +263,13 @@ func TestTraintuple(t *testing.T) {
 		AlgoKey: "aaa",
 	}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding objective with invalid key, status %d and message %s", resp.Status, resp.Message)
 
 	// Add traintuple with unexisting algo
 	inpTraintuple = inputTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding traintuple with unexisting algo, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add traintuple
@@ -282,7 +282,7 @@ func TestTraintuple(t *testing.T) {
 	traintupleKey := res.Key
 	// Query traintuple from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the traintuple - status %d and message %s", resp.Status, resp.Message)
 	out := outputTraintuple{}
 	err = json.Unmarshal(resp.Payload, &out)
@@ -313,7 +313,7 @@ func TestTraintuple(t *testing.T) {
 
 	// Query all traintuples and check consistency
 	args = [][]byte{[]byte("queryTraintuples")}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying traintuples - status %d and message %s", resp.Status, resp.Message)
 	// TODO add traintuple key to output struct
 	// For now we test it as cleanly as its added to the query response
@@ -329,7 +329,7 @@ func TestTraintuple(t *testing.T) {
 		InModels: []string{string(traintupleKey)},
 	}
 	args = inpWaitingTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when adding traintuple with status %d and message %s", resp.Status, resp.Message)
 	//waitingTraintupleKey := string(resp.Payload)
 
@@ -339,7 +339,7 @@ func TestTraintuple(t *testing.T) {
 		Attributes: worker + ", todo",
 	}
 	args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying traintuple of worker with todo status - status %d and message %s", resp.Status, resp.Message)
 	err = json.Unmarshal(resp.Payload, &queryTraintuples)
 	assert.NoError(t, err, "traintuples should unmarshal without problem")
@@ -355,14 +355,14 @@ func TestTraintuple(t *testing.T) {
 	}
 	traintupleStatus := []string{StatusDoing, StatusDone}
 	for i := range traintupleStatus {
-		resp = mockStub.MockInvoke(mockTxID, argsSlice[i])
+		resp = mockStub.MockInvoke(argsSlice[i])
 		require.EqualValuesf(t, 200, resp.Status, "when logging start %s with message %s", traintupleStatus[i], resp.Message)
 		filter := inputQueryFilter{
 			IndexName:  "traintuple~worker~status",
 			Attributes: worker + ", " + traintupleStatus[i],
 		}
 		args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-		resp = mockStub.MockInvoke(mockTxID, args)
+		resp = mockStub.MockInvoke(args)
 		assert.EqualValuesf(t, 200, resp.Status, "when querying traintuple of worker with %s status - message %s", traintupleStatus[i], resp.Message)
 		sPayload := make([]map[string]interface{}, 1)
 		assert.NoError(t, json.Unmarshal(resp.Payload, &sPayload), "when unmarshal queried traintuples")
@@ -372,7 +372,7 @@ func TestTraintuple(t *testing.T) {
 
 	// Query Traintuple From key
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying traintuple with status %d and message %s", resp.Status, resp.Message)
 	endTraintuple := outputTraintuple{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &endTraintuple))
@@ -386,7 +386,7 @@ func TestTraintuple(t *testing.T) {
 
 	// query all traintuples related to a traintuple with the same algo
 	args = [][]byte{[]byte("queryModelDetails"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying model details with status %d and message %s", resp.Status, resp.Message)
 	payload := outputModelDetails{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &payload))
@@ -394,7 +394,7 @@ func TestTraintuple(t *testing.T) {
 
 	// query all traintuples related to a traintuple with the same algo
 	args = [][]byte{[]byte("queryModels")}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying models with status %d and message %s", resp.Status, resp.Message)
 }
 
@@ -405,18 +405,18 @@ func TestQueryTraintupleNotFound(t *testing.T) {
 
 	// queryTraintuple: normal case
 	args := [][]byte{[]byte("queryTraintuple"), keyToJSON(traintupleKey)}
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the traintuple - status %d and message %s", resp.Status, resp.Message)
 
 	// queryTraintuple: key does not exist
 	notFoundKey := "eedbb7c3-1f62-244c-0f34-461cc1688042"
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(notFoundKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 404, resp.Status, "when querying the traintuple - status %d and message %s", resp.Status, resp.Message)
 
 	// queryTraintuple: key does not exist and use existing other asset type key
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(algoKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 404, resp.Status, "when querying the traintuple - status %d and message %s", resp.Status, resp.Message)
 }
 
@@ -428,7 +428,7 @@ func TestInsertTraintupleTwice(t *testing.T) {
 	// create a traintuple and start a ComplutePlan
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp := mockStub.MockInvoke(mockTxID, inCP.getArgs())
+	resp := mockStub.MockInvoke(inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple := inputTraintuple{
@@ -436,7 +436,7 @@ func TestInsertTraintupleTwice(t *testing.T) {
 		ComputePlanKey: cpKey,
 	}
 	inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, methodAndAssetToByte("createTraintuple", inpTraintuple))
+	resp = mockStub.MockInvoke(methodAndAssetToByte("createTraintuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusOK, resp.Status)
 
 	db := NewLedgerDB(mockStub)
@@ -447,11 +447,11 @@ func TestInsertTraintupleTwice(t *testing.T) {
 	inpTraintuple.Rank = "1"
 	inpTraintuple.ComputePlanKey = tuple.ComputePlanKey
 	inpTraintuple.InModels = []string{traintupleKey}
-	resp = mockStub.MockInvoke(mockTxID, methodAndAssetToByte("createTraintuple", inpTraintuple))
+	resp = mockStub.MockInvoke(methodAndAssetToByte("createTraintuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusOK, resp.Status)
 
 	// re-insert the same traintuple and expect a conflict error
-	resp = mockStub.MockInvoke(mockTxID, methodAndAssetToByte("createTraintuple", inpTraintuple))
+	resp = mockStub.MockInvoke(methodAndAssetToByte("createTraintuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusConflict, resp.Status)
 
 }

--- a/chaincode/traintuple_test.go
+++ b/chaincode/traintuple_test.go
@@ -27,7 +27,6 @@ import (
 func TestTraintupleWithNoTestDataset(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	key := strings.Replace(objectiveKey, "1", "2", 1)
@@ -55,7 +54,6 @@ func TestTraintupleWithNoTestDataset(t *testing.T) {
 func TestTraintupleWithSingleDatasample(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	key := strings.Replace(objectiveKey, "1", "2", 1)
@@ -88,7 +86,6 @@ func TestTraintupleWithSingleDatasample(t *testing.T) {
 func TestTraintupleWithDuplicatedDatasamples(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	key := strings.Replace(objectiveKey, "1", "2", 1)
@@ -139,7 +136,6 @@ func TestNoPanicWhileQueryingIncompleteTraintuple(t *testing.T) {
 func TestTraintupleComputePlanCreation(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add dataManager, dataSample and algo
 	registerItem(t, *mockStub, "algo")
@@ -188,7 +184,6 @@ func TestTraintupleComputePlanCreation(t *testing.T) {
 func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add a some dataManager, dataSample and traintuple
 	registerItem(t, *mockStub, "algo")
@@ -262,7 +257,6 @@ func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 func TestTraintuple(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add traintuple with invalid field
 	inpTraintuple := inputTraintuple{
@@ -407,7 +401,6 @@ func TestTraintuple(t *testing.T) {
 func TestQueryTraintupleNotFound(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "traintuple")
 
 	// queryTraintuple: normal case
@@ -430,7 +423,6 @@ func TestQueryTraintupleNotFound(t *testing.T) {
 func TestInsertTraintupleTwice(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "algo")
 
 	// create a traintuple and start a ComplutePlan

--- a/chaincode/traintuple_test.go
+++ b/chaincode/traintuple_test.go
@@ -27,84 +27,87 @@ import (
 func TestTraintupleWithNoTestDataset(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	key := strings.Replace(objectiveKey, "1", "2", 1)
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	inpTraintuple := inputTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "when adding traintuple without test dataset it should work: ", resp.Message)
 
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error ", resp.Message)
 }
 
 func TestTraintupleWithSingleDatasample(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	key := strings.Replace(objectiveKey, "1", "2", 1)
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	inpTraintuple := inputTraintuple{
 		DataSampleKeys: []string{trainDataSampleKey1},
 	}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "when adding traintuple with a single data samples it should work: ", resp.Message)
 
 	traintuple := outputKey{}
 	err := json.Unmarshal(resp.Payload, &traintuple)
 	assert.NoError(t, err, "should be unmarshaled")
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(traintuple.Key)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error ", resp.Message)
 }
 
 func TestTraintupleWithDuplicatedDatasamples(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	key := strings.Replace(objectiveKey, "1", "2", 1)
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	inpTraintuple := inputTraintuple{
 		DataSampleKeys: []string{trainDataSampleKey1, trainDataSampleKey2, trainDataSampleKey1},
 	}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding traintuple with a duplicated data samples it should not work: %s", resp.Message)
 }
 
@@ -136,30 +139,31 @@ func TestNoPanicWhileQueryingIncompleteTraintuple(t *testing.T) {
 func TestTraintupleComputePlanCreation(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add dataManager, dataSample and algo
 	registerItem(t, *mockStub, "algo")
 
 	inpTraintuple := inputTraintuple{ComputePlanKey: "someComputePlanKey"}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	require.EqualValues(t, 400, resp.Status, "should failed for missing rank")
 	require.Contains(t, resp.Message, "invalid inputs, a ComputePlan should have a rank", "invalid error message")
 
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inCP.getArgs())
+	resp = mockStub.MockInvoke(mockTxID, inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple = inputTraintuple{Rank: "1"}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	require.EqualValues(t, 400, resp.Status, "should failed for invalid rank")
 	require.Contains(t, resp.Message, "Field validation for 'ComputePlanKey' failed on the 'required_with' tag")
 
 	inpTraintuple = inputTraintuple{Rank: "0", ComputePlanKey: cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status)
 	res := outputKey{}
 	err := json.Unmarshal(resp.Payload, &res)
@@ -169,7 +173,7 @@ func TestTraintupleComputePlanCreation(t *testing.T) {
 
 	inpTraintuple = inputTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	require.EqualValues(t, 409, resp.Status, "should failed for existing traintuple key")
 	require.Contains(t, resp.Message, "already exists")
 
@@ -184,18 +188,19 @@ func TestTraintupleComputePlanCreation(t *testing.T) {
 func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add a some dataManager, dataSample and traintuple
 	registerItem(t, *mockStub, "algo")
 
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inCP.getArgs())
+	resp := mockStub.MockInvoke(mockTxID, inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple := inputTraintuple{Rank: "0", ComputePlanKey: cpKey}
 	args := inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status)
 	res := outputKey{}
 	err := json.Unmarshal(resp.Payload, &res)
@@ -211,7 +216,7 @@ func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 		Rank:           "0",
 		ComputePlanKey: cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 400, resp.Status, resp.Message, "should failed to add a traintuple of the same rank")
 
 	// Failed to add a traintuple to an unexisting CommputePlan
@@ -221,7 +226,7 @@ func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 		Rank:           "1",
 		ComputePlanKey: "notarealone"}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 404, resp.Status, resp.Message, "should failed to add a traintuple to an unexisting ComputePlanKey")
 
 	// Succesfully add a traintuple to the same ComputePlanKey
@@ -231,7 +236,7 @@ func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 		Rank:           "1",
 		ComputePlanKey: tuple.ComputePlanKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message, "should be able do create a traintuple with the same ComputePlanKey")
 	err = json.Unmarshal(resp.Payload, &res)
 	assert.NoError(t, err, "should unmarshal without problem")
@@ -240,7 +245,7 @@ func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 	newAlgoKey := strings.Replace(algoKey, "a", "b", 1)
 	inpAlgo := inputAlgo{Key: newAlgoKey}
 	args = inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple = inputTraintuple{
@@ -250,26 +255,27 @@ func TestTraintupleMultipleCommputePlanCreations(t *testing.T) {
 		Rank:           "2",
 		ComputePlanKey: tuple.ComputePlanKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message, "should be able to create a traintuple with the same ComputePlanKey and different algo keys")
 }
 
 func TestTraintuple(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add traintuple with invalid field
 	inpTraintuple := inputTraintuple{
 		AlgoKey: "aaa",
 	}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding objective with invalid key, status %d and message %s", resp.Status, resp.Message)
 
 	// Add traintuple with unexisting algo
 	inpTraintuple = inputTraintuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding traintuple with unexisting algo, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add traintuple
@@ -282,7 +288,7 @@ func TestTraintuple(t *testing.T) {
 	traintupleKey := res.Key
 	// Query traintuple from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the traintuple - status %d and message %s", resp.Status, resp.Message)
 	out := outputTraintuple{}
 	err = json.Unmarshal(resp.Payload, &out)
@@ -313,7 +319,7 @@ func TestTraintuple(t *testing.T) {
 
 	// Query all traintuples and check consistency
 	args = [][]byte{[]byte("queryTraintuples")}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying traintuples - status %d and message %s", resp.Status, resp.Message)
 	// TODO add traintuple key to output struct
 	// For now we test it as cleanly as its added to the query response
@@ -329,7 +335,7 @@ func TestTraintuple(t *testing.T) {
 		InModels: []string{string(traintupleKey)},
 	}
 	args = inpWaitingTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when adding traintuple with status %d and message %s", resp.Status, resp.Message)
 	//waitingTraintupleKey := string(resp.Payload)
 
@@ -339,7 +345,7 @@ func TestTraintuple(t *testing.T) {
 		Attributes: worker + ", todo",
 	}
 	args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying traintuple of worker with todo status - status %d and message %s", resp.Status, resp.Message)
 	err = json.Unmarshal(resp.Payload, &queryTraintuples)
 	assert.NoError(t, err, "traintuples should unmarshal without problem")
@@ -355,14 +361,14 @@ func TestTraintuple(t *testing.T) {
 	}
 	traintupleStatus := []string{StatusDoing, StatusDone}
 	for i := range traintupleStatus {
-		resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", argsSlice[i])
+		resp = mockStub.MockInvoke(mockTxID, argsSlice[i])
 		require.EqualValuesf(t, 200, resp.Status, "when logging start %s with message %s", traintupleStatus[i], resp.Message)
 		filter := inputQueryFilter{
 			IndexName:  "traintuple~worker~status",
 			Attributes: worker + ", " + traintupleStatus[i],
 		}
 		args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-		resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+		resp = mockStub.MockInvoke(mockTxID, args)
 		assert.EqualValuesf(t, 200, resp.Status, "when querying traintuple of worker with %s status - message %s", traintupleStatus[i], resp.Message)
 		sPayload := make([]map[string]interface{}, 1)
 		assert.NoError(t, json.Unmarshal(resp.Payload, &sPayload), "when unmarshal queried traintuples")
@@ -372,7 +378,7 @@ func TestTraintuple(t *testing.T) {
 
 	// Query Traintuple From key
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying traintuple with status %d and message %s", resp.Status, resp.Message)
 	endTraintuple := outputTraintuple{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &endTraintuple))
@@ -386,7 +392,7 @@ func TestTraintuple(t *testing.T) {
 
 	// query all traintuples related to a traintuple with the same algo
 	args = [][]byte{[]byte("queryModelDetails"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying model details with status %d and message %s", resp.Status, resp.Message)
 	payload := outputModelDetails{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &payload))
@@ -394,41 +400,43 @@ func TestTraintuple(t *testing.T) {
 
 	// query all traintuples related to a traintuple with the same algo
 	args = [][]byte{[]byte("queryModels")}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying models with status %d and message %s", resp.Status, resp.Message)
 }
 
 func TestQueryTraintupleNotFound(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "traintuple")
 
 	// queryTraintuple: normal case
 	args := [][]byte{[]byte("queryTraintuple"), keyToJSON(traintupleKey)}
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the traintuple - status %d and message %s", resp.Status, resp.Message)
 
 	// queryTraintuple: key does not exist
 	notFoundKey := "eedbb7c3-1f62-244c-0f34-461cc1688042"
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(notFoundKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 404, resp.Status, "when querying the traintuple - status %d and message %s", resp.Status, resp.Message)
 
 	// queryTraintuple: key does not exist and use existing other asset type key
 	args = [][]byte{[]byte("queryTraintuple"), keyToJSON(algoKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 404, resp.Status, "when querying the traintuple - status %d and message %s", resp.Status, resp.Message)
 }
 
 func TestInsertTraintupleTwice(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "algo")
 
 	// create a traintuple and start a ComplutePlan
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inCP.getArgs())
+	resp := mockStub.MockInvoke(mockTxID, inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple := inputTraintuple{
@@ -436,7 +444,7 @@ func TestInsertTraintupleTwice(t *testing.T) {
 		ComputePlanKey: cpKey,
 	}
 	inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("createTraintuple", inpTraintuple))
+	resp = mockStub.MockInvoke(mockTxID, methodAndAssetToByte("createTraintuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusOK, resp.Status)
 
 	db := NewLedgerDB(mockStub)
@@ -447,11 +455,11 @@ func TestInsertTraintupleTwice(t *testing.T) {
 	inpTraintuple.Rank = "1"
 	inpTraintuple.ComputePlanKey = tuple.ComputePlanKey
 	inpTraintuple.InModels = []string{traintupleKey}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("createTraintuple", inpTraintuple))
+	resp = mockStub.MockInvoke(mockTxID, methodAndAssetToByte("createTraintuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusOK, resp.Status)
 
 	// re-insert the same traintuple and expect a conflict error
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("createTraintuple", inpTraintuple))
+	resp = mockStub.MockInvoke(mockTxID, methodAndAssetToByte("createTraintuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusConflict, resp.Status)
 
 }

--- a/chaincode/tuple_aggregate_test.go
+++ b/chaincode/tuple_aggregate_test.go
@@ -40,24 +40,24 @@ func TestTraintupleWithNoTestDatasetAggregate(t *testing.T) {
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke(methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputAggregateAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "when adding aggregate algo it should work: ", resp.Message)
 
 	inpTraintuple := inputAggregatetuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 
 	assert.EqualValues(t, 200, resp.Status, "when adding aggregate tuple without test dataset it should work: ", resp.Message)
 
 	traintuple := outputAggregatetuple{}
 	json.Unmarshal(resp.Payload, &traintuple)
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(traintuple.Key)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the aggregate tuple without error ", resp.Message)
 }
 
@@ -70,26 +70,26 @@ func TestTraintupleWithSingleDatasampleAggregate(t *testing.T) {
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke(methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputAggregateAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "when adding aggregate algo it should work: ", resp.Message)
 
 	inpTraintuple := inputAggregatetuple{
 		AlgoKey: aggregateAlgoKey,
 	}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "when adding aggregate tuple with a single data samples it should work: ", resp.Message)
 
 	traintuple := outputKey{}
 	err := json.Unmarshal(resp.Payload, &traintuple)
 	assert.NoError(t, err, "should be unmarshaled")
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(traintuple.Key)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the aggregate tuple without error ", resp.Message)
 }
 
@@ -127,24 +127,24 @@ func TestTraintupleComputePlanCreationAggregate(t *testing.T) {
 
 	inpTraintuple := inputAggregatetuple{ComputePlanKey: "someComputePlanKey"}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	require.EqualValues(t, 400, resp.Status, "should failed for missing rank")
 	require.Contains(t, resp.Message, "invalid inputs, a ComputePlan should have a rank", "invalid error message")
 
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp = mockStub.MockInvoke(mockTxID, inCP.getArgs())
+	resp = mockStub.MockInvoke(inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple = inputAggregatetuple{Rank: "1"}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	require.EqualValues(t, 400, resp.Status, "should failed for invalid rank")
 	require.Contains(t, resp.Message, "Field validation for 'ComputePlanKey' failed on the 'required_with' tag")
 
 	inpTraintuple = inputAggregatetuple{Rank: "0", ComputePlanKey: cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status)
 	res := outputKey{}
 	err := json.Unmarshal(resp.Payload, &res)
@@ -154,7 +154,7 @@ func TestTraintupleComputePlanCreationAggregate(t *testing.T) {
 
 	inpTraintuple = inputAggregatetuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	require.EqualValues(t, 409, resp.Status, "should failed for existing aggregatetuple key")
 	require.Contains(t, resp.Message, "already exists")
 
@@ -176,12 +176,12 @@ func TestTraintupleMultipleCommputePlanCreationsAggregate(t *testing.T) {
 
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp := mockStub.MockInvoke(mockTxID, inCP.getArgs())
+	resp := mockStub.MockInvoke(inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple := inputAggregatetuple{Rank: "0", ComputePlanKey: cpKey}
 	args := inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status)
 	res := outputKey{}
 	err := json.Unmarshal(resp.Payload, &res)
@@ -197,7 +197,7 @@ func TestTraintupleMultipleCommputePlanCreationsAggregate(t *testing.T) {
 		Rank:           "0",
 		ComputePlanKey: cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 400, resp.Status, resp.Message, "should failed to add an aggregate tuple of the same rank")
 
 	// Failed to add a traintuple to an unexisting CommputePlan
@@ -207,7 +207,7 @@ func TestTraintupleMultipleCommputePlanCreationsAggregate(t *testing.T) {
 		Rank:           "1",
 		ComputePlanKey: "notarealone"}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 404, resp.Status, resp.Message, "should failed to add an aggregate tuple to an unexisting ComputePlanKey")
 
 	// Succesfully add a traintuple to the same ComputePlanKey
@@ -217,7 +217,7 @@ func TestTraintupleMultipleCommputePlanCreationsAggregate(t *testing.T) {
 		Rank:           "1",
 		ComputePlanKey: cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message, "should be able do create an aggregate tuple with the same ComputePlanKey")
 	err = json.Unmarshal(resp.Payload, &res)
 	assert.NoError(t, err, "should unmarshal without problem")
@@ -232,13 +232,13 @@ func TestTraintupleAggregate(t *testing.T) {
 		AlgoKey: "aaa",
 	}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding objective with invalid key, status %d and message %s", resp.Status, resp.Message)
 
 	// Add traintuple with unexisting algo
 	inpTraintuple = inputAggregatetuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding aggregate tuple with unexisting algo, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add traintuple
@@ -251,7 +251,7 @@ func TestTraintupleAggregate(t *testing.T) {
 	traintupleKey := res.Key
 	// Query traintuple from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the aggregate tuple - status %d and message %s", resp.Status, resp.Message)
 	out := outputAggregatetuple{}
 	err = json.Unmarshal(resp.Payload, &out)
@@ -279,7 +279,7 @@ func TestTraintupleAggregate(t *testing.T) {
 
 	// Query all traintuples and check consistency
 	args = [][]byte{[]byte("queryAggregatetuples")}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying aggregate tuples - status %d and message %s", resp.Status, resp.Message)
 	// TODO add traintuple key to output struct
 	// For now we test it as cleanly as its added to the query response
@@ -296,7 +296,7 @@ func TestTraintupleAggregate(t *testing.T) {
 		Key:      RandomUUID(),
 	}
 	args = inpWaitingTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when adding aggregate tuple with status %d and message %s", resp.Status, resp.Message)
 
 	// Query traintuple with status todo and worker as trainworker and check consistency
@@ -305,7 +305,7 @@ func TestTraintupleAggregate(t *testing.T) {
 		Attributes: worker + ", todo",
 	}
 	args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying aggregate tuple of worker with todo status - status %d and message %s", resp.Status, resp.Message)
 	err = json.Unmarshal(resp.Payload, &queryTraintuples)
 	assert.NoError(t, err, "aggregate tuples should unmarshal without problem")
@@ -322,14 +322,14 @@ func TestTraintupleAggregate(t *testing.T) {
 	}
 	traintupleStatus := []string{StatusDoing, StatusDone}
 	for i := range traintupleStatus {
-		resp = mockStub.MockInvoke(mockTxID, argsSlice[i])
+		resp = mockStub.MockInvoke(argsSlice[i])
 		require.EqualValuesf(t, 200, resp.Status, "when logging start %s with message %s", traintupleStatus[i], resp.Message)
 		filter := inputQueryFilter{
 			IndexName:  "aggregatetuple~worker~status",
 			Attributes: worker + ", " + traintupleStatus[i],
 		}
 		args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-		resp = mockStub.MockInvoke(mockTxID, args)
+		resp = mockStub.MockInvoke(args)
 		assert.EqualValuesf(t, 200, resp.Status, "when querying traintuple of worker with %s status - message %s", traintupleStatus[i], resp.Message)
 		sPayload := make([]map[string]interface{}, 1)
 		assert.NoError(t, json.Unmarshal(resp.Payload, &sPayload), "when unmarshal queried traintuples")
@@ -339,7 +339,7 @@ func TestTraintupleAggregate(t *testing.T) {
 
 	// Query Aggregatetuple From key
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(aggregatetupleKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying aggregate tuple with status %d and message %s", resp.Status, resp.Message)
 	endTraintuple := outputAggregatetuple{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &endTraintuple))
@@ -353,7 +353,7 @@ func TestTraintupleAggregate(t *testing.T) {
 
 	// query all traintuples related to a traintuple with the same algo
 	args = [][]byte{[]byte("queryModelDetails"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying model details with status %d and message %s", resp.Status, resp.Message)
 	payload := outputModelDetails{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &payload))
@@ -361,7 +361,7 @@ func TestTraintupleAggregate(t *testing.T) {
 
 	// query all traintuples related to a traintuple with the same algo
 	args = [][]byte{[]byte("queryModels")}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying models with status %d and message %s", resp.Status, resp.Message)
 }
 
@@ -373,24 +373,24 @@ func TestQueryTraintupleNotFoundAggregate(t *testing.T) {
 	inpTraintuple := inputAggregatetuple{}
 	inpTraintuple.fillDefaults()
 	args := inpTraintuple.getArgs()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	var _key struct{ Key string }
 	json.Unmarshal(resp.Payload, &_key)
 
 	// queryAggregatetuple: normal queryAggregatetuple
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(_key.Key)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the aggregate tuple - status %d and message %s", resp.Status, resp.Message)
 
 	// queryAggregatetuple: key does not exist
 	notFoundKey := "eedbb7c3-1f62-244c-0f34-461cc1688042"
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(notFoundKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 404, resp.Status, "when querying the aggregate tuple - status %d and message %s", resp.Status, resp.Message)
 
 	// queryAggregatetuple: key does not exist and use existing other asset type key
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(algoKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 404, resp.Status, "when querying the aggregate tuple - status %d and message %s", resp.Status, resp.Message)
 }
 
@@ -401,20 +401,20 @@ func TestInsertTraintupleTwiceAggregate(t *testing.T) {
 
 	inpAlgo := inputAggregateAlgo{}
 	args := inpAlgo.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	// create a aggregate tuple and start a ComplutePlan
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp = mockStub.MockInvoke(mockTxID, inCP.getArgs())
+	resp = mockStub.MockInvoke(inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 	inpTraintuple := inputAggregatetuple{
 		Rank:           "0",
 		ComputePlanKey: cpKey,
 	}
 	inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, methodAndAssetToByte("createAggregatetuple", inpTraintuple))
+	resp = mockStub.MockInvoke(methodAndAssetToByte("createAggregatetuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusOK, resp.Status)
 	var _key struct{ Key string }
 	json.Unmarshal(resp.Payload, &_key)
@@ -426,11 +426,11 @@ func TestInsertTraintupleTwiceAggregate(t *testing.T) {
 	inpTraintuple.Rank = "1"
 	inpTraintuple.ComputePlanKey = tuple.ComputePlanKey
 	inpTraintuple.InModels = []string{_key.Key}
-	resp = mockStub.MockInvoke(mockTxID, methodAndAssetToByte("createAggregatetuple", inpTraintuple))
+	resp = mockStub.MockInvoke(methodAndAssetToByte("createAggregatetuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusOK, resp.Status)
 
 	// re-insert the same aggregate tuple and expect a conflict error
-	resp = mockStub.MockInvoke(mockTxID, methodAndAssetToByte("createAggregatetuple", inpTraintuple))
+	resp = mockStub.MockInvoke(methodAndAssetToByte("createAggregatetuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusConflict, resp.Status)
 }
 
@@ -450,7 +450,7 @@ func TestAggregatetuplePermissions(t *testing.T) {
 	registerNode := func(nodeName string) {
 		initialCreator := mockStub.Creator
 		mockStub.Creator = nodeName
-		mockStub.MockInvoke(mockTxID, [][]byte{[]byte("registerNode")})
+		mockStub.MockInvoke([][]byte{[]byte("registerNode")})
 		mockStub.Creator = initialCreator
 	}
 	registerNode("nodeA")
@@ -472,7 +472,7 @@ func TestAggregatetuplePermissions(t *testing.T) {
 		inp.fillDefaults()
 		inp.OutTrunkModelPermissions.Process.Public = false
 		inp.OutTrunkModelPermissions.Process.AuthorizedIDs = authorizedIds
-		resp := mockStub.MockInvoke(mockTxID, inp.getArgs())
+		resp := mockStub.MockInvoke(inp.getArgs())
 		assert.EqualValues(t, 200, resp.Status, resp.Message)
 		var _key struct{ Key string }
 		json.Unmarshal(resp.Payload, &_key)
@@ -486,7 +486,7 @@ func TestAggregatetuplePermissions(t *testing.T) {
 	inpAgg := inputAggregatetuple{}
 	inpAgg.fillDefaults()
 	inpAgg.InModels = []string{traintuple1, traintuple2, traintuple3}
-	resp := mockStub.MockInvoke(mockTxID, inpAgg.getArgs())
+	resp := mockStub.MockInvoke(inpAgg.getArgs())
 	assert.EqualValues(t, 200, resp.Status, resp.Message)
 	var _key struct{ Key string }
 	json.Unmarshal(resp.Payload, &_key)
@@ -495,7 +495,7 @@ func TestAggregatetuplePermissions(t *testing.T) {
 	// fetch the aggregate tuple back
 	aggr := outputAggregatetuple{}
 	args := [][]byte{[]byte("queryAggregatetuple"), keyToJSON(aggrKey)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	aggr = outputAggregatetuple{}
 	json.Unmarshal(resp.Payload, &aggr)
 
@@ -517,7 +517,7 @@ func TestAggregatetupleLogSuccessFail(t *testing.T) {
 			key := _key.Key
 
 			// start
-			resp = mockStub.MockInvoke(mockTxID, [][]byte{[]byte("logStartAggregate"), keyToJSON(key)})
+			resp = mockStub.MockInvoke([][]byte{[]byte("logStartAggregate"), keyToJSON(key)})
 
 			var expectedStatus string
 
@@ -527,21 +527,21 @@ func TestAggregatetupleLogSuccessFail(t *testing.T) {
 				success.Key = key
 				success.createDefault()
 				success.fillDefaults()
-				resp = mockStub.MockInvoke(mockTxID, [][]byte{[]byte("logSuccessAggregate"), assetToJSON(success)})
+				resp = mockStub.MockInvoke([][]byte{[]byte("logSuccessAggregate"), assetToJSON(success)})
 				require.EqualValuesf(t, 200, resp.Status, "traintuple should be successfully set to 'success': %s", resp.Message)
 				expectedStatus = "done"
 			case StatusFailed:
 				failed := inputLogFailTrain{}
 				failed.Key = key
 				failed.fillDefaults()
-				resp = mockStub.MockInvoke(mockTxID, [][]byte{[]byte("logFailAggregate"), assetToJSON(failed)})
+				resp = mockStub.MockInvoke([][]byte{[]byte("logFailAggregate"), assetToJSON(failed)})
 				require.EqualValuesf(t, 200, resp.Status, "traintuple should be successfully set to 'failed': %s", resp.Message)
 				expectedStatus = "failed"
 			}
 
 			// fetch back
 			args := [][]byte{[]byte("queryAggregatetuple"), keyToJSON(key)}
-			resp = mockStub.MockInvoke(mockTxID, args)
+			resp = mockStub.MockInvoke(args)
 			assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error: %s", resp.Message)
 			traintuple := outputAggregatetuple{}
 			json.Unmarshal(resp.Payload, &traintuple)
@@ -558,14 +558,14 @@ func TestQueryAggregatetuple(t *testing.T) {
 	in := inputAggregatetuple{}
 	in.InModels = []string{traintupleKey, compositeTraintupleKey}
 	args := in.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding aggregate tuple with status %d and message %s", resp.Status, resp.Message)
 
 	var keyOnly struct{ Key string }
 	json.Unmarshal(resp.Payload, &keyOnly)
 
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(keyOnly.Key)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the aggregate tuple: %s", resp.Message)
 	out := outputAggregatetuple{}
 	json.Unmarshal(resp.Payload, &out)

--- a/chaincode/tuple_aggregate_test.go
+++ b/chaincode/tuple_aggregate_test.go
@@ -34,62 +34,64 @@ import (
 func TestTraintupleWithNoTestDatasetAggregate(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	key := strings.Replace(objectiveKey, "1", "2", 1)
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputAggregateAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "when adding aggregate algo it should work: ", resp.Message)
 
 	inpTraintuple := inputAggregatetuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 
 	assert.EqualValues(t, 200, resp.Status, "when adding aggregate tuple without test dataset it should work: ", resp.Message)
 
 	traintuple := outputAggregatetuple{}
 	json.Unmarshal(resp.Payload, &traintuple)
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(traintuple.Key)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the aggregate tuple without error ", resp.Message)
 }
 
 func TestTraintupleWithSingleDatasampleAggregate(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	key := strings.Replace(objectiveKey, "1", "2", 1)
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke(mockTxID, methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputAggregateAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "when adding aggregate algo it should work: ", resp.Message)
 
 	inpTraintuple := inputAggregatetuple{
 		AlgoKey: aggregateAlgoKey,
 	}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "when adding aggregate tuple with a single data samples it should work: ", resp.Message)
 
 	traintuple := outputKey{}
 	err := json.Unmarshal(resp.Payload, &traintuple)
 	assert.NoError(t, err, "should be unmarshaled")
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(traintuple.Key)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the aggregate tuple without error ", resp.Message)
 }
 
@@ -121,30 +123,31 @@ func TestNoPanicWhileQueryingIncompleteTraintupleAggregate(t *testing.T) {
 func TestTraintupleComputePlanCreationAggregate(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add dataManager, dataSample and algo
 	registerItem(t, *mockStub, "aggregateAlgo")
 
 	inpTraintuple := inputAggregatetuple{ComputePlanKey: "someComputePlanKey"}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	require.EqualValues(t, 400, resp.Status, "should failed for missing rank")
 	require.Contains(t, resp.Message, "invalid inputs, a ComputePlan should have a rank", "invalid error message")
 
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inCP.getArgs())
+	resp = mockStub.MockInvoke(mockTxID, inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple = inputAggregatetuple{Rank: "1"}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	require.EqualValues(t, 400, resp.Status, "should failed for invalid rank")
 	require.Contains(t, resp.Message, "Field validation for 'ComputePlanKey' failed on the 'required_with' tag")
 
 	inpTraintuple = inputAggregatetuple{Rank: "0", ComputePlanKey: cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status)
 	res := outputKey{}
 	err := json.Unmarshal(resp.Payload, &res)
@@ -154,7 +157,7 @@ func TestTraintupleComputePlanCreationAggregate(t *testing.T) {
 
 	inpTraintuple = inputAggregatetuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	require.EqualValues(t, 409, resp.Status, "should failed for existing aggregatetuple key")
 	require.Contains(t, resp.Message, "already exists")
 
@@ -169,6 +172,7 @@ func TestTraintupleComputePlanCreationAggregate(t *testing.T) {
 func TestTraintupleMultipleCommputePlanCreationsAggregate(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add a some dataManager, dataSample and traintuple
 	registerItem(t, *mockStub, "aggregateAlgo")
@@ -176,12 +180,12 @@ func TestTraintupleMultipleCommputePlanCreationsAggregate(t *testing.T) {
 
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inCP.getArgs())
+	resp := mockStub.MockInvoke(mockTxID, inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple := inputAggregatetuple{Rank: "0", ComputePlanKey: cpKey}
 	args := inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status)
 	res := outputKey{}
 	err := json.Unmarshal(resp.Payload, &res)
@@ -197,7 +201,7 @@ func TestTraintupleMultipleCommputePlanCreationsAggregate(t *testing.T) {
 		Rank:           "0",
 		ComputePlanKey: cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 400, resp.Status, resp.Message, "should failed to add an aggregate tuple of the same rank")
 
 	// Failed to add a traintuple to an unexisting CommputePlan
@@ -207,7 +211,7 @@ func TestTraintupleMultipleCommputePlanCreationsAggregate(t *testing.T) {
 		Rank:           "1",
 		ComputePlanKey: "notarealone"}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 404, resp.Status, resp.Message, "should failed to add an aggregate tuple to an unexisting ComputePlanKey")
 
 	// Succesfully add a traintuple to the same ComputePlanKey
@@ -217,7 +221,7 @@ func TestTraintupleMultipleCommputePlanCreationsAggregate(t *testing.T) {
 		Rank:           "1",
 		ComputePlanKey: cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message, "should be able do create an aggregate tuple with the same ComputePlanKey")
 	err = json.Unmarshal(resp.Payload, &res)
 	assert.NoError(t, err, "should unmarshal without problem")
@@ -226,19 +230,20 @@ func TestTraintupleMultipleCommputePlanCreationsAggregate(t *testing.T) {
 func TestTraintupleAggregate(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add traintuple with invalid field
 	inpTraintuple := inputAggregatetuple{
 		AlgoKey: "aaa",
 	}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding objective with invalid key, status %d and message %s", resp.Status, resp.Message)
 
 	// Add traintuple with unexisting algo
 	inpTraintuple = inputAggregatetuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding aggregate tuple with unexisting algo, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add traintuple
@@ -251,7 +256,7 @@ func TestTraintupleAggregate(t *testing.T) {
 	traintupleKey := res.Key
 	// Query traintuple from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the aggregate tuple - status %d and message %s", resp.Status, resp.Message)
 	out := outputAggregatetuple{}
 	err = json.Unmarshal(resp.Payload, &out)
@@ -279,7 +284,7 @@ func TestTraintupleAggregate(t *testing.T) {
 
 	// Query all traintuples and check consistency
 	args = [][]byte{[]byte("queryAggregatetuples")}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying aggregate tuples - status %d and message %s", resp.Status, resp.Message)
 	// TODO add traintuple key to output struct
 	// For now we test it as cleanly as its added to the query response
@@ -296,7 +301,7 @@ func TestTraintupleAggregate(t *testing.T) {
 		Key:      RandomUUID(),
 	}
 	args = inpWaitingTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when adding aggregate tuple with status %d and message %s", resp.Status, resp.Message)
 
 	// Query traintuple with status todo and worker as trainworker and check consistency
@@ -305,7 +310,7 @@ func TestTraintupleAggregate(t *testing.T) {
 		Attributes: worker + ", todo",
 	}
 	args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying aggregate tuple of worker with todo status - status %d and message %s", resp.Status, resp.Message)
 	err = json.Unmarshal(resp.Payload, &queryTraintuples)
 	assert.NoError(t, err, "aggregate tuples should unmarshal without problem")
@@ -322,14 +327,14 @@ func TestTraintupleAggregate(t *testing.T) {
 	}
 	traintupleStatus := []string{StatusDoing, StatusDone}
 	for i := range traintupleStatus {
-		resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", argsSlice[i])
+		resp = mockStub.MockInvoke(mockTxID, argsSlice[i])
 		require.EqualValuesf(t, 200, resp.Status, "when logging start %s with message %s", traintupleStatus[i], resp.Message)
 		filter := inputQueryFilter{
 			IndexName:  "aggregatetuple~worker~status",
 			Attributes: worker + ", " + traintupleStatus[i],
 		}
 		args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-		resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+		resp = mockStub.MockInvoke(mockTxID, args)
 		assert.EqualValuesf(t, 200, resp.Status, "when querying traintuple of worker with %s status - message %s", traintupleStatus[i], resp.Message)
 		sPayload := make([]map[string]interface{}, 1)
 		assert.NoError(t, json.Unmarshal(resp.Payload, &sPayload), "when unmarshal queried traintuples")
@@ -339,7 +344,7 @@ func TestTraintupleAggregate(t *testing.T) {
 
 	// Query Aggregatetuple From key
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(aggregatetupleKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying aggregate tuple with status %d and message %s", resp.Status, resp.Message)
 	endTraintuple := outputAggregatetuple{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &endTraintuple))
@@ -353,7 +358,7 @@ func TestTraintupleAggregate(t *testing.T) {
 
 	// query all traintuples related to a traintuple with the same algo
 	args = [][]byte{[]byte("queryModelDetails"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying model details with status %d and message %s", resp.Status, resp.Message)
 	payload := outputModelDetails{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &payload))
@@ -361,60 +366,62 @@ func TestTraintupleAggregate(t *testing.T) {
 
 	// query all traintuples related to a traintuple with the same algo
 	args = [][]byte{[]byte("queryModels")}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying models with status %d and message %s", resp.Status, resp.Message)
 }
 
 func TestQueryTraintupleNotFoundAggregate(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "aggregateAlgo")
 
 	inpTraintuple := inputAggregatetuple{}
 	inpTraintuple.fillDefaults()
 	args := inpTraintuple.getArgs()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	var _key struct{ Key string }
 	json.Unmarshal(resp.Payload, &_key)
 
 	// queryAggregatetuple: normal queryAggregatetuple
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(_key.Key)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the aggregate tuple - status %d and message %s", resp.Status, resp.Message)
 
 	// queryAggregatetuple: key does not exist
 	notFoundKey := "eedbb7c3-1f62-244c-0f34-461cc1688042"
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(notFoundKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 404, resp.Status, "when querying the aggregate tuple - status %d and message %s", resp.Status, resp.Message)
 
 	// queryAggregatetuple: key does not exist and use existing other asset type key
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(algoKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValuesf(t, 404, resp.Status, "when querying the aggregate tuple - status %d and message %s", resp.Status, resp.Message)
 }
 
 func TestInsertTraintupleTwiceAggregate(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	inpAlgo := inputAggregateAlgo{}
 	args := inpAlgo.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	// create a aggregate tuple and start a ComplutePlan
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inCP.getArgs())
+	resp = mockStub.MockInvoke(mockTxID, inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 	inpTraintuple := inputAggregatetuple{
 		Rank:           "0",
 		ComputePlanKey: cpKey,
 	}
 	inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("createAggregatetuple", inpTraintuple))
+	resp = mockStub.MockInvoke(mockTxID, methodAndAssetToByte("createAggregatetuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusOK, resp.Status)
 	var _key struct{ Key string }
 	json.Unmarshal(resp.Payload, &_key)
@@ -426,11 +433,11 @@ func TestInsertTraintupleTwiceAggregate(t *testing.T) {
 	inpTraintuple.Rank = "1"
 	inpTraintuple.ComputePlanKey = tuple.ComputePlanKey
 	inpTraintuple.InModels = []string{_key.Key}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("createAggregatetuple", inpTraintuple))
+	resp = mockStub.MockInvoke(mockTxID, methodAndAssetToByte("createAggregatetuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusOK, resp.Status)
 
 	// re-insert the same aggregate tuple and expect a conflict error
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("createAggregatetuple", inpTraintuple))
+	resp = mockStub.MockInvoke(mockTxID, methodAndAssetToByte("createAggregatetuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusConflict, resp.Status)
 }
 
@@ -444,13 +451,14 @@ func TestInsertTraintupleTwiceAggregate(t *testing.T) {
 func TestAggregatetuplePermissions(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "aggregateAlgo")
 
 	// register nodes
 	registerNode := func(nodeName string) {
 		initialCreator := mockStub.Creator
 		mockStub.Creator = nodeName
-		mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", [][]byte{[]byte("registerNode")})
+		mockStub.MockInvoke(mockTxID, [][]byte{[]byte("registerNode")})
 		mockStub.Creator = initialCreator
 	}
 	registerNode("nodeA")
@@ -472,7 +480,7 @@ func TestAggregatetuplePermissions(t *testing.T) {
 		inp.fillDefaults()
 		inp.OutTrunkModelPermissions.Process.Public = false
 		inp.OutTrunkModelPermissions.Process.AuthorizedIDs = authorizedIds
-		resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inp.getArgs())
+		resp := mockStub.MockInvoke(mockTxID, inp.getArgs())
 		assert.EqualValues(t, 200, resp.Status, resp.Message)
 		var _key struct{ Key string }
 		json.Unmarshal(resp.Payload, &_key)
@@ -486,7 +494,7 @@ func TestAggregatetuplePermissions(t *testing.T) {
 	inpAgg := inputAggregatetuple{}
 	inpAgg.fillDefaults()
 	inpAgg.InModels = []string{traintuple1, traintuple2, traintuple3}
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inpAgg.getArgs())
+	resp := mockStub.MockInvoke(mockTxID, inpAgg.getArgs())
 	assert.EqualValues(t, 200, resp.Status, resp.Message)
 	var _key struct{ Key string }
 	json.Unmarshal(resp.Payload, &_key)
@@ -495,7 +503,7 @@ func TestAggregatetuplePermissions(t *testing.T) {
 	// fetch the aggregate tuple back
 	aggr := outputAggregatetuple{}
 	args := [][]byte{[]byte("queryAggregatetuple"), keyToJSON(aggrKey)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	aggr = outputAggregatetuple{}
 	json.Unmarshal(resp.Payload, &aggr)
 
@@ -511,13 +519,14 @@ func TestAggregatetupleLogSuccessFail(t *testing.T) {
 		t.Run("TestAggregatetupleLog"+status, func(t *testing.T) {
 			scc := new(SubstraChaincode)
 			mockStub := NewMockStubWithRegisterNode("substra", scc)
+			mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 			resp, _ := registerItem(t, *mockStub, "aggregatetuple")
 			var _key struct{ Key string }
 			json.Unmarshal(resp.Payload, &_key)
 			key := _key.Key
 
 			// start
-			resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", [][]byte{[]byte("logStartAggregate"), keyToJSON(key)})
+			resp = mockStub.MockInvoke(mockTxID, [][]byte{[]byte("logStartAggregate"), keyToJSON(key)})
 
 			var expectedStatus string
 
@@ -527,21 +536,21 @@ func TestAggregatetupleLogSuccessFail(t *testing.T) {
 				success.Key = key
 				success.createDefault()
 				success.fillDefaults()
-				resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", [][]byte{[]byte("logSuccessAggregate"), assetToJSON(success)})
+				resp = mockStub.MockInvoke(mockTxID, [][]byte{[]byte("logSuccessAggregate"), assetToJSON(success)})
 				require.EqualValuesf(t, 200, resp.Status, "traintuple should be successfully set to 'success': %s", resp.Message)
 				expectedStatus = "done"
 			case StatusFailed:
 				failed := inputLogFailTrain{}
 				failed.Key = key
 				failed.fillDefaults()
-				resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", [][]byte{[]byte("logFailAggregate"), assetToJSON(failed)})
+				resp = mockStub.MockInvoke(mockTxID, [][]byte{[]byte("logFailAggregate"), assetToJSON(failed)})
 				require.EqualValuesf(t, 200, resp.Status, "traintuple should be successfully set to 'failed': %s", resp.Message)
 				expectedStatus = "failed"
 			}
 
 			// fetch back
 			args := [][]byte{[]byte("queryAggregatetuple"), keyToJSON(key)}
-			resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+			resp = mockStub.MockInvoke(mockTxID, args)
 			assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error: %s", resp.Message)
 			traintuple := outputAggregatetuple{}
 			json.Unmarshal(resp.Payload, &traintuple)
@@ -553,19 +562,20 @@ func TestAggregatetupleLogSuccessFail(t *testing.T) {
 func TestQueryAggregatetuple(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	_, _ = registerItem(t, *mockStub, "compositeTraintuple")
 
 	in := inputAggregatetuple{}
 	in.InModels = []string{traintupleKey, compositeTraintupleKey}
 	args := in.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding aggregate tuple with status %d and message %s", resp.Status, resp.Message)
 
 	var keyOnly struct{ Key string }
 	json.Unmarshal(resp.Payload, &keyOnly)
 
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(keyOnly.Key)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the aggregate tuple: %s", resp.Message)
 	out := outputAggregatetuple{}
 	json.Unmarshal(resp.Payload, &out)
@@ -586,8 +596,9 @@ func TestQueryAggregatetuple(t *testing.T) {
 func TestCreateFailedAggregate(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "compositeTraintuple")
-	mockStub.MockTransactionStart("42")
+	mockStub.MockTransactionStart(mockTxID)
 	db := NewLedgerDB(mockStub)
 
 	_, err := logStartCompositeTrain(db, assetToArgs(inputKey{Key: compositeTraintupleKey}))

--- a/chaincode/tuple_aggregate_test.go
+++ b/chaincode/tuple_aggregate_test.go
@@ -34,7 +34,6 @@ import (
 func TestTraintupleWithNoTestDatasetAggregate(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	key := strings.Replace(objectiveKey, "1", "2", 1)
@@ -65,7 +64,6 @@ func TestTraintupleWithNoTestDatasetAggregate(t *testing.T) {
 func TestTraintupleWithSingleDatasampleAggregate(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	key := strings.Replace(objectiveKey, "1", "2", 1)
@@ -123,7 +121,6 @@ func TestNoPanicWhileQueryingIncompleteTraintupleAggregate(t *testing.T) {
 func TestTraintupleComputePlanCreationAggregate(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add dataManager, dataSample and algo
 	registerItem(t, *mockStub, "aggregateAlgo")
@@ -172,7 +169,6 @@ func TestTraintupleComputePlanCreationAggregate(t *testing.T) {
 func TestTraintupleMultipleCommputePlanCreationsAggregate(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add a some dataManager, dataSample and traintuple
 	registerItem(t, *mockStub, "aggregateAlgo")
@@ -230,7 +226,6 @@ func TestTraintupleMultipleCommputePlanCreationsAggregate(t *testing.T) {
 func TestTraintupleAggregate(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	// Add traintuple with invalid field
 	inpTraintuple := inputAggregatetuple{
@@ -373,7 +368,6 @@ func TestTraintupleAggregate(t *testing.T) {
 func TestQueryTraintupleNotFoundAggregate(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "aggregateAlgo")
 
 	inpTraintuple := inputAggregatetuple{}
@@ -403,7 +397,6 @@ func TestQueryTraintupleNotFoundAggregate(t *testing.T) {
 func TestInsertTraintupleTwiceAggregate(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "trainDataset")
 
 	inpAlgo := inputAggregateAlgo{}
@@ -451,7 +444,6 @@ func TestInsertTraintupleTwiceAggregate(t *testing.T) {
 func TestAggregatetuplePermissions(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "aggregateAlgo")
 
 	// register nodes
@@ -519,7 +511,6 @@ func TestAggregatetupleLogSuccessFail(t *testing.T) {
 		t.Run("TestAggregatetupleLog"+status, func(t *testing.T) {
 			scc := new(SubstraChaincode)
 			mockStub := NewMockStubWithRegisterNode("substra", scc)
-			mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 			resp, _ := registerItem(t, *mockStub, "aggregatetuple")
 			var _key struct{ Key string }
 			json.Unmarshal(resp.Payload, &_key)
@@ -562,7 +553,6 @@ func TestAggregatetupleLogSuccessFail(t *testing.T) {
 func TestQueryAggregatetuple(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	_, _ = registerItem(t, *mockStub, "compositeTraintuple")
 
 	in := inputAggregatetuple{}
@@ -596,7 +586,6 @@ func TestQueryAggregatetuple(t *testing.T) {
 func TestCreateFailedAggregate(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	registerItem(t, *mockStub, "compositeTraintuple")
 	mockStub.MockTransactionStart(mockTxID)
 	db := NewLedgerDB(mockStub)

--- a/chaincode/tuple_aggregate_test.go
+++ b/chaincode/tuple_aggregate_test.go
@@ -40,24 +40,24 @@ func TestTraintupleWithNoTestDatasetAggregate(t *testing.T) {
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke("42", methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputAggregateAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "when adding aggregate algo it should work: ", resp.Message)
 
 	inpTraintuple := inputAggregatetuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 
 	assert.EqualValues(t, 200, resp.Status, "when adding aggregate tuple without test dataset it should work: ", resp.Message)
 
 	traintuple := outputAggregatetuple{}
 	json.Unmarshal(resp.Payload, &traintuple)
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(traintuple.Key)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the aggregate tuple without error ", resp.Message)
 }
 
@@ -70,26 +70,26 @@ func TestTraintupleWithSingleDatasampleAggregate(t *testing.T) {
 	inpObjective := inputObjective{Key: key}
 	inpObjective.createDefault()
 	inpObjective.TestDataset = inputDataset{}
-	resp := mockStub.MockInvoke("42", methodAndAssetToByte("registerObjective", inpObjective))
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("registerObjective", inpObjective))
 	assert.EqualValues(t, 200, resp.Status, "when adding objective without dataset it should work: ", resp.Message)
 
 	inpAlgo := inputAggregateAlgo{}
 	args := inpAlgo.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "when adding aggregate algo it should work: ", resp.Message)
 
 	inpTraintuple := inputAggregatetuple{
 		AlgoKey: aggregateAlgoKey,
 	}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "when adding aggregate tuple with a single data samples it should work: ", resp.Message)
 
 	traintuple := outputKey{}
 	err := json.Unmarshal(resp.Payload, &traintuple)
 	assert.NoError(t, err, "should be unmarshaled")
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(traintuple.Key)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the aggregate tuple without error ", resp.Message)
 }
 
@@ -127,24 +127,24 @@ func TestTraintupleComputePlanCreationAggregate(t *testing.T) {
 
 	inpTraintuple := inputAggregatetuple{ComputePlanKey: "someComputePlanKey"}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValues(t, 400, resp.Status, "should failed for missing rank")
 	require.Contains(t, resp.Message, "invalid inputs, a ComputePlan should have a rank", "invalid error message")
 
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp = mockStub.MockInvoke("42", inCP.getArgs())
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple = inputAggregatetuple{Rank: "1"}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValues(t, 400, resp.Status, "should failed for invalid rank")
 	require.Contains(t, resp.Message, "Field validation for 'ComputePlanKey' failed on the 'required_with' tag")
 
 	inpTraintuple = inputAggregatetuple{Rank: "0", ComputePlanKey: cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status)
 	res := outputKey{}
 	err := json.Unmarshal(resp.Payload, &res)
@@ -154,7 +154,7 @@ func TestTraintupleComputePlanCreationAggregate(t *testing.T) {
 
 	inpTraintuple = inputAggregatetuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValues(t, 409, resp.Status, "should failed for existing aggregatetuple key")
 	require.Contains(t, resp.Message, "already exists")
 
@@ -176,12 +176,12 @@ func TestTraintupleMultipleCommputePlanCreationsAggregate(t *testing.T) {
 
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp := mockStub.MockInvoke("42", inCP.getArgs())
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 
 	inpTraintuple := inputAggregatetuple{Rank: "0", ComputePlanKey: cpKey}
 	args := inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status)
 	res := outputKey{}
 	err := json.Unmarshal(resp.Payload, &res)
@@ -197,7 +197,7 @@ func TestTraintupleMultipleCommputePlanCreationsAggregate(t *testing.T) {
 		Rank:           "0",
 		ComputePlanKey: cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 400, resp.Status, resp.Message, "should failed to add an aggregate tuple of the same rank")
 
 	// Failed to add a traintuple to an unexisting CommputePlan
@@ -207,7 +207,7 @@ func TestTraintupleMultipleCommputePlanCreationsAggregate(t *testing.T) {
 		Rank:           "1",
 		ComputePlanKey: "notarealone"}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 404, resp.Status, resp.Message, "should failed to add an aggregate tuple to an unexisting ComputePlanKey")
 
 	// Succesfully add a traintuple to the same ComputePlanKey
@@ -217,7 +217,7 @@ func TestTraintupleMultipleCommputePlanCreationsAggregate(t *testing.T) {
 		Rank:           "1",
 		ComputePlanKey: cpKey}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message, "should be able do create an aggregate tuple with the same ComputePlanKey")
 	err = json.Unmarshal(resp.Payload, &res)
 	assert.NoError(t, err, "should unmarshal without problem")
@@ -232,13 +232,13 @@ func TestTraintupleAggregate(t *testing.T) {
 		AlgoKey: "aaa",
 	}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding objective with invalid key, status %d and message %s", resp.Status, resp.Message)
 
 	// Add traintuple with unexisting algo
 	inpTraintuple = inputAggregatetuple{}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 400, resp.Status, "when adding aggregate tuple with unexisting algo, status %d and message %s", resp.Status, resp.Message)
 
 	// Properly add traintuple
@@ -251,7 +251,7 @@ func TestTraintupleAggregate(t *testing.T) {
 	traintupleKey := res.Key
 	// Query traintuple from key and check the consistency of returned arguments
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the aggregate tuple - status %d and message %s", resp.Status, resp.Message)
 	out := outputAggregatetuple{}
 	err = json.Unmarshal(resp.Payload, &out)
@@ -279,7 +279,7 @@ func TestTraintupleAggregate(t *testing.T) {
 
 	// Query all traintuples and check consistency
 	args = [][]byte{[]byte("queryAggregatetuples")}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying aggregate tuples - status %d and message %s", resp.Status, resp.Message)
 	// TODO add traintuple key to output struct
 	// For now we test it as cleanly as its added to the query response
@@ -296,7 +296,7 @@ func TestTraintupleAggregate(t *testing.T) {
 		Key:      RandomUUID(),
 	}
 	args = inpWaitingTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when adding aggregate tuple with status %d and message %s", resp.Status, resp.Message)
 
 	// Query traintuple with status todo and worker as trainworker and check consistency
@@ -305,7 +305,7 @@ func TestTraintupleAggregate(t *testing.T) {
 		Attributes: worker + ", todo",
 	}
 	args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying aggregate tuple of worker with todo status - status %d and message %s", resp.Status, resp.Message)
 	err = json.Unmarshal(resp.Payload, &queryTraintuples)
 	assert.NoError(t, err, "aggregate tuples should unmarshal without problem")
@@ -322,14 +322,14 @@ func TestTraintupleAggregate(t *testing.T) {
 	}
 	traintupleStatus := []string{StatusDoing, StatusDone}
 	for i := range traintupleStatus {
-		resp = mockStub.MockInvoke("42", argsSlice[i])
+		resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", argsSlice[i])
 		require.EqualValuesf(t, 200, resp.Status, "when logging start %s with message %s", traintupleStatus[i], resp.Message)
 		filter := inputQueryFilter{
 			IndexName:  "aggregatetuple~worker~status",
 			Attributes: worker + ", " + traintupleStatus[i],
 		}
 		args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-		resp = mockStub.MockInvoke("42", args)
+		resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 		assert.EqualValuesf(t, 200, resp.Status, "when querying traintuple of worker with %s status - message %s", traintupleStatus[i], resp.Message)
 		sPayload := make([]map[string]interface{}, 1)
 		assert.NoError(t, json.Unmarshal(resp.Payload, &sPayload), "when unmarshal queried traintuples")
@@ -339,7 +339,7 @@ func TestTraintupleAggregate(t *testing.T) {
 
 	// Query Aggregatetuple From key
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(aggregatetupleKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying aggregate tuple with status %d and message %s", resp.Status, resp.Message)
 	endTraintuple := outputAggregatetuple{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &endTraintuple))
@@ -353,7 +353,7 @@ func TestTraintupleAggregate(t *testing.T) {
 
 	// query all traintuples related to a traintuple with the same algo
 	args = [][]byte{[]byte("queryModelDetails"), keyToJSON(traintupleKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying model details with status %d and message %s", resp.Status, resp.Message)
 	payload := outputModelDetails{}
 	assert.NoError(t, json.Unmarshal(resp.Payload, &payload))
@@ -361,7 +361,7 @@ func TestTraintupleAggregate(t *testing.T) {
 
 	// query all traintuples related to a traintuple with the same algo
 	args = [][]byte{[]byte("queryModels")}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying models with status %d and message %s", resp.Status, resp.Message)
 }
 
@@ -373,24 +373,24 @@ func TestQueryTraintupleNotFoundAggregate(t *testing.T) {
 	inpTraintuple := inputAggregatetuple{}
 	inpTraintuple.fillDefaults()
 	args := inpTraintuple.getArgs()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	var _key struct{ Key string }
 	json.Unmarshal(resp.Payload, &_key)
 
 	// queryAggregatetuple: normal queryAggregatetuple
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(_key.Key)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying the aggregate tuple - status %d and message %s", resp.Status, resp.Message)
 
 	// queryAggregatetuple: key does not exist
 	notFoundKey := "eedbb7c3-1f62-244c-0f34-461cc1688042"
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(notFoundKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 404, resp.Status, "when querying the aggregate tuple - status %d and message %s", resp.Status, resp.Message)
 
 	// queryAggregatetuple: key does not exist and use existing other asset type key
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(algoKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValuesf(t, 404, resp.Status, "when querying the aggregate tuple - status %d and message %s", resp.Status, resp.Message)
 }
 
@@ -401,20 +401,20 @@ func TestInsertTraintupleTwiceAggregate(t *testing.T) {
 
 	inpAlgo := inputAggregateAlgo{}
 	args := inpAlgo.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "when adding algo it should work: ", resp.Message)
 
 	// create a aggregate tuple and start a ComplutePlan
 	cpKey := RandomUUID()
 	inCP := inputComputePlan{Key: cpKey}
-	resp = mockStub.MockInvoke("42", inCP.getArgs())
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inCP.getArgs())
 	require.EqualValues(t, 200, resp.Status)
 	inpTraintuple := inputAggregatetuple{
 		Rank:           "0",
 		ComputePlanKey: cpKey,
 	}
 	inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", methodAndAssetToByte("createAggregatetuple", inpTraintuple))
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("createAggregatetuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusOK, resp.Status)
 	var _key struct{ Key string }
 	json.Unmarshal(resp.Payload, &_key)
@@ -426,11 +426,11 @@ func TestInsertTraintupleTwiceAggregate(t *testing.T) {
 	inpTraintuple.Rank = "1"
 	inpTraintuple.ComputePlanKey = tuple.ComputePlanKey
 	inpTraintuple.InModels = []string{_key.Key}
-	resp = mockStub.MockInvoke("42", methodAndAssetToByte("createAggregatetuple", inpTraintuple))
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("createAggregatetuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusOK, resp.Status)
 
 	// re-insert the same aggregate tuple and expect a conflict error
-	resp = mockStub.MockInvoke("42", methodAndAssetToByte("createAggregatetuple", inpTraintuple))
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", methodAndAssetToByte("createAggregatetuple", inpTraintuple))
 	assert.EqualValues(t, http.StatusConflict, resp.Status)
 }
 
@@ -450,7 +450,7 @@ func TestAggregatetuplePermissions(t *testing.T) {
 	registerNode := func(nodeName string) {
 		initialCreator := mockStub.Creator
 		mockStub.Creator = nodeName
-		mockStub.MockInvoke("42", [][]byte{[]byte("registerNode")})
+		mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", [][]byte{[]byte("registerNode")})
 		mockStub.Creator = initialCreator
 	}
 	registerNode("nodeA")
@@ -472,7 +472,7 @@ func TestAggregatetuplePermissions(t *testing.T) {
 		inp.fillDefaults()
 		inp.OutTrunkModelPermissions.Process.Public = false
 		inp.OutTrunkModelPermissions.Process.AuthorizedIDs = authorizedIds
-		resp := mockStub.MockInvoke("42", inp.getArgs())
+		resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inp.getArgs())
 		assert.EqualValues(t, 200, resp.Status, resp.Message)
 		var _key struct{ Key string }
 		json.Unmarshal(resp.Payload, &_key)
@@ -486,7 +486,7 @@ func TestAggregatetuplePermissions(t *testing.T) {
 	inpAgg := inputAggregatetuple{}
 	inpAgg.fillDefaults()
 	inpAgg.InModels = []string{traintuple1, traintuple2, traintuple3}
-	resp := mockStub.MockInvoke("42", inpAgg.getArgs())
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", inpAgg.getArgs())
 	assert.EqualValues(t, 200, resp.Status, resp.Message)
 	var _key struct{ Key string }
 	json.Unmarshal(resp.Payload, &_key)
@@ -495,7 +495,7 @@ func TestAggregatetuplePermissions(t *testing.T) {
 	// fetch the aggregate tuple back
 	aggr := outputAggregatetuple{}
 	args := [][]byte{[]byte("queryAggregatetuple"), keyToJSON(aggrKey)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	aggr = outputAggregatetuple{}
 	json.Unmarshal(resp.Payload, &aggr)
 
@@ -517,7 +517,7 @@ func TestAggregatetupleLogSuccessFail(t *testing.T) {
 			key := _key.Key
 
 			// start
-			resp = mockStub.MockInvoke("42", [][]byte{[]byte("logStartAggregate"), keyToJSON(key)})
+			resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", [][]byte{[]byte("logStartAggregate"), keyToJSON(key)})
 
 			var expectedStatus string
 
@@ -527,21 +527,21 @@ func TestAggregatetupleLogSuccessFail(t *testing.T) {
 				success.Key = key
 				success.createDefault()
 				success.fillDefaults()
-				resp = mockStub.MockInvoke("42", [][]byte{[]byte("logSuccessAggregate"), assetToJSON(success)})
+				resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", [][]byte{[]byte("logSuccessAggregate"), assetToJSON(success)})
 				require.EqualValuesf(t, 200, resp.Status, "traintuple should be successfully set to 'success': %s", resp.Message)
 				expectedStatus = "done"
 			case StatusFailed:
 				failed := inputLogFailTrain{}
 				failed.Key = key
 				failed.fillDefaults()
-				resp = mockStub.MockInvoke("42", [][]byte{[]byte("logFailAggregate"), assetToJSON(failed)})
+				resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", [][]byte{[]byte("logFailAggregate"), assetToJSON(failed)})
 				require.EqualValuesf(t, 200, resp.Status, "traintuple should be successfully set to 'failed': %s", resp.Message)
 				expectedStatus = "failed"
 			}
 
 			// fetch back
 			args := [][]byte{[]byte("queryAggregatetuple"), keyToJSON(key)}
-			resp = mockStub.MockInvoke("42", args)
+			resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 			assert.EqualValues(t, 200, resp.Status, "It should find the traintuple without error: %s", resp.Message)
 			traintuple := outputAggregatetuple{}
 			json.Unmarshal(resp.Payload, &traintuple)
@@ -558,14 +558,14 @@ func TestQueryAggregatetuple(t *testing.T) {
 	in := inputAggregatetuple{}
 	in.InModels = []string{traintupleKey, compositeTraintupleKey}
 	args := in.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	require.EqualValuesf(t, 200, resp.Status, "when adding aggregate tuple with status %d and message %s", resp.Status, resp.Message)
 
 	var keyOnly struct{ Key string }
 	json.Unmarshal(resp.Payload, &keyOnly)
 
 	args = [][]byte{[]byte("queryAggregatetuple"), keyToJSON(keyOnly.Key)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, "It should find the aggregate tuple: %s", resp.Message)
 	out := outputAggregatetuple{}
 	json.Unmarshal(resp.Payload, &out)

--- a/chaincode/tuple_test.go
+++ b/chaincode/tuple_test.go
@@ -121,7 +121,7 @@ func TestSpecifiqArgSeq(t *testing.T) {
 		for _, arg := range argList {
 			args = append(args, []byte(arg))
 		}
-		resp := mockStub.MockInvoke(mockTxID, args)
+		resp := mockStub.MockInvoke(args)
 		assert.EqualValues(t, 200, resp.Status, resp.Message, argList[0])
 	}
 }
@@ -136,18 +136,18 @@ func TestTagTuple(t *testing.T) {
 
 	inpTraintuple := inputTraintuple{Tag: noTag}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke(mockTxID, args)
+	resp := mockStub.MockInvoke(args)
 	assert.EqualValues(t, 400, resp.Status, resp.Message)
 
 	tag := "This is a tag"
 
 	inpTraintuple = inputTraintuple{Tag: tag}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message)
 
 	args = [][]byte{[]byte("queryTraintuples")}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 
 	traintuples := []outputTraintuple{}
 	err := json.Unmarshal(resp.Payload, &traintuples)
@@ -158,11 +158,11 @@ func TestTagTuple(t *testing.T) {
 
 	inpTesttuple := inputTesttuple{Tag: tag}
 	args = inpTesttuple.createDefault()
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message)
 
 	args = [][]byte{[]byte("queryTesttuples")}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	testtuples := []outputTesttuple{}
 	err = json.Unmarshal(resp.Payload, &testtuples)
 	assert.NoError(t, err, "should be unmarshaled")
@@ -174,7 +174,7 @@ func TestTagTuple(t *testing.T) {
 		Attributes: tag,
 	}
 	args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-	resp = mockStub.MockInvoke(mockTxID, args)
+	resp = mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message)
 	filtertuples := []outputTesttuple{}
 	err = json.Unmarshal(resp.Payload, &filtertuples)

--- a/chaincode/tuple_test.go
+++ b/chaincode/tuple_test.go
@@ -101,6 +101,7 @@ func TestSpecifiqArgSeq(t *testing.T) {
 	// parameters directly copied in a test. It can be realy usesul for debugging
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	argSeq := [][]string{
 		// []string{"registerDataManager", "Titanic", "17dbc4ece248304cab7b1dd53ec7edf1ebf8a5e12ff77a26dc6e8da9db4da223", "http://owkin.substrabac:8000/data_manager/17dbc4ece248304cab7b1dd53ec7edf1ebf8a5e12ff77a26dc6e8da9db4da223/opener/", "csv", "48c89276972363250ea949c32809020e9d7fda786547a570bcaecedcc5092627", "http://owkin.substrabac:8000/data_manager/17dbc4ece248304cab7b1dd53ec7edf1ebf8a5e12ff77a26dc6e8da9db4da223/description/", "", "all"},
 		[]string{"registerDataManager", "\"{\\\"Name\\\":\\\"Titanic\\\",\\\"OpenerChecksum\\\":\\\"17dbc4ece248304cab7b1dd53ec7edf1ebf8a5e12ff77a26dc6e8da9db4da223\\\",\\\"OpenerStorageAddress\\\":\\\"http://owkin.substrabac:8000/data_manager/17dbc4ece248304cab7b1dd53ec7edf1ebf8a5e12ff77a26dc6e8da9db4da223/opener/\\\",\\\"Type\\\":\\\"csv\\\",\\\"DescriptionChecksum\\\":\\\"48c89276972363250ea949c32809020e9d7fda786547a570bcaecedcc5092627\\\",\\\"DescriptionStorageAddress\\\":\\\"http://owkin.substrabac:8000/data_manager/17dbc4ece248304cab7b1dd53ec7edf1ebf8a5e12ff77a26dc6e8da9db4da223/description/\\\",\\\"ObjectiveKey\\\":\\\"\\\",\\\"Permissions\\\":\\\"all\\\"}\""},
@@ -121,7 +122,7 @@ func TestSpecifiqArgSeq(t *testing.T) {
 		for _, arg := range argList {
 			args = append(args, []byte(arg))
 		}
-		resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+		resp := mockStub.MockInvoke(mockTxID, args)
 		assert.EqualValues(t, 200, resp.Status, resp.Message, argList[0])
 	}
 }
@@ -129,6 +130,7 @@ func TestSpecifiqArgSeq(t *testing.T) {
 func TestTagTuple(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
+	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	registerItem(t, *mockStub, "algo")
 
@@ -136,18 +138,18 @@ func TestTagTuple(t *testing.T) {
 
 	inpTraintuple := inputTraintuple{Tag: noTag}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp := mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 400, resp.Status, resp.Message)
 
 	tag := "This is a tag"
 
 	inpTraintuple = inputTraintuple{Tag: tag}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message)
 
 	args = [][]byte{[]byte("queryTraintuples")}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 
 	traintuples := []outputTraintuple{}
 	err := json.Unmarshal(resp.Payload, &traintuples)
@@ -158,11 +160,11 @@ func TestTagTuple(t *testing.T) {
 
 	inpTesttuple := inputTesttuple{Tag: tag}
 	args = inpTesttuple.createDefault()
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message)
 
 	args = [][]byte{[]byte("queryTesttuples")}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	testtuples := []outputTesttuple{}
 	err = json.Unmarshal(resp.Payload, &testtuples)
 	assert.NoError(t, err, "should be unmarshaled")
@@ -174,7 +176,7 @@ func TestTagTuple(t *testing.T) {
 		Attributes: tag,
 	}
 	args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
+	resp = mockStub.MockInvoke(mockTxID, args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message)
 	filtertuples := []outputTesttuple{}
 	err = json.Unmarshal(resp.Payload, &filtertuples)

--- a/chaincode/tuple_test.go
+++ b/chaincode/tuple_test.go
@@ -101,7 +101,6 @@ func TestSpecifiqArgSeq(t *testing.T) {
 	// parameters directly copied in a test. It can be realy usesul for debugging
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 	argSeq := [][]string{
 		// []string{"registerDataManager", "Titanic", "17dbc4ece248304cab7b1dd53ec7edf1ebf8a5e12ff77a26dc6e8da9db4da223", "http://owkin.substrabac:8000/data_manager/17dbc4ece248304cab7b1dd53ec7edf1ebf8a5e12ff77a26dc6e8da9db4da223/opener/", "csv", "48c89276972363250ea949c32809020e9d7fda786547a570bcaecedcc5092627", "http://owkin.substrabac:8000/data_manager/17dbc4ece248304cab7b1dd53ec7edf1ebf8a5e12ff77a26dc6e8da9db4da223/description/", "", "all"},
 		[]string{"registerDataManager", "\"{\\\"Name\\\":\\\"Titanic\\\",\\\"OpenerChecksum\\\":\\\"17dbc4ece248304cab7b1dd53ec7edf1ebf8a5e12ff77a26dc6e8da9db4da223\\\",\\\"OpenerStorageAddress\\\":\\\"http://owkin.substrabac:8000/data_manager/17dbc4ece248304cab7b1dd53ec7edf1ebf8a5e12ff77a26dc6e8da9db4da223/opener/\\\",\\\"Type\\\":\\\"csv\\\",\\\"DescriptionChecksum\\\":\\\"48c89276972363250ea949c32809020e9d7fda786547a570bcaecedcc5092627\\\",\\\"DescriptionStorageAddress\\\":\\\"http://owkin.substrabac:8000/data_manager/17dbc4ece248304cab7b1dd53ec7edf1ebf8a5e12ff77a26dc6e8da9db4da223/description/\\\",\\\"ObjectiveKey\\\":\\\"\\\",\\\"Permissions\\\":\\\"all\\\"}\""},
@@ -130,7 +129,6 @@ func TestSpecifiqArgSeq(t *testing.T) {
 func TestTagTuple(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
-	mockTxID := "fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f"
 
 	registerItem(t, *mockStub, "algo")
 

--- a/chaincode/tuple_test.go
+++ b/chaincode/tuple_test.go
@@ -121,7 +121,7 @@ func TestSpecifiqArgSeq(t *testing.T) {
 		for _, arg := range argList {
 			args = append(args, []byte(arg))
 		}
-		resp := mockStub.MockInvoke("42", args)
+		resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 		assert.EqualValues(t, 200, resp.Status, resp.Message, argList[0])
 	}
 }
@@ -136,18 +136,18 @@ func TestTagTuple(t *testing.T) {
 
 	inpTraintuple := inputTraintuple{Tag: noTag}
 	args := inpTraintuple.createDefault()
-	resp := mockStub.MockInvoke("42", args)
+	resp := mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 400, resp.Status, resp.Message)
 
 	tag := "This is a tag"
 
 	inpTraintuple = inputTraintuple{Tag: tag}
 	args = inpTraintuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message)
 
 	args = [][]byte{[]byte("queryTraintuples")}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 
 	traintuples := []outputTraintuple{}
 	err := json.Unmarshal(resp.Payload, &traintuples)
@@ -158,11 +158,11 @@ func TestTagTuple(t *testing.T) {
 
 	inpTesttuple := inputTesttuple{Tag: tag}
 	args = inpTesttuple.createDefault()
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message)
 
 	args = [][]byte{[]byte("queryTesttuples")}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	testtuples := []outputTesttuple{}
 	err = json.Unmarshal(resp.Payload, &testtuples)
 	assert.NoError(t, err, "should be unmarshaled")
@@ -174,7 +174,7 @@ func TestTagTuple(t *testing.T) {
 		Attributes: tag,
 	}
 	args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
-	resp = mockStub.MockInvoke("42", args)
+	resp = mockStub.MockInvoke("fa0f757bc278fdf6a32d00975602eb853e23a86a156781588d99ddef5b80720f", args)
 	assert.EqualValues(t, 200, resp.Status, resp.Message)
 	filtertuples := []outputTesttuple{}
 	err = json.Unmarshal(resp.Payload, &filtertuples)


### PR DESCRIPTION
## Description
In case we use the same chaincode for multiple channel, like https://github.com/SubstraFoundation/hlf-k8s/pull/102, we need to log the channel name for each request to be able to review logs in case of troubleshooting sessions.

## Closes issue(s)
None

## Companion PRs
https://github.com/SubstraFoundation/hlf-k8s/pull/102

## How to test / repro
Launch e2e tests (minimal) and look for chaincode logs :) 

## Screenshots / Trace
```

time="2020-11-25T10:39:38Z" level=info msg="Load TLS certificates"
time="2020-11-25T10:39:38Z" level=info msg="Start Substra ChaincodeServer"
time="2020-11-25T10:41:01Z" level=info msg="Args received by the chaincode on channel 'mychannel': []string{\"registerNode\", \"[\\\"\\\"]\"}"
time="2020-11-25T10:41:01Z" level=info msg="Response from chaincode on channel 'mychannel' (in 18ms): main.Node{ID:\"MyOrg1MSP\"}, error: %!s(<nil>)"
time="2020-11-25T10:41:02Z" level=info msg="Args received by the chaincode on channel 'yourchannel': []string{\"registerNode\", \"[\\\"\\\"]\"}"
time="2020-11-25T10:41:02Z" level=info msg="Response from chaincode on channel 'yourchannel' (in 23ms): main.Node{ID:\"MyOrg1MSP\"}, error: %!s(<nil>)"
time="2020-11-25T10:41:26Z" level=info msg="Args received by the chaincode on channel 'mychannel': []string{\"registerNode\", \"[\\\"\\\"]\"}"
time="2020-11-25T10:41:26Z" level=info msg="Response from chaincode on channel 'mychanne'l (in 7ms): main.Node{ID:\"MyOrg2MSP\"}, error: %!s(<nil>)"
time="2020-11-25T10:41:27Z" level=info msg="Args received by the chaincode on channel 'yourchannel': []string{\"registerNode\", \"[\\\"\\\"]\"}"
time="2020-11-25T10:41:27Z" level=info msg="Response from chaincode on channel 'yourchannel' (in 17ms): main.Node{ID:\"MyOrg2MSP\"}, error: %!s(<nil>)"

```
## Changes include
- [x] Add channel name in `Args received` log line
- [x] Add channel name in `Response from chaincode` log line

## Checklist
- [x] I have tested this code with e2e tests from substra-tests

## Other comments
Feel free to change the format if you want to log it in a clearer way ! 
