### PR TITLE
fix CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # substra-chaincode
 
-[![Build Status](https://travis-ci.org/SubstraFoundation/substra-chaincode.svg?branch=master)](https://travis-ci.org/SubstraFoundation/substra-chaincode)
+![Build and test Go](https://github.com/SubstraFoundation/substra-chaincode/workflows/Build%20and%20test%20Go/badge.svg)
 
 Chaincode for the Substra platform
 


### PR DESCRIPTION
Follow-up to https://github.com/SubstraFoundation/substra-chaincode/pull/134

The badge update in the README had been overlooked. This PR fixes the badge.