### PR TITLE
feat!: add queryModel smart contract

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1264,8 +1264,8 @@ peer chaincode query -n mycc -c '{"Args":["queryModels"]}' -C myc
  ]
 }
 ```
-#### ------------ Query model permissions ------------
-Smart contract: `queryModelPermissions`
+#### ------------ Query model ------------
+Smart contract: `queryModel`
 
 ##### JSON Inputs:
 ```go
@@ -1275,15 +1275,24 @@ Smart contract: `queryModelPermissions`
 ```
 ##### Command peer example:
 ```bash
-peer chaincode query -n mycc -c '{"Args":["queryModelPermissions","{\"key\":\"eedbb7c3-1f62-244c-0f3a-761cc1688042\"}"]}' -C myc
+peer chaincode query -n mycc -c '{"Args":["queryModel","{\"key\":\"eedbb7c3-1f62-244c-0f3a-761cc1688042\"}"]}' -C myc
 ```
 ##### Command output:
 ```json
 {
- "process": {
-  "authorized_ids": [],
-  "public": true
- }
+ "key": "eedbb7c3-1f62-244c-0f3a-761cc1688042",
+ "owner": "SampleOrg",
+ "permissions": {
+  "download": {
+   "authorized_ids": [],
+   "public": true
+  },
+  "process": {
+   "authorized_ids": [],
+   "public": true
+  }
+ },
+ "storage_address": "https://substrabac/model/toto"
 }
 ```
 #### ------------ Query Dataset ------------

--- a/chaincode/compute_plan_test.go
+++ b/chaincode/compute_plan_test.go
@@ -711,7 +711,7 @@ func traintupleToDone(t *testing.T, db *LedgerDB, key string) {
 
 	success := inputLogSuccessTrain{}
 	success.Key = key
-	success.OutModel.Key = RandomUUID()
+	success.OutModel.Key = modelKey
 	success.OutModel.Checksum = GetRandomHash()
 	success.fillDefaults()
 	_, err = logSuccessTrain(db, assetToArgs(success))

--- a/chaincode/generate_examples_test.go
+++ b/chaincode/generate_examples_test.go
@@ -222,8 +222,8 @@ func TestPipeline(t *testing.T) {
 	fmt.Fprintln(&out, "#### ------------ Query all models ------------")
 	callAssertAndPrint("query", "queryModels", nil)
 
-	fmt.Fprintln(&out, "#### ------------ Query model permissions ------------")
-	callAssertAndPrint("query", "queryModelPermissions", inputKey{modelKey})
+	fmt.Fprintln(&out, "#### ------------ Query model ------------")
+	callAssertAndPrint("query", "queryModel", inputKey{modelKey})
 
 	fmt.Fprintln(&out, "#### ------------ Query Dataset ------------")
 	callAssertAndPrint("query", "queryDataset", inputKey{dataManagerKey})

--- a/chaincode/main.go
+++ b/chaincode/main.go
@@ -137,10 +137,10 @@ func (t *SubstraChaincode) Invoke(stub shim.ChaincodeStubInterface) peer.Respons
 		result, err = queryDataset(db, args)
 	case "queryFilter":
 		result, err = queryFilter(db, args)
+	case "queryModel":
+		result, err = queryModel(db, args)
 	case "queryModelDetails":
 		result, err = queryModelDetails(db, args)
-	case "queryModelPermissions":
-		result, err = queryModelPermissions(db, args)
 	case "queryModels":
 		result, bookmark, err = queryModels(db, args)
 		hasBookmark = true

--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -304,10 +304,17 @@ type outputModelDetails struct {
 	NonCertifiedTesttuples []outputTesttuple          `json:"non_certified_testtuples"`
 }
 
-type outputModel struct {
+type outputModelListItem struct {
 	Aggregatetuple      *outputAggregatetuple      `json:"aggregatetuple,omitempty"`
 	CompositeTraintuple *outputCompositeTraintuple `json:"composite_traintuple,omitempty"`
 	Traintuple          *outputTraintuple          `json:"traintuple,omitempty"`
+}
+
+type outputModel struct {
+	Key            string                `json:"key"`
+	StorageAddress string                `json:"storage_address"`
+	Permissions    outputPermissionsFull `json:"permissions"`
+	Owner          string                `json:"owner"`
 }
 
 // Event is the collection of tuples sent in an event
@@ -363,6 +370,8 @@ func (out *outputComputePlan) Fill(key string, in ComputePlan, newIDs []string, 
 	out.CleanModels = in.CleanModels
 }
 
+// This is the "historical" output permissions, not
+// implementing "Download" permissions.
 type outputPermissions struct {
 	Process Permission `json:"process"`
 }
@@ -372,6 +381,20 @@ func (out *outputPermissions) Fill(in Permissions) {
 	out.Process.AuthorizedIDs = []string{}
 	if !in.Process.Public {
 		out.Process.AuthorizedIDs = in.Process.AuthorizedIDs
+	}
+}
+
+type outputPermissionsFull struct {
+	outputPermissions
+	Download Permission `json:"download"`
+}
+
+func (out *outputPermissionsFull) Fill(in Permissions) {
+	out.outputPermissions.Fill(in)
+	out.Download.Public = in.Download.Public
+	out.Download.AuthorizedIDs = []string{}
+	if !in.Download.Public {
+		out.Download.AuthorizedIDs = in.Download.AuthorizedIDs
 	}
 }
 


### PR DESCRIPTION
Companion PR: https://github.com/SubstraFoundation/substra-backend/pull/395

The new `queryModel` smart contract exposes the model storage address, owner, and full permissions (including download)

**BREAKING CHANGE:** remove the obsolete `queryModelPermissions` smart contract