### PR TITLE
fix: aggregate permissions

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1241,7 +1241,7 @@ peer chaincode query -n mycc -c '{"Args":["queryModels"]}' -C myc
     "in_models": [
      {
       "checksum": "eedbb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482eed",
-      "key": "b0289ab8-3a71-f01e-2b72-0259a6452244",
+      "key": "eedbb7c3-1f62-244c-0f3a-761cc1688042",
       "storage_address": "https://substrabac/model/toto",
       "traintuple_key": "b0289ab8-3a71-f01e-2b72-0259a6452244"
      }

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1241,7 +1241,7 @@ peer chaincode query -n mycc -c '{"Args":["queryModels"]}' -C myc
     "in_models": [
      {
       "checksum": "eedbb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482eed",
-      "key": "eedbb7c3-1f62-244c-0f3a-761cc1688042",
+      "key": "b0289ab8-3a71-f01e-2b72-0259a6452244",
       "storage_address": "https://substrabac/model/toto",
       "traintuple_key": "b0289ab8-3a71-f01e-2b72-0259a6452244"
      }

--- a/chaincode/permissions.go
+++ b/chaincode/permissions.go
@@ -119,6 +119,39 @@ func mergePermissions(x, y Permission) Permission {
 	return priv
 }
 
+// UnionPermissions returns the union between two sets of permissions
+func UnionPermissions(x, y Permissions) Permissions {
+	perm := Permissions{}
+	perm.Process = unionPermissions(x.Process, y.Process)
+	perm.Download = unionPermissions(x.Download, y.Download)
+	return perm
+}
+
+func unionPermissions(x, y Permission) Permission {
+	res := Permission{
+		Public: x.Public || y.Public,
+	}
+	if !res.Public {
+		res.AuthorizedIDs = x.getNodesUnion(y)
+	}
+	return res
+}
+
+func (priv Permission) getNodesUnion(p Permission) []string {
+	authorizedIds := map[string]bool{}
+	for _, i := range priv.AuthorizedIDs {
+		authorizedIds[i] = true
+	}
+	for _, i := range p.AuthorizedIDs {
+		authorizedIds[i] = true
+	}
+	res := make([]string, 0, len(authorizedIds))
+	for k := range authorizedIds {
+		res = append(res, k)
+	}
+	return res
+}
+
 func (priv Permission) getNodesIntersection(p Permission) []string {
 	nodes := []string{}
 	for _, i := range priv.AuthorizedIDs {

--- a/chaincode/tuple_aggregate.go
+++ b/chaincode/tuple_aggregate.go
@@ -66,7 +66,7 @@ func (tuple *Aggregatetuple) SetFromParents(db *LedgerDB, inModels []string) err
 	inModelKeys := tuple.InModelKeys
 	owner, err := GetTxCreator(db.cc)
 	if err != nil {
-		return errors.BadRequest(err, "could not transaction creator")
+		return errors.BadRequest(err, "could not get transaction creator")
 	}
 
 	authorizedIdsMap := map[string]bool{

--- a/chaincode/tuple_aggregate.go
+++ b/chaincode/tuple_aggregate.go
@@ -64,7 +64,6 @@ func (tuple *Aggregatetuple) SetFromInput(db *LedgerDB, inp inputAggregatetuple)
 func (tuple *Aggregatetuple) SetFromParents(db *LedgerDB, inModels []string) error {
 	var parentStatuses []string
 	inModelKeys := tuple.InModelKeys
-
 	permissions, err := NewPermissions(db, inputPermissions{})
 	if err != nil {
 		return errors.BadRequest(err, "could not generate open permissions")
@@ -109,7 +108,6 @@ func (tuple *Aggregatetuple) SetFromParents(db *LedgerDB, inModels []string) err
 		inModelKeys = append(inModelKeys, parentTraintupleKey)
 		permissions = UnionPermissions(permissions, parentPermissions)
 	}
-
 	tuple.Status = determineStatusFromInModels(parentStatuses)
 	tuple.InModelKeys = inModelKeys
 	tuple.Permissions = permissions

--- a/chaincode/tuple_aggregate_test.go
+++ b/chaincode/tuple_aggregate_test.go
@@ -512,6 +512,7 @@ func TestAggregatetuplePermissions(t *testing.T) {
 }
 
 // return true if slices contain the same elements, regardless of order
+// https://stackoverflow.com/a/36000696/1370722
 func sameStringSlice(x, y []string) bool {
 	if len(x) != len(y) {
 		return false
@@ -527,7 +528,7 @@ func sameStringSlice(x, y []string) bool {
 		if _, ok := diff[_y]; !ok {
 			return false
 		}
-		diff[_y] -= 1
+		diff[_y]--
 		if diff[_y] == 0 {
 			delete(diff, _y)
 		}

--- a/chaincode/tuple_aggregate_test.go
+++ b/chaincode/tuple_aggregate_test.go
@@ -273,8 +273,8 @@ func TestTraintupleAggregate(t *testing.T) {
 		Status:  StatusTodo,
 		Permissions: outputPermissions{
 			Process: Permission{
-				Public:        true,
-				AuthorizedIDs: []string{},
+				Public:        false,
+				AuthorizedIDs: []string{workerA},
 			},
 		},
 		Metadata: map[string]string{},
@@ -507,8 +507,8 @@ func TestAggregatetuplePermissions(t *testing.T) {
 	// verify permissions
 	assert.EqualValues(t, false, aggr.Permissions.Process.Public,
 		"the aggregate tuple should not be public")
-	assert.EqualValues(t, []string{workerA, "nodeC"}, aggr.Permissions.Process.AuthorizedIDs,
-		"the aggregate tuple permissions should be the intersect of the in-model permissions")
+	assert.EqualValues(t, []string{workerA}, aggr.Permissions.Process.AuthorizedIDs,
+		"the aggregate tuple permissions should be union of the aggregate worker and the in-model workers")
 }
 
 func TestAggregatetupleLogSuccessFail(t *testing.T) {

--- a/chaincode/tuple_aggregate_test.go
+++ b/chaincode/tuple_aggregate_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -508,7 +507,6 @@ func TestAggregatetuplePermissions(t *testing.T) {
 	// verify permissions
 	assert.EqualValues(t, false, aggr.Permissions.Process.Public,
 		"the aggregate tuple should not be public")
-	fmt.Println(aggr.Permissions.Process.AuthorizedIDs)
 	assert.True(t, sameStringSlice([]string{workerA, "nodeA", "nodeB", "nodeC", "nodeD"}, aggr.Permissions.Process.AuthorizedIDs),
 		"the aggregate tuple permissions should be union of the in-model permissions")
 }

--- a/chaincode/tuple_aggregate_test.go
+++ b/chaincode/tuple_aggregate_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -507,8 +508,33 @@ func TestAggregatetuplePermissions(t *testing.T) {
 	// verify permissions
 	assert.EqualValues(t, false, aggr.Permissions.Process.Public,
 		"the aggregate tuple should not be public")
-	assert.EqualValues(t, []string{workerA}, aggr.Permissions.Process.AuthorizedIDs,
-		"the aggregate tuple permissions should be union of the aggregate worker and the in-model workers")
+	fmt.Println(aggr.Permissions.Process.AuthorizedIDs)
+	assert.True(t, sameStringSlice([]string{workerA, "nodeA", "nodeB", "nodeC", "nodeD"}, aggr.Permissions.Process.AuthorizedIDs),
+		"the aggregate tuple permissions should be union of the in-model permissions")
+}
+
+// return true if slices contain the same elements, regardless of order
+func sameStringSlice(x, y []string) bool {
+	if len(x) != len(y) {
+		return false
+	}
+	// create a map of string -> int
+	diff := make(map[string]int, len(x))
+	for _, _x := range x {
+		// 0 value for int is 0, so just increment a counter for the string
+		diff[_x]++
+	}
+	for _, _y := range y {
+		// If the string _y is not in diff bail out early
+		if _, ok := diff[_y]; !ok {
+			return false
+		}
+		diff[_y] -= 1
+		if diff[_y] == 0 {
+			delete(diff, _y)
+		}
+	}
+	return len(diff) == 0
 }
 
 func TestAggregatetupleLogSuccessFail(t *testing.T) {


### PR DESCRIPTION
This PR fixes incorrect permissions for aggregate models. 

Scenario:

- N composite traintuples on N different worker nodes. Each of these composite traintuples only grants process permission to itself.
- 1 aggregatetuple, which aggregates the N composite traintuples

```
composite 1: {worker: "node_1", permissions: {public: false, authorized_ids: ["node_1"]}}
...
composite N: {worker: "node_N", permissions: {public: false, authorized_ids: ["node_N"]}}
``` 

### Before this PR:

The aggregate permission is the intersection of parent permissions. In this case, **nobody** has process permissions.

```
aggregate: {permissions: {public: false, authorized_ids: []}}
```


### After this PR:

The aggreate permission is the union of the parent workers. In this case, **all the composite workers** have process permissions.

```
aggregate: {permissions: {public: false, authorized_ids: {"node_1", ..., "node_N"}}}
```

## Why the fix is needed

There has historically been a hack that **granted open permissions for ALL aggregate tuples**. Here is the old incorrect code:

https://github.com/SubstraFoundation/substra-chaincode/blob/f2ba798baf8a9bd86b7973ccc4a038a12a90d678/chaincode/tuple.go#L217-L233

This hack **was fixed** with https://github.com/SubstraFoundation/substra-chaincode/pull/139. Since that PR was merged, aggregate tuples were correctly enforcing permissions. 

However, the enforced permissions were calculated incorrectly. This is what this PR fixes.
