### PR TITLE
Chaincode Pagination with query[Asset]s.

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1176,7 +1176,7 @@ peer chaincode query -n mycc -c '{"Args":["queryModels"]}' -C myc
 ##### Command output:
 ```json
 {
- "bookmark": "",
+ "bookmark": "{\"traintuple\":\"\",\"composite_traintuple\":\"\",\"aggregatetuple\":\"\"}",
  "results": [
   {
    "traintuple": {

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -205,9 +205,7 @@ peer chaincode query -n mycc -c '{"Args":["queryDataManagers"]}' -C myc
 ##### Command output:
 ```json
 {
- "bookmarks": {
-  "dataManager~owner~key": ""
- },
+ "bookmark": "",
  "results": [
   {
    "description": {
@@ -242,9 +240,7 @@ peer chaincode query -n mycc -c '{"Args":["queryDataSamples"]}' -C myc
 ##### Command output:
 ```json
 {
- "bookmarks": {
-  "dataSample~dataManager~key": ""
- },
+ "bookmark": "",
  "results": [
   {
    "data_manager_keys": [
@@ -285,9 +281,7 @@ peer chaincode query -n mycc -c '{"Args":["queryObjectives"]}' -C myc
 ##### Command output:
 ```json
 {
- "bookmarks": {
-  "objective~owner~key": ""
- },
+ "bookmark": "",
  "results": [
   {
    "description": {
@@ -931,9 +925,7 @@ peer chaincode query -n mycc -c '{"Args":["queryTesttuples"]}' -C myc
 ##### Command output:
 ```json
 {
- "bookmarks": {
-  "testtuple~traintuple~certified~key": ""
- },
+ "bookmark": "",
  "results": [
   {
    "algo": {
@@ -1184,11 +1176,7 @@ peer chaincode query -n mycc -c '{"Args":["queryModels"]}' -C myc
 ##### Command output:
 ```json
 {
- "bookmarks": {
-  "aggregatetuple~algo~key": "",
-  "compositeTraintuple~algo~key": "",
-  "traintuple~algo~key": ""
- },
+ "bookmark": "",
  "results": [
   {
    "traintuple": {
@@ -1696,9 +1684,7 @@ peer chaincode invoke -n mycc -c '{"Args":["queryComputePlans"]}' -C myc
 ##### Command output:
 ```json
 {
- "bookmarks": {
-  "computePlan~key": ""
- },
+ "bookmark": "",
  "results": [
   {
    "aggregatetuple_keys": null,

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -204,30 +204,35 @@ peer chaincode query -n mycc -c '{"Args":["queryDataManagers"]}' -C myc
 ```
 ##### Command output:
 ```json
-[
- {
-  "description": {
-   "checksum": "8d4bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482eee",
-   "storage_address": "https://toto/dataManager/42234/description"
-  },
-  "key": "da1bb7c3-1f62-244c-0f3a-761cc1688042",
-  "metadata": {},
-  "name": "liver slide",
-  "objective_key": "5c1d9cd1-c2c1-082d-de09-21b56d11030c",
-  "opener": {
-   "checksum": "da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
-   "storage_address": "https://toto/dataManager/42234/opener"
-  },
-  "owner": "SampleOrg",
-  "permissions": {
-   "process": {
-    "authorized_ids": [],
-    "public": true
-   }
-  },
-  "type": "images"
- }
-]
+{
+ "bookmarks": {
+  "dataManager~owner~key": ""
+ },
+ "result": [
+  {
+   "description": {
+    "checksum": "8d4bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482eee",
+    "storage_address": "https://toto/dataManager/42234/description"
+   },
+   "key": "da1bb7c3-1f62-244c-0f3a-761cc1688042",
+   "metadata": {},
+   "name": "liver slide",
+   "objective_key": "5c1d9cd1-c2c1-082d-de09-21b56d11030c",
+   "opener": {
+    "checksum": "da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
+    "storage_address": "https://toto/dataManager/42234/opener"
+   },
+   "owner": "SampleOrg",
+   "permissions": {
+    "process": {
+     "authorized_ids": [],
+     "public": true
+    }
+   },
+   "type": "images"
+  }
+ ]
+}
 ```
 #### ------------ Query DataSamples ------------
 ##### Command peer example:
@@ -236,36 +241,41 @@ peer chaincode query -n mycc -c '{"Args":["queryDataSamples"]}' -C myc
 ```
 ##### Command output:
 ```json
-[
- {
-  "data_manager_keys": [
-   "da1bb7c3-1f62-244c-0f3a-761cc1688042"
-  ],
-  "key": "aa1bb7c3-1f62-244c-0f3a-761cc1688042",
-  "owner": "SampleOrg"
+{
+ "bookmarks": {
+  "dataSample~dataManager~key": ""
  },
- {
-  "data_manager_keys": [
-   "da1bb7c3-1f62-244c-0f3a-761cc1688042"
-  ],
-  "key": "aa2bb7c3-1f62-244c-0f3a-761cc1688042",
-  "owner": "SampleOrg"
- },
- {
-  "data_manager_keys": [
-   "da1bb7c3-1f62-244c-0f3a-761cc1688042"
-  ],
-  "key": "bb1bb7c3-1f62-244c-0f3a-761cc1688042",
-  "owner": "SampleOrg"
- },
- {
-  "data_manager_keys": [
-   "da1bb7c3-1f62-244c-0f3a-761cc1688042"
-  ],
-  "key": "bb2bb7c3-1f62-244c-0f3a-761cc1688042",
-  "owner": "SampleOrg"
- }
-]
+ "result": [
+  {
+   "data_manager_keys": [
+    "da1bb7c3-1f62-244c-0f3a-761cc1688042"
+   ],
+   "key": "aa1bb7c3-1f62-244c-0f3a-761cc1688042",
+   "owner": "SampleOrg"
+  },
+  {
+   "data_manager_keys": [
+    "da1bb7c3-1f62-244c-0f3a-761cc1688042"
+   ],
+   "key": "aa2bb7c3-1f62-244c-0f3a-761cc1688042",
+   "owner": "SampleOrg"
+  },
+  {
+   "data_manager_keys": [
+    "da1bb7c3-1f62-244c-0f3a-761cc1688042"
+   ],
+   "key": "bb1bb7c3-1f62-244c-0f3a-761cc1688042",
+   "owner": "SampleOrg"
+  },
+  {
+   "data_manager_keys": [
+    "da1bb7c3-1f62-244c-0f3a-761cc1688042"
+   ],
+   "key": "bb2bb7c3-1f62-244c-0f3a-761cc1688042",
+   "owner": "SampleOrg"
+  }
+ ]
+}
 ```
 #### ------------ Query Objectives ------------
 ##### Command peer example:
@@ -274,38 +284,43 @@ peer chaincode query -n mycc -c '{"Args":["queryObjectives"]}' -C myc
 ```
 ##### Command output:
 ```json
-[
- {
-  "description": {
-   "checksum": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-   "storage_address": "https://toto/objective/222/description"
-  },
-  "key": "5c1d9cd1-c2c1-082d-de09-21b56d11030c",
-  "metadata": {},
-  "metrics": {
-   "checksum": "4a1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-   "name": "accuracy",
-   "storage_address": "https://toto/objective/222/metrics"
-  },
-  "name": "MSI classification",
-  "owner": "SampleOrg",
-  "permissions": {
-   "process": {
-    "authorized_ids": [],
-    "public": true
-   }
-  },
-  "test_dataset": {
-   "data_manager_key": "da1bb7c3-1f62-244c-0f3a-761cc1688042",
-   "data_sample_keys": [
-    "bb1bb7c3-1f62-244c-0f3a-761cc1688042",
-    "bb2bb7c3-1f62-244c-0f3a-761cc1688042"
-   ],
+{
+ "bookmarks": {
+  "objective~owner~key": ""
+ },
+ "result": [
+  {
+   "description": {
+    "checksum": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
+    "storage_address": "https://toto/objective/222/description"
+   },
+   "key": "5c1d9cd1-c2c1-082d-de09-21b56d11030c",
    "metadata": {},
-   "worker": ""
+   "metrics": {
+    "checksum": "4a1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
+    "name": "accuracy",
+    "storage_address": "https://toto/objective/222/metrics"
+   },
+   "name": "MSI classification",
+   "owner": "SampleOrg",
+   "permissions": {
+    "process": {
+     "authorized_ids": [],
+     "public": true
+    }
+   },
+   "test_dataset": {
+    "data_manager_key": "da1bb7c3-1f62-244c-0f3a-761cc1688042",
+    "data_sample_keys": [
+     "bb1bb7c3-1f62-244c-0f3a-761cc1688042",
+     "bb2bb7c3-1f62-244c-0f3a-761cc1688042"
+    ],
+    "metadata": {},
+    "worker": ""
+   }
   }
- }
-]
+ ]
+}
 ```
 #### ------------ Add Traintuple ------------
 Smart contract: `createTraintuple`
@@ -915,116 +930,121 @@ peer chaincode query -n mycc -c '{"Args":["queryTesttuples"]}' -C myc
 ```
 ##### Command output:
 ```json
-[
- {
-  "algo": {
-   "checksum": "fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
-   "key": "fd1bb7c3-1f62-244c-0f3a-761cc1688042",
-   "name": "hog + svm",
-   "storage_address": "https://toto/algo/222/algo"
-  },
-  "certified": false,
-  "compute_plan_key": "",
-  "creator": "SampleOrg",
-  "dataset": {
-   "data_sample_keys": [
-    "aa1bb7c3-1f62-244c-0f3a-761cc1688042",
-    "aa2bb7c3-1f62-244c-0f3a-761cc1688042"
-   ],
-   "key": "da1bb7c3-1f62-244c-0f3a-761cc1688042",
-   "opener_checksum": "da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
-   "perf": 0,
-   "worker": "SampleOrg"
-  },
-  "key": "dadada11-50f6-26d3-fa86-1bf6387e3896",
-  "log": "",
-  "metadata": {},
-  "objective": {
-   "key": "5c1d9cd1-c2c1-082d-de09-21b56d11030c",
-   "metrics": {
-    "checksum": "4a1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-    "storage_address": "https://toto/objective/222/metrics"
-   }
-  },
-  "rank": 0,
-  "status": "todo",
-  "tag": "",
-  "traintuple_key": "b0289ab8-3a71-f01e-2b72-0259a6452244",
-  "traintuple_type": "traintuple"
+{
+ "bookmarks": {
+  "testtuple~traintuple~certified~key": ""
  },
- {
-  "algo": {
-   "checksum": "fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
-   "key": "fd1bb7c3-1f62-244c-0f3a-761cc1688042",
-   "name": "hog + svm",
-   "storage_address": "https://toto/algo/222/algo"
+ "result": [
+  {
+   "algo": {
+    "checksum": "fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
+    "key": "fd1bb7c3-1f62-244c-0f3a-761cc1688042",
+    "name": "hog + svm",
+    "storage_address": "https://toto/algo/222/algo"
+   },
+   "certified": false,
+   "compute_plan_key": "",
+   "creator": "SampleOrg",
+   "dataset": {
+    "data_sample_keys": [
+     "aa1bb7c3-1f62-244c-0f3a-761cc1688042",
+     "aa2bb7c3-1f62-244c-0f3a-761cc1688042"
+    ],
+    "key": "da1bb7c3-1f62-244c-0f3a-761cc1688042",
+    "opener_checksum": "da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
+    "perf": 0,
+    "worker": "SampleOrg"
+   },
+   "key": "dadada11-50f6-26d3-fa86-1bf6387e3896",
+   "log": "",
+   "metadata": {},
+   "objective": {
+    "key": "5c1d9cd1-c2c1-082d-de09-21b56d11030c",
+    "metrics": {
+     "checksum": "4a1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
+     "storage_address": "https://toto/objective/222/metrics"
+    }
+   },
+   "rank": 0,
+   "status": "todo",
+   "tag": "",
+   "traintuple_key": "b0289ab8-3a71-f01e-2b72-0259a6452244",
+   "traintuple_type": "traintuple"
   },
-  "certified": true,
-  "compute_plan_key": "",
-  "creator": "SampleOrg",
-  "dataset": {
-   "data_sample_keys": [
-    "bb1bb7c3-1f62-244c-0f3a-761cc1688042",
-    "bb2bb7c3-1f62-244c-0f3a-761cc1688042"
-   ],
-   "key": "da1bb7c3-1f62-244c-0f3a-761cc1688042",
-   "opener_checksum": "da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
-   "perf": 0.9,
-   "worker": "SampleOrg"
+  {
+   "algo": {
+    "checksum": "fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
+    "key": "fd1bb7c3-1f62-244c-0f3a-761cc1688042",
+    "name": "hog + svm",
+    "storage_address": "https://toto/algo/222/algo"
+   },
+   "certified": true,
+   "compute_plan_key": "",
+   "creator": "SampleOrg",
+   "dataset": {
+    "data_sample_keys": [
+     "bb1bb7c3-1f62-244c-0f3a-761cc1688042",
+     "bb2bb7c3-1f62-244c-0f3a-761cc1688042"
+    ],
+    "key": "da1bb7c3-1f62-244c-0f3a-761cc1688042",
+    "opener_checksum": "da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
+    "perf": 0.9,
+    "worker": "SampleOrg"
+   },
+   "key": "bbbada11-50f6-26d3-fa86-1bf6387e3896",
+   "log": "no error, ah ah ah",
+   "metadata": {},
+   "objective": {
+    "key": "5c1d9cd1-c2c1-082d-de09-21b56d11030c",
+    "metrics": {
+     "checksum": "4a1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
+     "storage_address": "https://toto/objective/222/metrics"
+    }
+   },
+   "rank": 0,
+   "status": "done",
+   "tag": "",
+   "traintuple_key": "b0289ab8-3a71-f01e-2b72-0259a6452244",
+   "traintuple_type": "traintuple"
   },
-  "key": "bbbada11-50f6-26d3-fa86-1bf6387e3896",
-  "log": "no error, ah ah ah",
-  "metadata": {},
-  "objective": {
-   "key": "5c1d9cd1-c2c1-082d-de09-21b56d11030c",
-   "metrics": {
-    "checksum": "4a1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-    "storage_address": "https://toto/objective/222/metrics"
-   }
-  },
-  "rank": 0,
-  "status": "done",
-  "tag": "",
-  "traintuple_key": "b0289ab8-3a71-f01e-2b72-0259a6452244",
-  "traintuple_type": "traintuple"
- },
- {
-  "algo": {
-   "checksum": "fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
-   "key": "fd1bb7c3-1f62-244c-0f3a-761cc1688042",
-   "name": "hog + svm",
-   "storage_address": "https://toto/algo/222/algo"
-  },
-  "certified": true,
-  "compute_plan_key": "",
-  "creator": "SampleOrg",
-  "dataset": {
-   "data_sample_keys": [
-    "bb1bb7c3-1f62-244c-0f3a-761cc1688042",
-    "bb2bb7c3-1f62-244c-0f3a-761cc1688042"
-   ],
-   "key": "da1bb7c3-1f62-244c-0f3a-761cc1688042",
-   "opener_checksum": "da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
-   "perf": 0,
-   "worker": "SampleOrg"
-  },
-  "key": "cccada11-50f6-26d3-fa86-1bf6387e3896",
-  "log": "",
-  "metadata": {},
-  "objective": {
-   "key": "5c1d9cd1-c2c1-082d-de09-21b56d11030c",
-   "metrics": {
-    "checksum": "4a1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
-    "storage_address": "https://toto/objective/222/metrics"
-   }
-  },
-  "rank": 0,
-  "status": "waiting",
-  "tag": "",
-  "traintuple_key": "bbb89ab8-3a71-f01e-2b72-0259a6452244",
-  "traintuple_type": "traintuple"
- }
-]
+  {
+   "algo": {
+    "checksum": "fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
+    "key": "fd1bb7c3-1f62-244c-0f3a-761cc1688042",
+    "name": "hog + svm",
+    "storage_address": "https://toto/algo/222/algo"
+   },
+   "certified": true,
+   "compute_plan_key": "",
+   "creator": "SampleOrg",
+   "dataset": {
+    "data_sample_keys": [
+     "bb1bb7c3-1f62-244c-0f3a-761cc1688042",
+     "bb2bb7c3-1f62-244c-0f3a-761cc1688042"
+    ],
+    "key": "da1bb7c3-1f62-244c-0f3a-761cc1688042",
+    "opener_checksum": "da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
+    "perf": 0,
+    "worker": "SampleOrg"
+   },
+   "key": "cccada11-50f6-26d3-fa86-1bf6387e3896",
+   "log": "",
+   "metadata": {},
+   "objective": {
+    "key": "5c1d9cd1-c2c1-082d-de09-21b56d11030c",
+    "metrics": {
+     "checksum": "4a1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
+     "storage_address": "https://toto/objective/222/metrics"
+    }
+   },
+   "rank": 0,
+   "status": "waiting",
+   "tag": "",
+   "traintuple_key": "bbb89ab8-3a71-f01e-2b72-0259a6452244",
+   "traintuple_type": "traintuple"
+  }
+ ]
+}
 ```
 #### ------------ Query details about a model ------------
 Smart contract: `queryModelDetails`
@@ -1163,91 +1183,98 @@ peer chaincode query -n mycc -c '{"Args":["queryModels"]}' -C myc
 ```
 ##### Command output:
 ```json
-[
- {
-  "traintuple": {
-   "algo": {
-    "checksum": "fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
-    "key": "fd1bb7c3-1f62-244c-0f3a-761cc1688042",
-    "name": "hog + svm",
-    "storage_address": "https://toto/algo/222/algo"
-   },
-   "compute_plan_key": "",
-   "creator": "SampleOrg",
-   "dataset": {
-    "data_sample_keys": [
-     "aa1bb7c3-1f62-244c-0f3a-761cc1688042",
-     "aa2bb7c3-1f62-244c-0f3a-761cc1688042"
-    ],
-    "key": "da1bb7c3-1f62-244c-0f3a-761cc1688042",
-    "metadata": {},
-    "opener_checksum": "da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
-    "worker": "SampleOrg"
-   },
-   "in_models": null,
-   "key": "b0289ab8-3a71-f01e-2b72-0259a6452244",
-   "log": "no error, ah ah ah",
-   "metadata": {},
-   "out_model": {
-    "checksum": "eedbb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482eed",
-    "key": "eedbb7c3-1f62-244c-0f3a-761cc1688042",
-    "storage_address": "https://substrabac/model/toto"
-   },
-   "permissions": {
-    "process": {
-     "authorized_ids": [],
-     "public": true
-    }
-   },
-   "rank": 0,
-   "status": "done",
-   "tag": ""
-  }
+{
+ "bookmarks": {
+  "aggregatetuple~algo~key": "",
+  "compositeTraintuple~algo~key": "",
+  "traintuple~algo~key": ""
  },
- {
-  "traintuple": {
-   "algo": {
-    "checksum": "fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
-    "key": "fd1bb7c3-1f62-244c-0f3a-761cc1688042",
-    "name": "hog + svm",
-    "storage_address": "https://toto/algo/222/algo"
-   },
-   "compute_plan_key": "",
-   "creator": "SampleOrg",
-   "dataset": {
-    "data_sample_keys": [
-     "aa1bb7c3-1f62-244c-0f3a-761cc1688042",
-     "aa2bb7c3-1f62-244c-0f3a-761cc1688042"
-    ],
-    "key": "da1bb7c3-1f62-244c-0f3a-761cc1688042",
+ "result": [
+  {
+   "traintuple": {
+    "algo": {
+     "checksum": "fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
+     "key": "fd1bb7c3-1f62-244c-0f3a-761cc1688042",
+     "name": "hog + svm",
+     "storage_address": "https://toto/algo/222/algo"
+    },
+    "compute_plan_key": "",
+    "creator": "SampleOrg",
+    "dataset": {
+     "data_sample_keys": [
+      "aa1bb7c3-1f62-244c-0f3a-761cc1688042",
+      "aa2bb7c3-1f62-244c-0f3a-761cc1688042"
+     ],
+     "key": "da1bb7c3-1f62-244c-0f3a-761cc1688042",
+     "metadata": {},
+     "opener_checksum": "da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
+     "worker": "SampleOrg"
+    },
+    "in_models": null,
+    "key": "b0289ab8-3a71-f01e-2b72-0259a6452244",
+    "log": "no error, ah ah ah",
     "metadata": {},
-    "opener_checksum": "da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
-    "worker": "SampleOrg"
-   },
-   "in_models": [
-    {
+    "out_model": {
      "checksum": "eedbb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482eed",
-     "key": "b0289ab8-3a71-f01e-2b72-0259a6452244",
-     "storage_address": "https://substrabac/model/toto",
-     "traintuple_key": "b0289ab8-3a71-f01e-2b72-0259a6452244"
-    }
-   ],
-   "key": "bbb89ab8-3a71-f01e-2b72-0259a6452244",
-   "log": "",
-   "metadata": {},
-   "out_model": null,
-   "permissions": {
-    "process": {
-     "authorized_ids": [],
-     "public": true
-    }
-   },
-   "rank": 0,
-   "status": "todo",
-   "tag": ""
+     "key": "eedbb7c3-1f62-244c-0f3a-761cc1688042",
+     "storage_address": "https://substrabac/model/toto"
+    },
+    "permissions": {
+     "process": {
+      "authorized_ids": [],
+      "public": true
+     }
+    },
+    "rank": 0,
+    "status": "done",
+    "tag": ""
+   }
+  },
+  {
+   "traintuple": {
+    "algo": {
+     "checksum": "fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
+     "key": "fd1bb7c3-1f62-244c-0f3a-761cc1688042",
+     "name": "hog + svm",
+     "storage_address": "https://toto/algo/222/algo"
+    },
+    "compute_plan_key": "",
+    "creator": "SampleOrg",
+    "dataset": {
+     "data_sample_keys": [
+      "aa1bb7c3-1f62-244c-0f3a-761cc1688042",
+      "aa2bb7c3-1f62-244c-0f3a-761cc1688042"
+     ],
+     "key": "da1bb7c3-1f62-244c-0f3a-761cc1688042",
+     "metadata": {},
+     "opener_checksum": "da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
+     "worker": "SampleOrg"
+    },
+    "in_models": [
+     {
+      "checksum": "eedbb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482eed",
+      "key": "b0289ab8-3a71-f01e-2b72-0259a6452244",
+      "storage_address": "https://substrabac/model/toto",
+      "traintuple_key": "b0289ab8-3a71-f01e-2b72-0259a6452244"
+     }
+    ],
+    "key": "bbb89ab8-3a71-f01e-2b72-0259a6452244",
+    "log": "",
+    "metadata": {},
+    "out_model": null,
+    "permissions": {
+     "process": {
+      "authorized_ids": [],
+      "public": true
+     }
+    },
+    "rank": 0,
+    "status": "todo",
+    "tag": ""
+   }
   }
- }
-]
+ ]
+}
 ```
 #### ------------ Query model permissions ------------
 Smart contract: `queryModelPermissions`
@@ -1668,29 +1695,34 @@ peer chaincode invoke -n mycc -c '{"Args":["queryComputePlans"]}' -C myc
 ```
 ##### Command output:
 ```json
-[
- {
-  "aggregatetuple_keys": null,
-  "clean_models": false,
-  "composite_traintuple_keys": null,
-  "done_count": 0,
-  "id_to_key": {},
-  "key": "00000000-50f6-26d3-fa86-1bf6387e3896",
-  "metadata": {},
-  "status": "todo",
-  "tag": "a tag is simply a string",
-  "testtuple_keys": [
-   "11000033-50f6-26d3-fa86-1bf6387e3896",
-   "22000033-50f6-26d3-fa86-1bf6387e3896"
-  ],
-  "traintuple_keys": [
-   "11000000-50f6-26d3-fa86-1bf6387e3896",
-   "22000000-50f6-26d3-fa86-1bf6387e3896",
-   "33000000-50f6-26d3-fa86-1bf6387e3896"
-  ],
-  "tuple_count": 5
- }
-]
+{
+ "bookmarks": {
+  "computePlan~key": ""
+ },
+ "result": [
+  {
+   "aggregatetuple_keys": null,
+   "clean_models": false,
+   "composite_traintuple_keys": null,
+   "done_count": 0,
+   "id_to_key": {},
+   "key": "00000000-50f6-26d3-fa86-1bf6387e3896",
+   "metadata": {},
+   "status": "todo",
+   "tag": "a tag is simply a string",
+   "testtuple_keys": [
+    "11000033-50f6-26d3-fa86-1bf6387e3896",
+    "22000033-50f6-26d3-fa86-1bf6387e3896"
+   ],
+   "traintuple_keys": [
+    "11000000-50f6-26d3-fa86-1bf6387e3896",
+    "22000000-50f6-26d3-fa86-1bf6387e3896",
+    "33000000-50f6-26d3-fa86-1bf6387e3896"
+   ],
+   "tuple_count": 5
+  }
+ ]
+}
 ```
 #### ------------ Cancel a ComputePlan ------------
 Smart contract: `cancelComputePlan`

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -208,7 +208,7 @@ peer chaincode query -n mycc -c '{"Args":["queryDataManagers"]}' -C myc
  "bookmarks": {
   "dataManager~owner~key": ""
  },
- "result": [
+ "results": [
   {
    "description": {
     "checksum": "8d4bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482eee",
@@ -245,7 +245,7 @@ peer chaincode query -n mycc -c '{"Args":["queryDataSamples"]}' -C myc
  "bookmarks": {
   "dataSample~dataManager~key": ""
  },
- "result": [
+ "results": [
   {
    "data_manager_keys": [
     "da1bb7c3-1f62-244c-0f3a-761cc1688042"
@@ -288,7 +288,7 @@ peer chaincode query -n mycc -c '{"Args":["queryObjectives"]}' -C myc
  "bookmarks": {
   "objective~owner~key": ""
  },
- "result": [
+ "results": [
   {
    "description": {
     "checksum": "5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379",
@@ -934,7 +934,7 @@ peer chaincode query -n mycc -c '{"Args":["queryTesttuples"]}' -C myc
  "bookmarks": {
   "testtuple~traintuple~certified~key": ""
  },
- "result": [
+ "results": [
   {
    "algo": {
     "checksum": "fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc",
@@ -1189,7 +1189,7 @@ peer chaincode query -n mycc -c '{"Args":["queryModels"]}' -C myc
   "compositeTraintuple~algo~key": "",
   "traintuple~algo~key": ""
  },
- "result": [
+ "results": [
   {
    "traintuple": {
     "algo": {
@@ -1699,7 +1699,7 @@ peer chaincode invoke -n mycc -c '{"Args":["queryComputePlans"]}' -C myc
  "bookmarks": {
   "computePlan~key": ""
  },
- "result": [
+ "results": [
   {
    "aggregatetuple_keys": null,
    "clean_models": false,

--- a/chaincode/algo.go
+++ b/chaincode/algo.go
@@ -93,19 +93,27 @@ func queryAlgo(db *LedgerDB, args []string) (out outputAlgo, err error) {
 }
 
 // queryAlgos returns all algos of the ledger
-func queryAlgos(db *LedgerDB, args []string) (outAlgos []outputAlgo, bookmark string, err error) {
+func queryAlgos(db *LedgerDB, args []string) (outAlgos []outputAlgo, bookmarks map[string]string, err error) {
 	outAlgos = []outputAlgo{}
+	index := "algo~owner~key"
+	bookmarks = map[string]string{index: ""}
 
 	if len(args) > 1 {
 		err = errors.BadRequest("incorrect number of arguments, expecting at most one argument")
 		return
 	}
 
-	if len(args) == 1 {
-		bookmark = args[0]
+	if len(args) == 1 && args[0] != "" {
+		inp := inputBookmarks{}
+		err := AssetFromJSON(args, &inp)
+		if err != nil {
+			return nil, bookmarks, err
+		}
+		bookmarks = inp.Bookmarks
 	}
 
-	elementsKeys, bookmark, err := db.GetIndexKeysWithPagination("algo~owner~key", []string{"algo"}, OutputAssetPaginationHardLimit, bookmark)
+	elementsKeys, bookmark, err := db.GetIndexKeysWithPagination(index, []string{"algo"}, OutputAssetPaginationHardLimit, bookmarks[index])
+	bookmarks[index] = bookmark
 
 	if err != nil {
 		return
@@ -114,7 +122,7 @@ func queryAlgos(db *LedgerDB, args []string) (outAlgos []outputAlgo, bookmark st
 	for _, key := range elementsKeys {
 		algo, err := db.GetAlgo(key)
 		if err != nil {
-			return outAlgos, bookmark, err
+			return outAlgos, bookmarks, err
 		}
 		var out outputAlgo
 		out.Fill(algo)

--- a/chaincode/algo_aggregate_test.go
+++ b/chaincode/algo_aggregate_test.go
@@ -21,6 +21,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type AggregateAlgoResponse struct {
+	Result  []outputAggregateAlgo `json:"result"`
+	Author map[string]string `json:"bookmarks"`
+}
+
 func TestAggregateAlgo(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
@@ -76,9 +81,9 @@ func TestAggregateAlgo(t *testing.T) {
 	args = [][]byte{[]byte("queryAggregateAlgos")}
 	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying aggregate algos - status %d and message %s", resp.Status, resp.Message)
-	var algos []outputAggregateAlgo
+	var algos AggregateAlgoResponse
 	err = json.Unmarshal(resp.Payload, &algos)
 	assert.NoError(t, err, "while unmarshalling aggregate algos")
-	assert.Len(t, algos, 1)
-	assert.Exactly(t, expectedAlgo, algos[0], "return aggregate algo different from registered one")
+	assert.Len(t, algos.Result, 1)
+	assert.Exactly(t, expectedAlgo, algos.Result[0], "return aggregate algo different from registered one")
 }

--- a/chaincode/algo_aggregate_test.go
+++ b/chaincode/algo_aggregate_test.go
@@ -22,8 +22,8 @@ import (
 )
 
 type AggregateAlgoResponse struct {
-	Result  []outputAggregateAlgo `json:"results"`
-	Author map[string]string `json:"bookmarks"`
+	Results  []outputAggregateAlgo `json:"results"`
+	Bookmark string                `json:"bookmark"`
 }
 
 func TestAggregateAlgo(t *testing.T) {
@@ -84,6 +84,6 @@ func TestAggregateAlgo(t *testing.T) {
 	var algos AggregateAlgoResponse
 	err = json.Unmarshal(resp.Payload, &algos)
 	assert.NoError(t, err, "while unmarshalling aggregate algos")
-	assert.Len(t, algos.Result, 1)
-	assert.Exactly(t, expectedAlgo, algos.Result[0], "return aggregate algo different from registered one")
+	assert.Len(t, algos.Results, 1)
+	assert.Exactly(t, expectedAlgo, algos.Results[0], "return aggregate algo different from registered one")
 }

--- a/chaincode/algo_aggregate_test.go
+++ b/chaincode/algo_aggregate_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 type AggregateAlgoResponse struct {
-	Result  []outputAggregateAlgo `json:"result"`
+	Result  []outputAggregateAlgo `json:"results"`
 	Author map[string]string `json:"bookmarks"`
 }
 

--- a/chaincode/algo_composite.go
+++ b/chaincode/algo_composite.go
@@ -93,10 +93,9 @@ func queryCompositeAlgo(db *LedgerDB, args []string) (out outputCompositeAlgo, e
 }
 
 // queryCompositeAlgos returns all algos of the ledger
-func queryCompositeAlgos(db *LedgerDB, args []string) (outAlgos []outputCompositeAlgo, bookmarks map[string]string, err error) {
+func queryCompositeAlgos(db *LedgerDB, args []string) (outAlgos []outputCompositeAlgo, bookmark string, err error) {
+	inp := inputBookmark{}
 	outAlgos = []outputCompositeAlgo{}
-	index := "compositeAlgo~owner~key"
-	bookmarks = map[string]string{index: ""}
 
 	if len(args) > 1 {
 		err = errors.BadRequest("incorrect number of arguments, expecting at most one argument")
@@ -104,16 +103,13 @@ func queryCompositeAlgos(db *LedgerDB, args []string) (outAlgos []outputComposit
 	}
 
 	if len(args) == 1 && args[0] != "" {
-		inp := inputBookmarks{}
-		err := AssetFromJSON(args, &inp)
+		err = AssetFromJSON(args, &inp)
 		if err != nil {
-			return nil, bookmarks, err
+			return
 		}
-		bookmarks = inp.Bookmarks
 	}
 
-	elementsKeys, bookmark, err := db.GetIndexKeysWithPagination(index, []string{"compositeAlgo"}, OutputAssetPaginationHardLimit, bookmarks[index])
-	bookmarks[index] = bookmark
+	elementsKeys, bookmark, err := db.GetIndexKeysWithPagination("compositeAlgo~owner~key", []string{"compositeAlgo"}, OutputPageSize, inp.Bookmark)
 
 	if err != nil {
 		return
@@ -122,7 +118,7 @@ func queryCompositeAlgos(db *LedgerDB, args []string) (outAlgos []outputComposit
 	for _, key := range elementsKeys {
 		algo, err := db.GetCompositeAlgo(key)
 		if err != nil {
-			return outAlgos, bookmarks, err
+			return outAlgos, bookmark, err
 		}
 		var out outputCompositeAlgo
 		out.Fill(algo)

--- a/chaincode/algo_composite_test.go
+++ b/chaincode/algo_composite_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 type CompositeAlgoResponse struct {
-	Result  []outputCompositeAlgo `json:"result"`
+	Result  []outputCompositeAlgo `json:"results"`
 	Author map[string]string `json:"bookmarks"`
 }
 

--- a/chaincode/algo_composite_test.go
+++ b/chaincode/algo_composite_test.go
@@ -21,6 +21,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type CompositeAlgoResponse struct {
+	Result  []outputCompositeAlgo `json:"result"`
+	Author map[string]string `json:"bookmarks"`
+}
+
 func TestCompositeAlgo(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
@@ -76,9 +81,9 @@ func TestCompositeAlgo(t *testing.T) {
 	args = [][]byte{[]byte("queryCompositeAlgos")}
 	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying composite algos - status %d and message %s", resp.Status, resp.Message)
-	var algos []outputCompositeAlgo
+	var algos CompositeAlgoResponse
 	err = json.Unmarshal(resp.Payload, &algos)
 	assert.NoError(t, err, "while unmarshalling composite algos")
-	assert.Len(t, algos, 1)
-	assert.Exactly(t, expectedAlgo, algos[0], "return composite algo different from registered one")
+	assert.Len(t, algos.Result, 1)
+	assert.Exactly(t, expectedAlgo, algos.Result[0], "return composite algo different from registered one")
 }

--- a/chaincode/algo_composite_test.go
+++ b/chaincode/algo_composite_test.go
@@ -22,8 +22,8 @@ import (
 )
 
 type CompositeAlgoResponse struct {
-	Result  []outputCompositeAlgo `json:"results"`
-	Author map[string]string `json:"bookmarks"`
+	Results []outputCompositeAlgo `json:"results"`
+	Author  map[string]string     `json:"bookmarks"`
 }
 
 func TestCompositeAlgo(t *testing.T) {
@@ -84,6 +84,6 @@ func TestCompositeAlgo(t *testing.T) {
 	var algos CompositeAlgoResponse
 	err = json.Unmarshal(resp.Payload, &algos)
 	assert.NoError(t, err, "while unmarshalling composite algos")
-	assert.Len(t, algos.Result, 1)
-	assert.Exactly(t, expectedAlgo, algos.Result[0], "return composite algo different from registered one")
+	assert.Len(t, algos.Results, 1)
+	assert.Exactly(t, expectedAlgo, algos.Results[0], "return composite algo different from registered one")
 }

--- a/chaincode/algo_test.go
+++ b/chaincode/algo_test.go
@@ -21,6 +21,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+
+type AlgoResponse struct {
+	Result  []outputAlgo `json:"result"`
+	Author map[string]string `json:"bookmarks"`
+}
+
 func TestAlgo(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
@@ -71,9 +77,9 @@ func TestAlgo(t *testing.T) {
 	args = [][]byte{[]byte("queryAlgos")}
 	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying algos - status %d and message %s", resp.Status, resp.Message)
-	var algos []outputAlgo
+	var algos AlgoResponse
 	err = json.Unmarshal(resp.Payload, &algos)
 	assert.NoError(t, err, "while unmarshalling algos")
-	assert.Len(t, algos, 1)
-	assert.Exactly(t, expectedAlgo, algos[0], "return algo different from registered one")
+	assert.Len(t, algos.Result, 1)
+	assert.Exactly(t, expectedAlgo, algos.Result[0], "return algo different from registered one")
 }

--- a/chaincode/algo_test.go
+++ b/chaincode/algo_test.go
@@ -21,10 +21,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-
 type AlgoResponse struct {
-	Result  []outputAlgo `json:"results"`
-	Author map[string]string `json:"bookmarks"`
+	Results  []outputAlgo `json:"results"`
+	Bookmark string       `json:"bookmark"`
 }
 
 func TestAlgo(t *testing.T) {
@@ -80,6 +79,6 @@ func TestAlgo(t *testing.T) {
 	var algos AlgoResponse
 	err = json.Unmarshal(resp.Payload, &algos)
 	assert.NoError(t, err, "while unmarshalling algos")
-	assert.Len(t, algos.Result, 1)
-	assert.Exactly(t, expectedAlgo, algos.Result[0], "return algo different from registered one")
+	assert.Len(t, algos.Results, 1)
+	assert.Exactly(t, expectedAlgo, algos.Results[0], "return algo different from registered one")
 }

--- a/chaincode/algo_test.go
+++ b/chaincode/algo_test.go
@@ -23,7 +23,7 @@ import (
 
 
 type AlgoResponse struct {
-	Result  []outputAlgo `json:"result"`
+	Result  []outputAlgo `json:"results"`
 	Author map[string]string `json:"bookmarks"`
 }
 

--- a/chaincode/compute_plan_test.go
+++ b/chaincode/compute_plan_test.go
@@ -309,14 +309,14 @@ func TestCreateComputePlanCompositeAggregate(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check the composite traintuples
-	traintuples, err := queryCompositeTraintuples(db, []string{})
+	traintuples, _, err := queryCompositeTraintuples(db, []string{})
 	assert.NoError(t, err)
 	require.Len(t, traintuples, 2)
 	require.Contains(t, outCP.CompositeTraintupleKeys, traintuples[0].Key)
 	require.Contains(t, outCP.CompositeTraintupleKeys, traintuples[1].Key)
 
 	// Check the aggregate traintuples
-	aggtuples, err := queryAggregatetuples(db, []string{})
+	aggtuples, _, err := queryAggregatetuples(db, []string{})
 	assert.NoError(t, err)
 	require.Len(t, aggtuples, 2)
 	require.Contains(t, outCP.AggregatetupleKeys, aggtuples[0].Key)
@@ -330,7 +330,7 @@ func TestCreateComputePlanCompositeAggregate(t *testing.T) {
 	assert.Equal(t, 2, len(cp.AggregatetupleKeys))
 
 	// Query compute plans
-	cps, err := queryComputePlans(db, []string{})
+	cps, _, err := queryComputePlans(db, []string{})
 	assert.NoError(t, err, "calling queryComputePlans should succeed")
 	assert.Len(t, cps, 1, "queryComputePlans should return one compute plan")
 	assert.Equal(t, 2, len(cps[0].CompositeTraintupleKeys))
@@ -352,7 +352,7 @@ func TestCreateComputePlan(t *testing.T) {
 	validateDefaultComputePlan(t, outCP)
 
 	// Check the traintuples
-	traintuples, err := queryTraintuples(db, []string{})
+	traintuples, _, err := queryTraintuples(db, []string{})
 	assert.NoError(t, err)
 	assert.Len(t, traintuples, 2)
 	require.Contains(t, outCP.TraintupleKeys, traintuples[0].Key)
@@ -387,7 +387,7 @@ func TestCreateComputePlan(t *testing.T) {
 	assert.Equal(t, StatusWaiting, second.Status)
 
 	// Check the testtuples
-	testtuples, err := queryTesttuples(db, []string{})
+	testtuples, _, err := queryTesttuples(db, []string{})
 	assert.NoError(t, err)
 	require.Len(t, testtuples, 1)
 	testtuple := testtuples[0]
@@ -430,7 +430,7 @@ func TestQueryComputePlans(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, outCP)
 
-	cps, err := queryComputePlans(db, []string{})
+	cps, _, err := queryComputePlans(db, []string{})
 	assert.NoError(t, err, "calling queryComputePlans should succeed")
 	assert.Len(t, cps, 1, "queryComputePlans should return one compute plan")
 	validateDefaultComputePlan(t, cps[0])
@@ -487,7 +487,7 @@ func TestComputePlanEmptyTesttuples(t *testing.T) {
 	assert.NotNil(t, cp)
 	assert.Len(t, outCP.TesttupleKeys, 0)
 
-	cps, err := queryComputePlans(db, []string{})
+	cps, _, err := queryComputePlans(db, []string{})
 	assert.NoError(t, err, "calling queryComputePlans should succeed")
 	assert.Len(t, cps, 1, "queryComputePlans should return one compute plan")
 	assert.Len(t, cps[0].TesttupleKeys, 0)
@@ -501,7 +501,7 @@ func TestQueryComputePlanEmpty(t *testing.T) {
 	mockStub.MockTransactionStart("42")
 	db := NewLedgerDB(mockStub)
 
-	cps, err := queryComputePlans(db, []string{})
+	cps, _, err := queryComputePlans(db, []string{})
 	assert.NoError(t, err, "calling queryComputePlans should succeed")
 	assert.Equal(t, []outputComputePlan{}, cps)
 }
@@ -525,7 +525,7 @@ func TestCancelComputePlan(t *testing.T) {
 	computePlan, err := getOutComputePlan(db, out.Key)
 	assert.Equal(t, StatusCanceled, computePlan.Status)
 
-	tuples, err := queryCompositeTraintuples(db, []string{})
+	tuples, _, err := queryCompositeTraintuples(db, []string{})
 	assert.NoError(t, err)
 
 	nbAborted, nbTodo := 0, 0
@@ -541,7 +541,7 @@ func TestCancelComputePlan(t *testing.T) {
 	assert.Equal(t, nbAborted, 2)
 	assert.Equal(t, nbTodo, 2)
 
-	tests, err := queryTesttuples(db, []string{})
+	tests, _, err := queryTesttuples(db, []string{})
 	assert.NoError(t, err)
 	for _, test := range tests {
 		assert.Equal(t, StatusAborted, test.Status)
@@ -569,7 +569,7 @@ func TestStartedTuplesOfCanceledComputePlan(t *testing.T) {
 	computePlan, err := getOutComputePlan(db, out.Key)
 	assert.Equal(t, StatusCanceled, computePlan.Status)
 
-	tuples, err := queryCompositeTraintuples(db, []string{})
+	tuples, _, err := queryCompositeTraintuples(db, []string{})
 	assert.NoError(t, err)
 	for _, tuple := range tuples {
 		if tuple.Rank == 0 {

--- a/chaincode/data.go
+++ b/chaincode/data.go
@@ -260,10 +260,9 @@ func queryDataManager(db *LedgerDB, args []string) (out outputDataManager, err e
 }
 
 // queryDataManagers returns all DataManagers of the ledger
-func queryDataManagers(db *LedgerDB, args []string) (outDataManagers []outputDataManager, bookmarks map[string]string, err error) {
+func queryDataManagers(db *LedgerDB, args []string) (outDataManagers []outputDataManager, bookmark string, err error) {
+	inp := inputBookmark{}
 	outDataManagers = []outputDataManager{}
-	index := "dataManager~owner~key"
-	bookmarks = map[string]string{index: ""}
 
 	if len(args) > 1 {
 		err = errors.BadRequest("incorrect number of arguments, expecting at most one argument")
@@ -271,16 +270,13 @@ func queryDataManagers(db *LedgerDB, args []string) (outDataManagers []outputDat
 	}
 
 	if len(args) == 1 && args[0] != "" {
-		inp := inputBookmarks{}
-		err := AssetFromJSON(args, &inp)
+		err = AssetFromJSON(args, &inp)
 		if err != nil {
-			return nil, bookmarks, err
+			return
 		}
-		bookmarks = inp.Bookmarks
 	}
 
-	elementsKeys, bookmark, err := db.GetIndexKeysWithPagination(index, []string{"dataManager"}, OutputAssetPaginationHardLimit, bookmarks[index])
-	bookmarks[index] = bookmark
+	elementsKeys, bookmark, err := db.GetIndexKeysWithPagination("dataManager~owner~key", []string{"dataManager"}, OutputPageSize, inp.Bookmark)
 
 	if err != nil {
 		return
@@ -289,7 +285,7 @@ func queryDataManagers(db *LedgerDB, args []string) (outDataManagers []outputDat
 	for _, key := range elementsKeys {
 		dataManager, err := db.GetDataManager(key)
 		if err != nil {
-			return outDataManagers, bookmarks, err
+			return outDataManagers, bookmark, err
 		}
 		var out outputDataManager
 		out.Fill(dataManager)
@@ -328,10 +324,9 @@ func queryDataset(db *LedgerDB, args []string) (outputDataset, error) {
 	return out, nil
 }
 
-func queryDataSamples(db *LedgerDB, args []string) (outDataSamples []outputDataSample, bookmarks map[string]string, err error) {
+func queryDataSamples(db *LedgerDB, args []string) (outDataSamples []outputDataSample, bookmark string, err error) {
+	inp := inputBookmark{}
 	outDataSamples = []outputDataSample{}
-	index := "dataSample~dataManager~key"
-	bookmarks = map[string]string{index: ""}
 
 	if len(args) > 1 {
 		err = errors.BadRequest("incorrect number of arguments, expecting at most one argument")
@@ -339,16 +334,13 @@ func queryDataSamples(db *LedgerDB, args []string) (outDataSamples []outputDataS
 	}
 
 	if len(args) == 1 && args[0] != "" {
-		inp := inputBookmarks{}
-		err := AssetFromJSON(args, &inp)
+		err = AssetFromJSON(args, &inp)
 		if err != nil {
-			return nil, bookmarks, err
+			return
 		}
-		bookmarks = inp.Bookmarks
 	}
 
-	elementsKeys, bookmark, err := db.GetIndexKeysWithPagination(index, []string{"dataSample"}, OutputAssetPaginationHardLimit, bookmarks[index])
-	bookmarks[index] = bookmark
+	elementsKeys, bookmark, err := db.GetIndexKeysWithPagination("dataSample~dataManager~key", []string{"dataSample"}, OutputPageSize, inp.Bookmark)
 
 	if err != nil {
 		return
@@ -357,7 +349,7 @@ func queryDataSamples(db *LedgerDB, args []string) (outDataSamples []outputDataS
 	for _, key := range elementsKeys {
 		dataSample, err := db.GetDataSample(key)
 		if err != nil {
-			return outDataSamples, bookmarks, err
+			return outDataSamples, bookmark, err
 		}
 		var out outputDataSample
 		out.Fill(key, dataSample)

--- a/chaincode/data_test.go
+++ b/chaincode/data_test.go
@@ -33,6 +33,13 @@ func TestJsonInputsDataManager(t *testing.T) {
 	resp := mockStub.MockInvoke(args)
 	assert.EqualValues(t, 200, resp.Status)
 }
+
+type DataManagerResponse struct {
+	Result  []outputDataManager `json:"result"`
+	Author map[string]string `json:"bookmarks"`
+}
+
+
 func TestDataManager(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
@@ -90,11 +97,11 @@ func TestDataManager(t *testing.T) {
 	args = [][]byte{[]byte("queryDataManagers")}
 	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying dataManagers - status %d and message %s", resp.Status, resp.Message)
-	var dataManagers []outputDataManager
+	var dataManagers DataManagerResponse
 	err = json.Unmarshal(resp.Payload, &dataManagers)
 	assert.NoError(t, err, "while unmarshalling dataManagers")
-	assert.Len(t, dataManagers, 1)
-	assert.Exactly(t, expectedDataManager, dataManagers[0], "return objective different from registered one")
+	assert.Len(t, dataManagers.Result, 1)
+	assert.Exactly(t, expectedDataManager, dataManagers.Result[0], "return objective different from registered one")
 
 	args = [][]byte{[]byte("queryDataset"), keyToJSON(inpDataManager.Key)}
 	resp = mockStub.MockInvoke(args)

--- a/chaincode/data_test.go
+++ b/chaincode/data_test.go
@@ -35,7 +35,7 @@ func TestJsonInputsDataManager(t *testing.T) {
 }
 
 type DataManagerResponse struct {
-	Result  []outputDataManager `json:"result"`
+	Result  []outputDataManager `json:"results"`
 	Author map[string]string `json:"bookmarks"`
 }
 

--- a/chaincode/data_test.go
+++ b/chaincode/data_test.go
@@ -35,10 +35,9 @@ func TestJsonInputsDataManager(t *testing.T) {
 }
 
 type DataManagerResponse struct {
-	Result  []outputDataManager `json:"results"`
-	Author map[string]string `json:"bookmarks"`
+	Results  []outputDataManager `json:"results"`
+	Bookmark string              `json:"bookmark"`
 }
-
 
 func TestDataManager(t *testing.T) {
 	scc := new(SubstraChaincode)
@@ -100,8 +99,8 @@ func TestDataManager(t *testing.T) {
 	var dataManagers DataManagerResponse
 	err = json.Unmarshal(resp.Payload, &dataManagers)
 	assert.NoError(t, err, "while unmarshalling dataManagers")
-	assert.Len(t, dataManagers.Result, 1)
-	assert.Exactly(t, expectedDataManager, dataManagers.Result[0], "return objective different from registered one")
+	assert.Len(t, dataManagers.Results, 1)
+	assert.Exactly(t, expectedDataManager, dataManagers.Results[0], "return objective different from registered one")
 
 	args = [][]byte{[]byte("queryDataset"), keyToJSON(inpDataManager.Key)}
 	resp = mockStub.MockInvoke(args)

--- a/chaincode/input.go
+++ b/chaincode/input.go
@@ -122,8 +122,8 @@ type inputKey struct {
 	Key string `validate:"required,len=36" json:"key"`
 }
 
-type inputBookmark struct {
-	Bookmark string `validate:"required" json:"bookmark"`
+type inputBookmarks struct {
+	Bookmarks map[string]string `validate:"required,dive,keys,endkeys" json:"bookmarks"`
 }
 
 type inputLogSuccessTrain struct {

--- a/chaincode/input.go
+++ b/chaincode/input.go
@@ -122,8 +122,8 @@ type inputKey struct {
 	Key string `validate:"required,len=36" json:"key"`
 }
 
-type inputBookmarks struct {
-	Bookmarks map[string]string `validate:"required,dive,keys,endkeys" json:"bookmarks"`
+type inputBookmark struct {
+	Bookmark string `validate:"required" json:"bookmark"`
 }
 
 type inputLogSuccessTrain struct {

--- a/chaincode/input.go
+++ b/chaincode/input.go
@@ -122,6 +122,10 @@ type inputKey struct {
 	Key string `validate:"required,len=36" json:"key"`
 }
 
+type inputBookmark struct {
+	Bookmark string `validate:"required" json:"bookmark"`
+}
+
 type inputLogSuccessTrain struct {
 	inputLog
 	OutModel inputKeyChecksumAddress `validate:"required" json:"out_model"`

--- a/chaincode/input.go
+++ b/chaincode/input.go
@@ -123,7 +123,7 @@ type inputKey struct {
 }
 
 type inputBookmark struct {
-	Bookmark string `validate:"required" json:"bookmark"`
+	Bookmark string `json:"bookmark"`
 }
 
 type inputLogSuccessTrain struct {

--- a/chaincode/ledger_db.go
+++ b/chaincode/ledger_db.go
@@ -181,6 +181,13 @@ func (db *LedgerDB) GetIndexKeys(index string, attributes []string) ([]string, e
 func (db *LedgerDB) GetIndexKeysWithPagination(index string, attributes []string, pageSize int32, bookmark string) ([]string, string, error) {
 	keys := make([]string, 0)
 
+
+	/*
+	compositeKeyNamespace = "\x00"
+	minUnicodeRuneValue   = 0            //U+0000
+	maxUnicodeRuneValue   = utf8.MaxRune //U+10FFFF - maximum (and unallocated) code point
+	*/
+
 	if bookmark != "" {
 		// replace composite key substra delimiters "/" by couchDB delimiters
 		bookmark = strings.Replace(bookmark, "/", "\x00", -1)

--- a/chaincode/ledger_db.go
+++ b/chaincode/ledger_db.go
@@ -181,6 +181,16 @@ func (db *LedgerDB) GetIndexKeys(index string, attributes []string) ([]string, e
 func (db *LedgerDB) GetIndexKeysWithPagination(index string, attributes []string, pageSize int32, bookmark string) ([]string, string, error) {
 	keys := make([]string, 0)
 
+	if bookmark != "" {
+		inp := inputBookmark{}
+		err := AssetFromJSON([]string{bookmark}, &inp)
+		if err != nil {
+			return nil, "", err
+		}
+		bookmark = inp.Bookmark
+	}
+
+
 	// replace composite key substra delimiter "/" by couchDB delimiter "\x00"
 	bookmark = strings.Replace(bookmark, "/", "\x00", -1)
 

--- a/chaincode/ledger_db.go
+++ b/chaincode/ledger_db.go
@@ -181,10 +181,12 @@ func (db *LedgerDB) GetIndexKeys(index string, attributes []string) ([]string, e
 func (db *LedgerDB) GetIndexKeysWithPagination(index string, attributes []string, pageSize int32, bookmark string) ([]string, string, error) {
 	keys := make([]string, 0)
 
-	// replace composite key substra delimiters "/" by couchDB delimiters
-	bookmark = strings.Replace(bookmark, "/", "\x00", -1)
-	bookmark = strings.Replace(bookmark, "#", "\\u0000", -1)
-	bookmark = strings.Replace(bookmark, "END", "\U0010ffff", -1)
+	if bookmark != "" {
+		// replace composite key substra delimiters "/" by couchDB delimiters
+		bookmark = strings.Replace(bookmark, "/", "\x00", -1)
+		bookmark = strings.Replace(bookmark, "#", "\\u0000", -1)
+		bookmark = strings.Replace(bookmark, "END", "\U0010ffff", -1)
+	}
 
 	iterator, metadata, err := db.cc.GetStateByPartialCompositeKeyWithPagination(index, attributes, pageSize, bookmark)
 	if err != nil {
@@ -203,10 +205,12 @@ func (db *LedgerDB) GetIndexKeysWithPagination(index string, attributes []string
 		keys = append(keys, keyParts[len(keyParts)-1])
 	}
 
-	// replace composite key couchDB delimiters by substra delimiters
-	bookmark = strings.Replace(metadata.Bookmark, "\x00", "/", -1)
-	bookmark = strings.Replace(bookmark, "\\u0000", "#", -1)
-	bookmark = strings.Replace(bookmark, "\U0010ffff", "END", -1)
+	if metadata != nil {
+		// replace composite key couchDB delimiters by substra delimiters
+		bookmark = strings.Replace(metadata.Bookmark, "\x00", "/", -1)
+		bookmark = strings.Replace(bookmark, "\\u0000", "#", -1)
+		bookmark = strings.Replace(bookmark, "\U0010ffff", "END", -1)
+	}
 
 	return keys, bookmark, nil
 }

--- a/chaincode/ledger_db.go
+++ b/chaincode/ledger_db.go
@@ -177,19 +177,12 @@ func (db *LedgerDB) GetIndexKeys(index string, attributes []string) ([]string, e
 	return keys, nil
 }
 
-// GetIndexKeys returns keys matching composite key values from the chaincode db
+// GetIndexKeysWithPagination returns keys matching composite key values from the chaincode db
 func (db *LedgerDB) GetIndexKeysWithPagination(index string, attributes []string, pageSize int32, bookmark string) ([]string, string, error) {
 	keys := make([]string, 0)
 
-
-	/*
-	compositeKeyNamespace = "\x00"
-	minUnicodeRuneValue   = 0            //U+0000
-	maxUnicodeRuneValue   = utf8.MaxRune //U+10FFFF - maximum (and unallocated) code point
-	*/
-
 	if bookmark != "" {
-		// replace composite key substra delimiters "/" by couchDB delimiters
+		// Transform bookmark from JSON-friendly format to CouchDB format
 		bookmark = strings.Replace(bookmark, "/", "\x00", -1)
 		bookmark = strings.Replace(bookmark, "#", "\\u0000", -1)
 		bookmark = strings.Replace(bookmark, "END", "\U0010ffff", -1)
@@ -213,7 +206,7 @@ func (db *LedgerDB) GetIndexKeysWithPagination(index string, attributes []string
 	}
 
 	if metadata != nil {
-		// replace composite key couchDB delimiters by substra delimiters
+		// Transform bookmark from CouchDB format to JSON-friendly format
 		bookmark = strings.Replace(metadata.Bookmark, "\x00", "/", -1)
 		bookmark = strings.Replace(bookmark, "\\u0000", "#", -1)
 		bookmark = strings.Replace(bookmark, "\U0010ffff", "END", -1)
@@ -221,7 +214,6 @@ func (db *LedgerDB) GetIndexKeysWithPagination(index string, attributes []string
 
 	return keys, bookmark, nil
 }
-
 
 // ----------------------------------------------
 // High-level functions

--- a/chaincode/ledger_db.go
+++ b/chaincode/ledger_db.go
@@ -181,18 +181,10 @@ func (db *LedgerDB) GetIndexKeys(index string, attributes []string) ([]string, e
 func (db *LedgerDB) GetIndexKeysWithPagination(index string, attributes []string, pageSize int32, bookmark string) ([]string, string, error) {
 	keys := make([]string, 0)
 
-	if bookmark != "" {
-		inp := inputBookmark{}
-		err := AssetFromJSON([]string{bookmark}, &inp)
-		if err != nil {
-			return nil, "", err
-		}
-		bookmark = inp.Bookmark
-	}
-
-
-	// replace composite key substra delimiter "/" by couchDB delimiter "\x00"
+	// replace composite key substra delimiters "/" by couchDB delimiters
 	bookmark = strings.Replace(bookmark, "/", "\x00", -1)
+	bookmark = strings.Replace(bookmark, "#", "\\u0000", -1)
+	bookmark = strings.Replace(bookmark, "END", "\U0010ffff", -1)
 
 	iterator, metadata, err := db.cc.GetStateByPartialCompositeKeyWithPagination(index, attributes, pageSize, bookmark)
 	if err != nil {
@@ -211,8 +203,10 @@ func (db *LedgerDB) GetIndexKeysWithPagination(index string, attributes []string
 		keys = append(keys, keyParts[len(keyParts)-1])
 	}
 
-	// replace composite key couchDB delimiter "\x00" by substra delimiter "/"
+	// replace composite key couchDB delimiters by substra delimiters
 	bookmark = strings.Replace(metadata.Bookmark, "\x00", "/", -1)
+	bookmark = strings.Replace(bookmark, "\\u0000", "#", -1)
+	bookmark = strings.Replace(bookmark, "\U0010ffff", "END", -1)
 
 	return keys, bookmark, nil
 }

--- a/chaincode/main.go
+++ b/chaincode/main.go
@@ -70,7 +70,7 @@ func (t *SubstraChaincode) Invoke(stub shim.ChaincodeStubInterface) peer.Respons
 	db := NewLedgerDB(stub)
 
 	var result interface{}
-	var bookmark string
+	var bookmarks map[string]string
 
 	switch fn {
 	case "createComputePlan":
@@ -112,21 +112,21 @@ func (t *SubstraChaincode) Invoke(stub shim.ChaincodeStubInterface) peer.Respons
 	case "queryAlgo":
 		result, err = queryAlgo(db, args)
 	case "queryAlgos":
-		result, bookmark, err = queryAlgos(db, args)
+		result, bookmarks, err = queryAlgos(db, args)
 	case "queryCompositeAlgo":
 		result, err = queryCompositeAlgo(db, args)
 	case "queryCompositeAlgos":
-		result, bookmark, err = queryCompositeAlgos(db, args)
+		result, bookmarks, err = queryCompositeAlgos(db, args)
 	case "queryAggregateAlgo":
 		result, err = queryAggregateAlgo(db, args)
 	case "queryAggregateAlgos":
-		result, bookmark, err = queryAggregateAlgos(db, args)
+		result, bookmarks, err = queryAggregateAlgos(db, args)
 	case "queryDataManager":
 		result, err = queryDataManager(db, args)
 	case "queryDataManagers":
-		result, bookmark, err = queryDataManagers(db, args)
+		result, bookmarks, err = queryDataManagers(db, args)
 	case "queryDataSamples":
-		result, bookmark, err = queryDataSamples(db, args)
+		result, bookmarks, err = queryDataSamples(db, args)
 	case "queryDataset":
 		result, err = queryDataset(db, args)
 	case "queryFilter":
@@ -136,17 +136,17 @@ func (t *SubstraChaincode) Invoke(stub shim.ChaincodeStubInterface) peer.Respons
 	case "queryModelPermissions":
 		result, err = queryModelPermissions(db, args)
 	case "queryModels":
-		result, bookmark, err = queryModels(db, args)
+		result, bookmarks, err = queryModels(db, args)
 	case "queryObjective":
 		result, err = queryObjective(db, args)
 	case "queryObjectiveLeaderboard":
 		result, err = queryObjectiveLeaderboard(db, args)
 	case "queryObjectives":
-		result, bookmark, err = queryObjectives(db, args)
+		result, bookmarks, err = queryObjectives(db, args)
 	case "queryTesttuple":
 		result, err = queryTesttuple(db, args)
 	case "queryTesttuples":
-		result, bookmark, err = queryTesttuples(db, args)
+		result, bookmarks, err = queryTesttuples(db, args)
 	case "queryTraintuple":
 		result, err = queryTraintuple(db, args)
 	case "queryCompositeTraintuple":
@@ -154,15 +154,15 @@ func (t *SubstraChaincode) Invoke(stub shim.ChaincodeStubInterface) peer.Respons
 	case "queryAggregatetuple":
 		result, err = queryAggregatetuple(db, args)
 	case "queryTraintuples":
-		result, bookmark, err = queryTraintuples(db, args)
+		result, bookmarks, err = queryTraintuples(db, args)
 	case "queryCompositeTraintuples":
-		result, bookmark, err = queryCompositeTraintuples(db, args)
+		result, bookmarks, err = queryCompositeTraintuples(db, args)
 	case "queryAggregatetuples":
-		result, bookmark, err = queryAggregatetuples(db, args)
+		result, bookmarks, err = queryAggregatetuples(db, args)
 	case "queryComputePlan":
 		result, err = queryComputePlan(db, args)
 	case "queryComputePlans":
-		result, bookmark, err = queryComputePlans(db, args)
+		result, bookmarks, err = queryComputePlans(db, args)
 	case "registerAlgo":
 		result, err = registerAlgo(db, args)
 	case "registerCompositeAlgo":
@@ -193,25 +193,24 @@ func (t *SubstraChaincode) Invoke(stub shim.ChaincodeStubInterface) peer.Respons
 	duration := int(time.Since(start).Nanoseconds()) / 1e6
 	// Return the result as success payload
 	if err != nil {
-		logger.Errorf("[%s][%s] Response (%dms): '%#v','%s' - Error: '%s'", stub.GetChannelID(), stub.GetTxID()[:10], duration, result, bookmark, err)
+		logger.Errorf("[%s][%s] Response (%dms): '%#v','%s' - Error: '%s'", stub.GetChannelID(), stub.GetTxID()[:10], duration, result, bookmarks, err)
 		return formatErrorResponse(err)
 	}
 
 	// Marshal to json the smartcontract result
 	var resp []byte
-
-	if bookmark != "" {
-		// Marshal to json the smartcontract result + bookmark
+	if len(bookmarks) != 0 {
+		// Marshal to json the smartcontract result + bookmarks
 		resp, err = json.Marshal(map[string]interface{}{
-			"response": result,
-			"bookmark": bookmark})
+			"result": result,
+			"bookmarks": bookmarks})
 	} else {
 		// Marshal to json the smartcontract result
 		resp, err = json.Marshal(result)
 	}
 
 	if err != nil {
-		logger.Infof("[%s][%s] Response (%dms): '%#v','%s'", stub.GetChannelID(), stub.GetTxID()[:10], duration, result, bookmark)
+		logger.Infof("[%s][%s] Response (%dms): '%#v','%s'", stub.GetChannelID(), stub.GetTxID()[:10], duration, result, bookmarks)
 		return formatErrorResponse(errors.Internal("could not format response: %s", err.Error()))
 	}
 

--- a/chaincode/main.go
+++ b/chaincode/main.go
@@ -202,7 +202,7 @@ func (t *SubstraChaincode) Invoke(stub shim.ChaincodeStubInterface) peer.Respons
 	if len(bookmarks) != 0 {
 		// Marshal to json the smartcontract result + bookmarks
 		resp, err = json.Marshal(map[string]interface{}{
-			"result": result,
+			"results": result,
 			"bookmarks": bookmarks})
 	} else {
 		// Marshal to json the smartcontract result

--- a/chaincode/main_test.go
+++ b/chaincode/main_test.go
@@ -342,10 +342,10 @@ func TestQueryEmptyResponse(t *testing.T) {
 			args := [][]byte{[]byte(contractName)}
 			resp := mockStub.MockInvoke(args)
 
-			expectedResult := map[string]interface{}{
+			expectedPayload := map[string]interface{}{
 				"result":   make([]string, 0),
 				"bookmark": ""}
-			assert.Equal(t, expectedResult, resp.Payload, "payload is not an empty list")
+			assert.Equal(t, expectedPayload, resp.Payload, "payload is not an empty list")
 		})
 	}
 }

--- a/chaincode/main_test.go
+++ b/chaincode/main_test.go
@@ -342,9 +342,10 @@ func TestQueryEmptyResponse(t *testing.T) {
 			args := [][]byte{[]byte(contractName)}
 			resp := mockStub.MockInvoke(args)
 
-			expectedPayload := map[string]interface{}{
-				"result":   make([]string, 0),
+			expectedResult := map[string]interface{}{
+				"results":  make([]string, 0),
 				"bookmark": ""}
+			expectedPayload, _ := json.Marshal(expectedResult)
 			assert.Equal(t, expectedPayload, resp.Payload, "payload is not an empty list")
 		})
 	}

--- a/chaincode/main_test.go
+++ b/chaincode/main_test.go
@@ -342,9 +342,17 @@ func TestQueryEmptyResponse(t *testing.T) {
 			args := [][]byte{[]byte(contractName)}
 			resp := mockStub.MockInvoke(args)
 
+			expectedBookmark := ""
+			if contractName == "queryModels" {
+				// special case for queryModels: we return a map instead of a string
+				expectedBookmarkBytes, _ := json.Marshal(queryModelsBookmarks{})
+				expectedBookmark = string(expectedBookmarkBytes)
+			}
+
 			expectedResult := map[string]interface{}{
 				"results":  make([]string, 0),
-				"bookmark": ""}
+				"bookmark": expectedBookmark}
+
 			expectedPayload, _ := json.Marshal(expectedResult)
 			assert.Equal(t, expectedPayload, resp.Payload, "payload is not an empty list")
 		})

--- a/chaincode/main_test.go
+++ b/chaincode/main_test.go
@@ -342,8 +342,10 @@ func TestQueryEmptyResponse(t *testing.T) {
 			args := [][]byte{[]byte(contractName)}
 			resp := mockStub.MockInvoke(args)
 
-			expectedPayload, _ := json.Marshal(make([]string, 0))
-			assert.Equal(t, expectedPayload, resp.Payload, "payload is not an empty list")
+			expectedResult := map[string]interface{}{
+				"result":   make([]string, 0),
+				"bookmark": ""}
+			assert.Equal(t, expectedResult, resp.Payload, "payload is not an empty list")
 		})
 	}
 }

--- a/chaincode/mockstub_test.go
+++ b/chaincode/mockstub_test.go
@@ -337,7 +337,11 @@ func (stub *MockStub) GetStateByRangeWithPagination(startKey, endKey string, pag
 
 func (stub *MockStub) GetStateByPartialCompositeKeyWithPagination(objectType string, keys []string,
 	pageSize int32, bookmark string) (shim.StateQueryIteratorInterface, *pb.QueryResponseMetadata, error) {
-	return nil, nil, nil
+	partialCompositeKey, err := stub.CreateCompositeKey(objectType, keys)
+	if err != nil {
+		return nil, nil, err
+	}
+	return NewMockStateRangeQueryIterator(stub, partialCompositeKey, partialCompositeKey+string(maxUnicodeRuneValue)), nil, nil
 }
 
 func (stub *MockStub) GetQueryResultWithPagination(query string, pageSize int32,

--- a/chaincode/mockstub_test.go
+++ b/chaincode/mockstub_test.go
@@ -283,7 +283,7 @@ func (stub *MockStub) GetStateByRange(startKey, endKey string) (shim.StateQueryI
 	if err := validateSimpleKeys(startKey, endKey); err != nil {
 		return nil, err
 	}
-	return NewMockStateRangeQueryIterator(stub, startKey, endKey), nil
+	return NewMockStateRangeQueryIterator(stub, startKey, endKey, false, OutputPageSize), nil
 }
 
 // GetQueryResult function can be invoked by a chaincode to perform a
@@ -315,7 +315,7 @@ func (stub *MockStub) GetStateByPartialCompositeKey(objectType string, attribute
 	if err != nil {
 		return nil, err
 	}
-	return NewMockStateRangeQueryIterator(stub, partialCompositeKey, partialCompositeKey+string(maxUnicodeRuneValue)), nil
+	return NewMockStateRangeQueryIterator(stub, partialCompositeKey, partialCompositeKey+string(maxUnicodeRuneValue), false, OutputPageSize), nil
 }
 
 // CreateCompositeKey combines the list of attributes
@@ -341,7 +341,12 @@ func (stub *MockStub) GetStateByPartialCompositeKeyWithPagination(objectType str
 	if err != nil {
 		return nil, nil, err
 	}
-	return NewMockStateRangeQueryIterator(stub, partialCompositeKey, partialCompositeKey+string(maxUnicodeRuneValue)), nil, nil
+	startKey := partialCompositeKey
+	if bookmark != "" {
+		startKey = bookmark
+	}
+	iterator := NewMockStateRangeQueryIterator(stub, startKey, partialCompositeKey+string(maxUnicodeRuneValue), true, pageSize)
+	return iterator, iterator.Metadata, nil
 }
 
 func (stub *MockStub) GetQueryResultWithPagination(query string, pageSize int32,
@@ -490,7 +495,7 @@ func NewMockStub(name string, cc shim.Chaincode) *MockStub {
 	s.EndorsementPolicies = make(map[string]map[string][]byte)
 	s.Invokables = make(map[string]*MockStub)
 	s.Keys = list.New()
-	s.ChaincodeEventsChannel = make(chan *pb.ChaincodeEvent, 100) //define large capacity for non-blocking setEvent calls.
+	s.ChaincodeEventsChannel = make(chan *pb.ChaincodeEvent, OutputPageSize+1) //define large capacity for non-blocking setEvent calls.
 	s.Decorations = make(map[string][]byte)
 	s.TxTimestamp = &timestamp.Timestamp{}
 
@@ -509,11 +514,14 @@ func NewMockStubWithRegisterNode(name string, cc shim.Chaincode) *MockStub {
 *****************************/
 
 type MockStateRangeQueryIterator struct {
-	Closed   bool
-	Stub     *MockStub
-	StartKey string
-	EndKey   string
-	Current  *list.Element
+	Closed      bool
+	Stub        *MockStub
+	StartKey    string
+	EndKey      string
+	Current     *list.Element
+	IsPaginated bool
+	PageSize    int32
+	Metadata    *pb.QueryResponseMetadata
 }
 
 // HasNext returns true if the range query iterator contains additional keys
@@ -534,12 +542,17 @@ func (iter *MockStateRangeQueryIterator) HasNext() bool {
 		if iter.StartKey == "" && iter.EndKey == "" {
 			return true
 		}
+		// iterator has already yielded enough results
+		if iter.IsPaginated && iter.Metadata.FetchedRecordsCount == iter.PageSize {
+			return false
+		}
 		comp1 := strings.Compare(current.Value.(string), iter.StartKey)
 		comp2 := strings.Compare(current.Value.(string), iter.EndKey)
 		if comp1 >= 0 {
 			if comp2 < 0 {
 				return true
 			}
+			iter.Metadata.Bookmark = ""
 			return false
 		}
 		current = current.Next()
@@ -561,6 +574,10 @@ func (iter *MockStateRangeQueryIterator) Next() (*queryresult.KV, error) {
 		return nil, err
 	}
 
+	if iter.Current != nil && iter.IsPaginated && iter.Metadata.FetchedRecordsCount >= iter.PageSize {
+		return nil, errors.New("Paginated MockStateRangeQueryIterator.Next() went past end of range")
+	}
+
 	for iter.Current != nil {
 		comp1 := strings.Compare(iter.Current.Value.(string), iter.StartKey)
 		comp2 := strings.Compare(iter.Current.Value.(string), iter.EndKey)
@@ -570,6 +587,12 @@ func (iter *MockStateRangeQueryIterator) Next() (*queryresult.KV, error) {
 			key := iter.Current.Value.(string)
 			value, err := iter.Stub.GetState(key)
 			iter.Current = iter.Current.Next()
+			if iter.Current != nil {
+				iter.Metadata.Bookmark = iter.Current.Value.(string)
+			} else {
+				iter.Metadata.Bookmark = ""
+			}
+			iter.Metadata.FetchedRecordsCount++
 			return &queryresult.KV{Key: key, Value: value}, err
 		}
 		iter.Current = iter.Current.Next()
@@ -593,13 +616,16 @@ func (iter *MockStateRangeQueryIterator) Close() error {
 func (iter *MockStateRangeQueryIterator) Print() {
 }
 
-func NewMockStateRangeQueryIterator(stub *MockStub, startKey string, endKey string) *MockStateRangeQueryIterator {
+func NewMockStateRangeQueryIterator(stub *MockStub, startKey string, endKey string, isPaginated bool, pageSize int32) *MockStateRangeQueryIterator {
 	iter := new(MockStateRangeQueryIterator)
 	iter.Closed = false
 	iter.Stub = stub
 	iter.StartKey = startKey
 	iter.EndKey = endKey
 	iter.Current = stub.Keys.Front()
+	iter.IsPaginated = isPaginated
+	iter.PageSize = pageSize
+	iter.Metadata = &pb.QueryResponseMetadata{}
 
 	iter.Print()
 

--- a/chaincode/node.go
+++ b/chaincode/node.go
@@ -14,6 +14,10 @@
 
 package main
 
+import (
+	"chaincode/errors"
+)
+
 func registerNode(db *LedgerDB, args []string) (Node, error) {
 	txCreator, err := GetTxCreator(db.cc)
 	if err != nil {
@@ -46,21 +50,28 @@ func registerNode(db *LedgerDB, args []string) (Node, error) {
 	return node, nil
 }
 
-func queryNodes(db *LedgerDB, args []string) (resp []Node, err error) {
+func queryNodes(db *LedgerDB, args []string) (nodes []Node, err error) {
+	nodes = []Node{}
+
 	elementsKeys, err := db.GetIndexKeys("node~key", []string{"node"})
-	if err != nil {
-		return nil, err
+
+	if len(args) != 0 {
+		err = errors.BadRequest("incorrect number of arguments, expecting at most one argument")
+		return
 	}
 
-	nodes := []Node{}
+	if err != nil {
+		return
+	}
+
 	for _, key := range elementsKeys {
 		node, err := db.GetNode(key)
 		if err != nil {
-			return nil, err
+			return nodes, err
 		}
 
 		nodes = append(nodes, node)
 	}
 
-	return nodes, nil
+	return
 }

--- a/chaincode/objective_test.go
+++ b/chaincode/objective_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 type ObjectiveResponse struct {
-	Result  []outputObjective `json:"result"`
+	Result  []outputObjective `json:"results"`
 	Author map[string]string `json:"bookmarks"`
 }
 

--- a/chaincode/objective_test.go
+++ b/chaincode/objective_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 type ObjectiveResponse struct {
-	Result  []outputObjective `json:"results"`
-	Author map[string]string `json:"bookmarks"`
+	Results  []outputObjective `json:"results"`
+	Bookmark string            `json:"bookmark"`
 }
 
 func TestLeaderBoard(t *testing.T) {
@@ -188,6 +188,6 @@ func TestObjective(t *testing.T) {
 	var objectives ObjectiveResponse
 	err = json.Unmarshal(resp.Payload, &objectives)
 	assert.NoError(t, err, "while unmarshalling objectives")
-	assert.Len(t, objectives.Result, 1)
-	assert.Exactly(t, expectedObjective, objectives.Result[0], "return objective different from registered one")
+	assert.Len(t, objectives.Results, 1)
+	assert.Exactly(t, expectedObjective, objectives.Results[0], "return objective different from registered one")
 }

--- a/chaincode/objective_test.go
+++ b/chaincode/objective_test.go
@@ -22,6 +22,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type ObjectiveResponse struct {
+	Result  []outputObjective `json:"result"`
+	Author map[string]string `json:"bookmarks"`
+}
+
 func TestLeaderBoard(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
@@ -180,9 +185,9 @@ func TestObjective(t *testing.T) {
 	args = [][]byte{[]byte("queryObjectives")}
 	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying objectives - status %d and message %s", resp.Status, resp.Message)
-	var objectives []outputObjective
+	var objectives ObjectiveResponse
 	err = json.Unmarshal(resp.Payload, &objectives)
 	assert.NoError(t, err, "while unmarshalling objectives")
-	assert.Len(t, objectives, 1)
-	assert.Exactly(t, expectedObjective, objectives[0], "return objective different from registered one")
+	assert.Len(t, objectives.Result, 1)
+	assert.Exactly(t, expectedObjective, objectives.Result[0], "return objective different from registered one")
 }

--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -20,7 +20,7 @@ import (
 )
 
 // OutputPageSize is a used to avoid issues listing assets
-const OutputPageSize = 5 // 500
+const OutputPageSize = 500
 
 // Struct use as output representation of ledger data
 

--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -19,8 +19,8 @@ import (
 	"math"
 )
 
-// OutputAssetPaginationHardLimit is a used to avoid issues listing assets
-const OutputAssetPaginationHardLimit = 5 // 500
+// OutputPageSize is a used to avoid issues listing assets
+const OutputPageSize = 5 // 500
 
 // Struct use as output representation of ledger data
 
@@ -424,7 +424,7 @@ func (out *outputBoardTuple) Fill(db *LedgerDB, in Testtuple, testtupleKey strin
 }
 
 func getLimitedNbSliceElements(s []string) int {
-	return int(math.Min(float64(len(s)), OutputAssetPaginationHardLimit))
+	return int(math.Min(float64(len(s)), OutputPageSize))
 }
 
 type outputKey struct {

--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -20,7 +20,7 @@ import (
 )
 
 // OutputAssetPaginationHardLimit is a used to avoid issues listing assets
-const OutputAssetPaginationHardLimit = 500
+const OutputAssetPaginationHardLimit = 5 // 500
 
 // Struct use as output representation of ledger data
 

--- a/chaincode/testtuple_test.go
+++ b/chaincode/testtuple_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 type TesttupleResponse struct {
-	Result []outputTesttuple `json:"result"`
+	Result []outputTesttuple `json:"results"`
 	Author map[string]string `json:"bookmarks"`
 }
 

--- a/chaincode/testtuple_test.go
+++ b/chaincode/testtuple_test.go
@@ -23,6 +23,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type TesttupleResponse struct {
+	Result []outputTesttuple `json:"result"`
+	Author map[string]string `json:"bookmarks"`
+}
+
 func TestTesttupleOnFailedTraintuple(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
@@ -68,11 +73,11 @@ func TestCertifiedExplicitTesttuple(t *testing.T) {
 
 	args = [][]byte{[]byte("queryTesttuples")}
 	resp = mockStub.MockInvoke(args)
-	testtuples := [](map[string]interface{}){}
+	var testtuples TesttupleResponse
 	err := json.Unmarshal(resp.Payload, &testtuples)
 	assert.NoError(t, err, "should be unmarshaled")
-	assert.Len(t, testtuples, 1, "there should be only one testtuple...")
-	assert.True(t, testtuples[0]["certified"].(bool), "... and it should be certified")
+	assert.Len(t, testtuples.Result, 1, "there should be only one testtuple...")
+	assert.True(t, testtuples.Result[0].Certified, "... and it should be certified")
 
 }
 

--- a/chaincode/testtuple_test.go
+++ b/chaincode/testtuple_test.go
@@ -24,8 +24,8 @@ import (
 )
 
 type TesttupleResponse struct {
-	Result []outputTesttuple `json:"results"`
-	Author map[string]string `json:"bookmarks"`
+	Results  []outputTesttuple `json:"results"`
+	Bookmark string            `json:"bookmark"`
 }
 
 func TestTesttupleOnFailedTraintuple(t *testing.T) {
@@ -76,8 +76,8 @@ func TestCertifiedExplicitTesttuple(t *testing.T) {
 	var testtuples TesttupleResponse
 	err := json.Unmarshal(resp.Payload, &testtuples)
 	assert.NoError(t, err, "should be unmarshaled")
-	assert.Len(t, testtuples.Result, 1, "there should be only one testtuple...")
-	assert.True(t, testtuples.Result[0].Certified, "... and it should be certified")
+	assert.Len(t, testtuples.Results, 1, "there should be only one testtuple...")
+	assert.True(t, testtuples.Results[0].Certified, "... and it should be certified")
 
 }
 

--- a/chaincode/traintuple.go
+++ b/chaincode/traintuple.go
@@ -385,10 +385,9 @@ func queryTraintuple(db *LedgerDB, args []string) (outputTraintuple outputTraint
 }
 
 // queryTraintuples returns all traintuples
-func queryTraintuples(db *LedgerDB, args []string) (outTraintuples []outputTraintuple, bookmarks map[string]string, err error) {
+func queryTraintuples(db *LedgerDB, args []string) (outTraintuples []outputTraintuple, bookmark string, err error) {
+	inp := inputBookmark{}
 	outTraintuples = []outputTraintuple{}
-	index := "traintuple~algo~key"
-	bookmarks = map[string]string{index: ""}
 
 	if len(args) > 1 {
 		err = errors.BadRequest("incorrect number of arguments, expecting at most one argument")
@@ -396,16 +395,13 @@ func queryTraintuples(db *LedgerDB, args []string) (outTraintuples []outputTrain
 	}
 
 	if len(args) == 1 && args[0] != "" {
-		inp := inputBookmarks{}
-		err := AssetFromJSON(args, &inp)
+		err = AssetFromJSON(args, &inp)
 		if err != nil {
-			return nil, bookmarks, err
+			return
 		}
-		bookmarks = inp.Bookmarks
 	}
 
-	elementsKeys, bookmark, err := db.GetIndexKeysWithPagination(index, []string{"traintuple"}, OutputAssetPaginationHardLimit, bookmarks[index])
-	bookmarks[index] = bookmark
+	elementsKeys, bookmark, err := db.GetIndexKeysWithPagination("traintuple~algo~key", []string{"traintuple"}, OutputPageSize, inp.Bookmark)
 
 	if err != nil {
 		return
@@ -414,7 +410,7 @@ func queryTraintuples(db *LedgerDB, args []string) (outTraintuples []outputTrain
 	for _, key := range elementsKeys {
 		outputTraintuple, err := getOutputTraintuple(db, key)
 		if err != nil {
-			return outTraintuples, bookmarks, err
+			return outTraintuples, bookmark, err
 		}
 		outTraintuples = append(outTraintuples, outputTraintuple)
 	}

--- a/chaincode/traintuple.go
+++ b/chaincode/traintuple.go
@@ -385,25 +385,31 @@ func queryTraintuple(db *LedgerDB, args []string) (outputTraintuple outputTraint
 }
 
 // queryTraintuples returns all traintuples
-func queryTraintuples(db *LedgerDB, args []string) ([]outputTraintuple, error) {
-	outTraintuples := []outputTraintuple{}
+func queryTraintuples(db *LedgerDB, args []string) (outTraintuples []outputTraintuple, bookmark string, err error) {
+	outTraintuples = []outputTraintuple{}
 
-	if len(args) != 0 {
-		err := errors.BadRequest("incorrect number of arguments, expecting nothing")
-		return outTraintuples, err
+	if len(args) > 1 {
+		err = errors.BadRequest("incorrect number of arguments, expecting at most one argument")
+		return
 	}
-	elementsKeys, err := db.GetIndexKeys("traintuple~algo~key", []string{"traintuple"})
+
+	if len(args) == 1 {
+		bookmark = args[0]
+	}
+
+	elementsKeys, bookmark, err := db.GetIndexKeysWithPagination("traintuple~algo~key", []string{"traintuple"}, OutputAssetPaginationHardLimit, bookmark)
 	if err != nil {
-		return outTraintuples, err
+		return
 	}
+
 	for _, key := range elementsKeys {
 		outputTraintuple, err := getOutputTraintuple(db, key)
 		if err != nil {
-			return outTraintuples, err
+			return outTraintuples, bookmark, err
 		}
 		outTraintuples = append(outTraintuples, outputTraintuple)
 	}
-	return outTraintuples, nil
+	return
 }
 
 // -----------------------------------------------

--- a/chaincode/traintuple_composite.go
+++ b/chaincode/traintuple_composite.go
@@ -439,10 +439,9 @@ func queryCompositeTraintuple(db *LedgerDB, args []string) (outputTraintuple out
 }
 
 // queryCompositeTraintuples returns all composite traintuples
-func queryCompositeTraintuples(db *LedgerDB, args []string) (outTraintuples[]outputCompositeTraintuple, bookmarks map[string]string, err error) {
+func queryCompositeTraintuples(db *LedgerDB, args []string) (outTraintuples []outputCompositeTraintuple, bookmark string, err error) {
+	inp := inputBookmark{}
 	outTraintuples = []outputCompositeTraintuple{}
-	index := "compositeTraintuple~algo~key"
-	bookmarks = map[string]string{index: ""}
 
 	if len(args) > 1 {
 		err = errors.BadRequest("incorrect number of arguments, expecting at most one argument")
@@ -450,16 +449,13 @@ func queryCompositeTraintuples(db *LedgerDB, args []string) (outTraintuples[]out
 	}
 
 	if len(args) == 1 && args[0] != "" {
-		inp := inputBookmarks{}
-		err := AssetFromJSON(args, &inp)
+		err = AssetFromJSON(args, &inp)
 		if err != nil {
-			return nil, bookmarks, err
+			return
 		}
-		bookmarks = inp.Bookmarks
 	}
 
-	elementsKeys, bookmark, err := db.GetIndexKeysWithPagination(index, []string{"compositeTraintuple"}, OutputAssetPaginationHardLimit, bookmarks[index])
-	bookmarks[index] = bookmark
+	elementsKeys, bookmark, err := db.GetIndexKeysWithPagination("compositeTraintuple~algo~key", []string{"compositeTraintuple"}, OutputPageSize, inp.Bookmark)
 
 	if err != nil {
 		return
@@ -468,7 +464,7 @@ func queryCompositeTraintuples(db *LedgerDB, args []string) (outTraintuples[]out
 	for _, key := range elementsKeys {
 		outputTraintuple, err := getOutputCompositeTraintuple(db, key)
 		if err != nil {
-			return outTraintuples, bookmarks, err
+			return outTraintuples, bookmark, err
 		}
 		outTraintuples = append(outTraintuples, outputTraintuple)
 	}

--- a/chaincode/traintuple_composite_test.go
+++ b/chaincode/traintuple_composite_test.go
@@ -34,10 +34,9 @@ import (
 /////////////////////////////////////////////////////////////
 
 type CompositeTraintupleResponse struct {
-	Result []outputCompositeTraintuple  `json:"results"`
-	Author map[string]string `json:"bookmarks"`
+	Results  []outputCompositeTraintuple `json:"results"`
+	Bookmark string                      `json:"bookmark"`
 }
-
 
 func TestTraintupleWithNoTestDatasetComposite(t *testing.T) {
 	scc := new(SubstraChaincode)
@@ -334,7 +333,7 @@ func TestTraintupleComposite(t *testing.T) {
 	err = json.Unmarshal(resp.Payload, &queryTraintuples)
 	assert.NoError(t, err, "composite traintuples should unmarshal without problem")
 	require.NotZero(t, queryTraintuples)
-	assert.Exactly(t, out, queryTraintuples.Result[0])
+	assert.Exactly(t, out, queryTraintuples.Results[0])
 
 	// Add traintuple with inmodel from the above-submitted traintuple
 	inpWaitingTraintuple := inputCompositeTraintuple{

--- a/chaincode/traintuple_composite_test.go
+++ b/chaincode/traintuple_composite_test.go
@@ -33,6 +33,12 @@ import (
 //
 /////////////////////////////////////////////////////////////
 
+type CompositeTraintupleResponse struct {
+	Result []outputCompositeTraintuple  `json:"result"`
+	Author map[string]string `json:"bookmarks"`
+}
+
+
 func TestTraintupleWithNoTestDatasetComposite(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
@@ -324,11 +330,11 @@ func TestTraintupleComposite(t *testing.T) {
 	// TODO add traintuple key to output struct
 	// For now we test it as cleanly as its added to the query response
 	assert.Contains(t, string(resp.Payload), "key\":\""+compositeTraintupleKey)
-	var queryTraintuples []outputCompositeTraintuple
+	var queryTraintuples CompositeTraintupleResponse
 	err = json.Unmarshal(resp.Payload, &queryTraintuples)
 	assert.NoError(t, err, "composite traintuples should unmarshal without problem")
 	require.NotZero(t, queryTraintuples)
-	assert.Exactly(t, out, queryTraintuples[0])
+	assert.Exactly(t, out, queryTraintuples.Result[0])
 
 	// Add traintuple with inmodel from the above-submitted traintuple
 	inpWaitingTraintuple := inputCompositeTraintuple{
@@ -347,9 +353,10 @@ func TestTraintupleComposite(t *testing.T) {
 	args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
 	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying composite traintuple of worker with todo status - status %d and message %s", resp.Status, resp.Message)
-	err = json.Unmarshal(resp.Payload, &queryTraintuples)
+	var queryTraintuplesF []outputCompositeTraintuple
+	err = json.Unmarshal(resp.Payload, &queryTraintuplesF)
 	assert.NoError(t, err, "composite traintuples should unmarshal without problem")
-	assert.Exactly(t, out, queryTraintuples[0])
+	assert.Exactly(t, out, queryTraintuplesF[0])
 
 	// Update status and check consistency
 	success := inputLogSuccessCompositeTrain{}

--- a/chaincode/traintuple_composite_test.go
+++ b/chaincode/traintuple_composite_test.go
@@ -34,7 +34,7 @@ import (
 /////////////////////////////////////////////////////////////
 
 type CompositeTraintupleResponse struct {
-	Result []outputCompositeTraintuple  `json:"result"`
+	Result []outputCompositeTraintuple  `json:"results"`
 	Author map[string]string `json:"bookmarks"`
 }
 

--- a/chaincode/traintuple_test.go
+++ b/chaincode/traintuple_test.go
@@ -24,10 +24,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-
 type TraintupleResponse struct {
-	Result []outputTraintuple  `json:"results"`
-	Author map[string]string `json:"bookmarks"`
+	Results  []outputTraintuple `json:"results"`
+	Bookmark string             `json:"bookmark"`
 }
 
 func TestTraintupleWithNoTestDataset(t *testing.T) {
@@ -327,7 +326,7 @@ func TestTraintuple(t *testing.T) {
 	var queryTraintuples TraintupleResponse
 	err = json.Unmarshal(resp.Payload, &queryTraintuples)
 	assert.NoError(t, err, "traintuples should unmarshal without problem")
-	assert.Exactly(t, out, queryTraintuples.Result[0])
+	assert.Exactly(t, out, queryTraintuples.Results[0])
 
 	// Add traintuple with inmodel from the above-submitted traintuple
 	inpWaitingTraintuple := inputTraintuple{

--- a/chaincode/traintuple_test.go
+++ b/chaincode/traintuple_test.go
@@ -26,7 +26,7 @@ import (
 
 
 type TraintupleResponse struct {
-	Result []outputTraintuple  `json:"result"`
+	Result []outputTraintuple  `json:"results"`
 	Author map[string]string `json:"bookmarks"`
 }
 

--- a/chaincode/traintuple_test.go
+++ b/chaincode/traintuple_test.go
@@ -24,6 +24,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+
+type TraintupleResponse struct {
+	Result []outputTraintuple  `json:"result"`
+	Author map[string]string `json:"bookmarks"`
+}
+
 func TestTraintupleWithNoTestDataset(t *testing.T) {
 	scc := new(SubstraChaincode)
 	mockStub := NewMockStubWithRegisterNode("substra", scc)
@@ -318,10 +324,10 @@ func TestTraintuple(t *testing.T) {
 	// TODO add traintuple key to output struct
 	// For now we test it as cleanly as its added to the query response
 	assert.Contains(t, string(resp.Payload), "key\":\""+traintupleKey)
-	var queryTraintuples []outputTraintuple
+	var queryTraintuples TraintupleResponse
 	err = json.Unmarshal(resp.Payload, &queryTraintuples)
 	assert.NoError(t, err, "traintuples should unmarshal without problem")
-	assert.Exactly(t, out, queryTraintuples[0])
+	assert.Exactly(t, out, queryTraintuples.Result[0])
 
 	// Add traintuple with inmodel from the above-submitted traintuple
 	inpWaitingTraintuple := inputTraintuple{
@@ -341,9 +347,10 @@ func TestTraintuple(t *testing.T) {
 	args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
 	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying traintuple of worker with todo status - status %d and message %s", resp.Status, resp.Message)
-	err = json.Unmarshal(resp.Payload, &queryTraintuples)
+	var queryTraintuplesF []outputTraintuple
+	err = json.Unmarshal(resp.Payload, &queryTraintuplesF)
 	assert.NoError(t, err, "traintuples should unmarshal without problem")
-	assert.Exactly(t, out, queryTraintuples[0])
+	assert.Exactly(t, out, queryTraintuplesF[0])
 
 	// Update status and check consistency
 	success := inputLogSuccessTrain{}

--- a/chaincode/tuple_aggregate_test.go
+++ b/chaincode/tuple_aggregate_test.go
@@ -31,7 +31,7 @@ import (
 //
 /////////////////////////////////////////////////////////////
 type AggregatetupleResponse struct {
-	Result  []outputAggregatetuple `json:"result"`
+	Result  []outputAggregatetuple `json:"results"`
 	Author map[string]string `json:"bookmarks"`
 }
 

--- a/chaincode/tuple_aggregate_test.go
+++ b/chaincode/tuple_aggregate_test.go
@@ -30,6 +30,11 @@ import (
 // Copied from `traintuple_test.go` and adapted for aggregate
 //
 /////////////////////////////////////////////////////////////
+type AggregatetupleResponse struct {
+	Result  []outputAggregatetuple `json:"result"`
+	Author map[string]string `json:"bookmarks"`
+}
+
 
 func TestTraintupleWithNoTestDatasetAggregate(t *testing.T) {
 	scc := new(SubstraChaincode)
@@ -284,11 +289,11 @@ func TestTraintupleAggregate(t *testing.T) {
 	// TODO add traintuple key to output struct
 	// For now we test it as cleanly as its added to the query response
 	assert.Contains(t, string(resp.Payload), "key\":\""+aggregatetupleKey)
-	var queryTraintuples []outputAggregatetuple
+	var queryTraintuples AggregatetupleResponse
 	err = json.Unmarshal(resp.Payload, &queryTraintuples)
 	assert.NoError(t, err, "aggregate tuples should unmarshal without problem")
 	require.NotZero(t, queryTraintuples)
-	assert.Exactly(t, out, queryTraintuples[0])
+	assert.Exactly(t, out, queryTraintuples.Result[0])
 
 	// Add traintuple with inmodel from the above-submitted traintuple
 	inpWaitingTraintuple := inputAggregatetuple{
@@ -307,9 +312,10 @@ func TestTraintupleAggregate(t *testing.T) {
 	args = [][]byte{[]byte("queryFilter"), assetToJSON(filter)}
 	resp = mockStub.MockInvoke(args)
 	assert.EqualValuesf(t, 200, resp.Status, "when querying aggregate tuple of worker with todo status - status %d and message %s", resp.Status, resp.Message)
-	err = json.Unmarshal(resp.Payload, &queryTraintuples)
+	var queryTraintuplesF []outputAggregatetuple
+	err = json.Unmarshal(resp.Payload, &queryTraintuplesF)
 	assert.NoError(t, err, "aggregate tuples should unmarshal without problem")
-	assert.Exactly(t, out, queryTraintuples[0])
+	assert.Exactly(t, out, queryTraintuplesF[0])
 
 	// Update status and check consistency
 	success := inputLogSuccessTrain{}

--- a/chaincode/tuple_aggregate_test.go
+++ b/chaincode/tuple_aggregate_test.go
@@ -31,10 +31,9 @@ import (
 //
 /////////////////////////////////////////////////////////////
 type AggregatetupleResponse struct {
-	Result  []outputAggregatetuple `json:"results"`
-	Author map[string]string `json:"bookmarks"`
+	Results  []outputAggregatetuple `json:"results"`
+	Bookmark string                 `json:"bookmark"`
 }
-
 
 func TestTraintupleWithNoTestDatasetAggregate(t *testing.T) {
 	scc := new(SubstraChaincode)
@@ -293,7 +292,7 @@ func TestTraintupleAggregate(t *testing.T) {
 	err = json.Unmarshal(resp.Payload, &queryTraintuples)
 	assert.NoError(t, err, "aggregate tuples should unmarshal without problem")
 	require.NotZero(t, queryTraintuples)
-	assert.Exactly(t, out, queryTraintuples.Result[0])
+	assert.Exactly(t, out, queryTraintuples.Results[0])
 
 	// Add traintuple with inmodel from the above-submitted traintuple
 	inpWaitingTraintuple := inputAggregatetuple{

--- a/chaincode/tuple_test.go
+++ b/chaincode/tuple_test.go
@@ -153,8 +153,8 @@ func TestTagTuple(t *testing.T) {
 	err := json.Unmarshal(resp.Payload, &traintuples)
 
 	assert.NoError(t, err, "should be unmarshaled")
-	assert.Len(t, traintuples.Result, 1, "there should be one traintuple")
-	assert.EqualValues(t, tag, traintuples.Result[0].Tag)
+	assert.Len(t, traintuples.Results, 1, "there should be one traintuple")
+	assert.EqualValues(t, tag, traintuples.Results[0].Tag)
 
 	inpTesttuple := inputTesttuple{Tag: tag}
 	args = inpTesttuple.createDefault()
@@ -166,8 +166,8 @@ func TestTagTuple(t *testing.T) {
 	var testtuples TesttupleResponse
 	err = json.Unmarshal(resp.Payload, &testtuples)
 	assert.NoError(t, err, "should be unmarshaled")
-	assert.Len(t, testtuples.Result, 1, "there should be one traintuple")
-	assert.EqualValues(t, tag, testtuples.Result[0].Tag)
+	assert.Len(t, testtuples.Results, 1, "there should be one traintuple")
+	assert.EqualValues(t, tag, testtuples.Results[0].Tag)
 
 	filter := inputQueryFilter{
 		IndexName:  "testtuple~tag",
@@ -179,8 +179,8 @@ func TestTagTuple(t *testing.T) {
 	filtertuples := []outputTesttuple{}
 	err = json.Unmarshal(resp.Payload, &filtertuples)
 	assert.NoError(t, err, "should be unmarshaled")
-	assert.Len(t, testtuples.Result, 1, "there should be one traintuple")
-	assert.EqualValues(t, tag, testtuples.Result[0].Tag)
+	assert.Len(t, testtuples.Results, 1, "there should be one traintuple")
+	assert.EqualValues(t, tag, testtuples.Results[0].Tag)
 
 }
 

--- a/chaincode/tuple_test.go
+++ b/chaincode/tuple_test.go
@@ -149,12 +149,12 @@ func TestTagTuple(t *testing.T) {
 	args = [][]byte{[]byte("queryTraintuples")}
 	resp = mockStub.MockInvoke(args)
 
-	traintuples := []outputTraintuple{}
+	var traintuples TraintupleResponse
 	err := json.Unmarshal(resp.Payload, &traintuples)
 
 	assert.NoError(t, err, "should be unmarshaled")
-	assert.Len(t, traintuples, 1, "there should be one traintuple")
-	assert.EqualValues(t, tag, traintuples[0].Tag)
+	assert.Len(t, traintuples.Result, 1, "there should be one traintuple")
+	assert.EqualValues(t, tag, traintuples.Result[0].Tag)
 
 	inpTesttuple := inputTesttuple{Tag: tag}
 	args = inpTesttuple.createDefault()
@@ -163,11 +163,11 @@ func TestTagTuple(t *testing.T) {
 
 	args = [][]byte{[]byte("queryTesttuples")}
 	resp = mockStub.MockInvoke(args)
-	testtuples := []outputTesttuple{}
+	var testtuples TesttupleResponse
 	err = json.Unmarshal(resp.Payload, &testtuples)
 	assert.NoError(t, err, "should be unmarshaled")
-	assert.Len(t, testtuples, 1, "there should be one traintuple")
-	assert.EqualValues(t, tag, testtuples[0].Tag)
+	assert.Len(t, testtuples.Result, 1, "there should be one traintuple")
+	assert.EqualValues(t, tag, testtuples.Result[0].Tag)
 
 	filter := inputQueryFilter{
 		IndexName:  "testtuple~tag",
@@ -179,8 +179,8 @@ func TestTagTuple(t *testing.T) {
 	filtertuples := []outputTesttuple{}
 	err = json.Unmarshal(resp.Payload, &filtertuples)
 	assert.NoError(t, err, "should be unmarshaled")
-	assert.Len(t, testtuples, 1, "there should be one traintuple")
-	assert.EqualValues(t, tag, testtuples[0].Tag)
+	assert.Len(t, testtuples.Result, 1, "there should be one traintuple")
+	assert.EqualValues(t, tag, testtuples.Result[0].Tag)
 
 }
 


### PR DESCRIPTION
## Description
The aim of this PR is to add chaincode pagination for query[Asset]s.
It's based on :
- https://hyperledger-fabric.readthedocs.io/en/release-2.2/couchdb_tutorial.html#cdb-pagination
- https://godoc.org/github.com/hyperledger/fabric-chaincode-go/shim#ChaincodeStub.GetStateByPartialCompositeKey
- https://godoc.org/github.com/hyperledger/fabric-chaincode-go/shim#ChaincodeStub.GetStateByPartialCompositeKeyWithPagination

## Closes issue(s)
None

## Companion PRs
https://github.com/SubstraFoundation/substra-backend/pull/352

## How to test / repro
Launch e2e tests, no regression should appear.

## Screenshots / Trace
None

## Changes include
- [x] Use `GetStateByPartialCompositeKeyWithPagination` instead of `GetStateByPartialCompositeKey`
- [x] Return bookmark to the user and and bookmark args
- [x] Update tests

## Checklist
- [x] I have tested this code
- [x] I have updated examples
- [x] Restore old limit value (5 -> 500)
## Other comments
