### PR TITLE
fix: Allow lookup for all types of parent tuples in Traintuple type's output Fill()

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1241,7 +1241,7 @@ peer chaincode query -n mycc -c '{"Args":["queryModels"]}' -C myc
     "in_models": [
      {
       "checksum": "eedbb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482eed",
-      "key": "b0289ab8-3a71-f01e-2b72-0259a6452244",
+      "key": "eedbb7c3-1f62-244c-0f3a-761cc1688042",
       "storage_address": "https://substrabac/model/toto",
       "traintuple_key": "b0289ab8-3a71-f01e-2b72-0259a6452244"
      }

--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -180,17 +180,18 @@ func (outputTraintuple *outputTraintuple) Fill(db *LedgerDB, traintuple Traintup
 		if inModelKey == "" {
 			break
 		}
-		parentTraintuple, err := db.GetTraintuple(inModelKey)
-		if err != nil {
-			return errors.Internal("could not retrieve parent traintuple with key %s - %s", inModelKey, err.Error())
+		keyChecksumAddress, _err := db.GetOutModelKeyChecksumAddress(inModelKey, []AssetType{TraintupleType, CompositeTraintupleType, AggregatetupleType})
+		if _err != nil {
+			err = errors.Internal("could not fill in-model with key \"%s\": %s", inModelKey, _err.Error())
+			return
 		}
 		inModel := &Model{
 			TraintupleKey: inModelKey,
 		}
-		if parentTraintuple.OutModel != nil {
-			inModel.Key = parentTraintuple.Key
-			inModel.Checksum = parentTraintuple.OutModel.Checksum
-			inModel.StorageAddress = parentTraintuple.OutModel.StorageAddress
+		if keyChecksumAddress != nil {
+			inModel.Key = keyChecksumAddress.Key
+			inModel.Checksum = keyChecksumAddress.Checksum
+			inModel.StorageAddress = keyChecksumAddress.StorageAddress
 		}
 		outputTraintuple.InModels = append(outputTraintuple.InModels, inModel)
 	}


### PR DESCRIPTION
using the ledger method GetOutModelKeyChecksumAddress() to lookup each parent's key, which allows not only Traintuple types as parents but also Aggregatetuple and CompositeTraintuple types.

Code in this file for Traintuple output Fill() is now consistent with the equivalent Fill() methods of AggregateTuple's and CompositeTraintuple's respective output files.

This solves a bug where Traintuples cannot retrieve non Traintuples (Aggregatetuples or CompositeTraintuples) as parent inputs. After submitting a compute plan that contains such a Traintuple, the chaincode and thus the backend and sdk, cli or frontend lose their ability to list models. The compute plan executes fine but listing tuples is now broken.

More specifically the smart contract methods queryTraintuple() or queryTraintuples() are not being able to find the parent Aggregatetuple or CompositeTraintuple when calling Fill() on a Traintuple that has a parent Aggregatetuple or CompositeTraintuple. The tuple (model) list API reports the error  message "could not retrieve parent traintuple with key PARENT-KEY-ID - traintuple PARENT-KEY-ID not found" which it's generated by the said Fill() method.